### PR TITLE
docs: add comprehensive payment provider integration guides

### DIFF
--- a/docs/providers/feature-comparison.md
+++ b/docs/providers/feature-comparison.md
@@ -1,0 +1,21 @@
+# Provider Feature Comparison
+
+This table outlines the supported features, currencies, and operating countries for each payment provider configured in the platform.
+
+| Feature | Flutterwave | Paystack | M-Pesa |
+|---------|-------------|----------|--------|
+| **Core Operations** | | | |
+| Collect Payments (Pay-in) | ✅ Yes | ✅ Yes | ✅ Yes (STK Push) |
+| Payouts / Withdrawals (Pay-out) | ✅ Yes | ✅ Yes | ✅ Yes (B2C) |
+| Webhook Support | ✅ Yes | ✅ Yes | ✅ Yes (Callback URLs) |
+| Hosted Checkout | ✅ Yes | ✅ Yes | ❌ No (Direct STK) |
+| **Common Currencies Supported** | | | |
+| NGN (Nigerian Naira) | ✅ Yes | ✅ Yes | ❌ No |
+| GHS (Ghanaian Cedi) | ✅ Yes | ✅ Yes | ❌ No |
+| KES (Kenyan Shilling) | ✅ Yes | ✅ Yes | ✅ Yes |
+| USD (US Dollar) | ✅ Yes | ✅ Yes | ❌ No |
+| ZAR (South African Rand) | ✅ Yes | ✅ Yes | ❌ No |
+| **Primary Countries** | Nigeria, Kenya, Ghana, South Africa, etc. (Pan-African) | Nigeria, Ghana, South Africa, Kenya | Kenya, Tanzania, etc. |
+| **Authentication Logic** | Bearer Token / Secret Key | Bearer Token / Secret Key | Basic Auth (generating short-lived token) + Passkey for STK |
+| **Webhook Signature Validation**| HMAC SHA256 (via verif-hash custom HTTP header) | HMAC SHA512 (via x-paystack-signature header) | Direct Server IP safelisting or basic certs (Often relying on internal state mapping) |
+| **Test Environment Limits** | Cards often simulated via specific test numbers. Bank transfer simulation requires specific test endpoints. | Extensive test card support. Webhooks can be manually triggered in dashboard. | Sandbox requires short-lived STK push simulation on Safaricom developer portal. |

--- a/docs/providers/flutterwave.md
+++ b/docs/providers/flutterwave.md
@@ -1,0 +1,69 @@
+# Flutterwave Integration Guide
+
+## Account Setup and API Key Generation
+
+1. **Sign Up / Login**: Navigate to [Flutterwave's Dashboard](https://dashboard.flutterwave.com/).
+2. **Switch to Test Mode**: For development, ensure you toggle "Test Mode" on.
+3. **API Keys**: Go to **Settings > API Keys** to find your keys. You will need:
+   - Secret Key
+   - Public Key
+   - Webhook Secret Hash (you define this in the dashboard).
+
+## Required Environment Variables
+
+Configure the following in your `.env` string or `config.rs`.
+
+```env
+# Required for making authenticated API calls
+FLUTTERWAVE_SECRET_KEY=FLWSECK_TEST-xxxxxxx-X
+# Required for Webhook Validation. Must match what is provided in the dashboard.
+FLUTTERWAVE_WEBHOOK_SECRET=your_secret_hash_value_here
+FLUTTERWAVE_WEBHOOK_HASH=your_secret_hash_value_here # Also checked as fallback
+# Optional / Timeout Settings
+FLUTTERWAVE_BASE_URL=https://api.flutterwave.com/v3
+FLUTTERWAVE_TIMEOUT_SECS=30
+PAYMENT_TIMEOUT_SECONDS=60
+FLUTTERWAVE_MAX_RETRIES=3
+```
+
+## Webhook Endpoint Configuration
+
+In the Flutterwave dashboard, go to **Settings > Webhooks**.
+1. **Webhook URL**: Input the platform's public facing endpoint mapping to flutterwave.
+   - Example: `https://api.yourdomain.com/webhooks/flutterwave`
+2. **Secret Hash**: Enter the value configured in `FLUTTERWAVE_WEBHOOK_SECRET`. 
+
+**Events to Subscribe to:**
+- `charge.completed`
+- `transfer.completed`
+- `transfer.failed`
+
+> The platform's `WebhookProcessor` parses `charge.completed` for pay-ins and `transfer.completed`/`transfer.failed` for pay-outs.
+
+## Webhook Signature Verification
+
+Flutterwave passes the secret hash via the custom header `verif-hash`. The platform validates this by comparing it against the `FLUTTERWAVE_WEBHOOK_SECRET`. 
+
+If `verif-hash` doesn't match the configured environment variable, the system returns an `InvalidSignature` error to prevent injection.
+
+## Sandbox Testing Procedures
+
+### Simulating Successful Payments
+Use Flutterwave test cards (e.g., standard testing Pan ending in `2004`) during checkout. This auto-approves.
+
+### Simulating Failed Payments
+Use a failure test card (e.g., Pan ending in `9995`). Do not use OTP, or input an incorrect OTP when prompted.
+
+### Simulating Withdrawals
+When executing a withdrawal via the `transfer` API in sandbox, providing specific standard bank accounts (like `044` Access Bank) acts differently. Flutterwave will trigger a `transfer.completed` asynchronously in test mode for most accounts to allow webhook debugging.
+
+## Known Limitations and Workarounds
+
+- **Webhook Delay in Sandbox**: In the test environment, `transfer.completed` webhooks can occasionally be delayed. Ensure you wait up to 5 minutes before assuming the webhook handler failed.
+- **Card Currency Limits**: Sandbox limits some multi-currency cross-tests. Always test NGN to NGN first, then change currency settings.
+
+## Common Error Codes and Resolution Steps
+
+- **`ERR_FLW_001` (Unauthorized)**: Verify that `FLUTTERWAVE_SECRET_KEY` is correct and doesn't contain spaces.
+- **Webhook Not Arriving**: Check `verif-hash` setup. If the platform logs `Missing webhook signature`, ensure the exact case is preserved. Note, ngrok might rewrite headers if not carefully set.
+- **`Validation Failed` during transfer**: Ensure amount limits don't exceed Sandbox constraints (usually large numbers > 1,000,000 will be auto-rejected).

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,0 +1,37 @@
+# Payment Provider Architecture
+
+## Overview
+
+The platform uses a unified payment provider architecture to integrate multiple external payment gateways like Flutterwave, Paystack, and M-Pesa. This architecture ensures the platform handles all payment operations seamlessly, irrespective of the underlying gateway.
+
+## Architecture
+
+The system is built on an abstraction layer (often structured via the Factory pattern) that handles routing of payment payloads to the respective provider modules:
+
+1. **Provider Factory**: The orchestrator evaluates transactions and routes API calls to the corresponding provider (e.g., Paystack or Flutterwave) using configured environment variables and endpoint routing.
+2. **Standardized Interfaces**: Each provider implements a standardized rust trait or interface, guaranteeing consistency when creating payments, verifying statuses, and handling withdrawals.
+3. **Webhook Processor**: A core `WebhookProcessor` accepts incoming `POST /webhooks/:provider` events. It automatically evaluates the configured provider string (e.g., `paystack`), finds the relevant secret key/hash config, validates the signature, and prevents replay attacks or double-processing.
+
+## Webhook Routing 
+
+All webhooks are pointing to:
+
+```http
+POST /webhooks/:provider
+```
+
+For instance:
+- `POST /webhooks/paystack`
+- `POST /webhooks/flutterwave`
+
+The platform uses signature validation specific to each provider.
+
+## Directory Structure
+
+In this `providers` directory, you will find comprehensive guides for each supported provider:
+
+- [Flutterwave Integration Guide](./flutterwave.md)
+- [Paystack Integration Guide](./paystack.md)
+- [M-Pesa Integration Guide](./mpesa.md)
+- [Webhook Testing Guide](./webhook-testing.md)
+- [Provider Feature Comparison](./feature-comparison.md)

--- a/docs/providers/mpesa.md
+++ b/docs/providers/mpesa.md
@@ -1,0 +1,56 @@
+# M-Pesa Integration Guide
+
+## Developer Portal Setup and App Registration
+
+1. **Sign Up**: Navigate to the [Daraja (Safaricom Developer Portal)](https://developer.safaricom.co.ke/).
+2. **Create a Test App**: Go to **My Apps** > **Create New App**.
+3. **Select Products**: Tick the boxes for **Lipa na M-Pesa Sandbox** (STK Push) and **B2C Sandbox** (if allowing withdrawals).
+4. **App Credentials**: Once created, click on the app to retrieve your **Consumer Key** and **Consumer Secret**.
+5. **Sandbox Credentials**: Go to the **APIs** section to retrieve your test Passkey and test business shortcodes (e.g., `174379`).
+
+## Required Environment Variables
+
+You must maintain the Daraja credentials in `.env` string format or mapped config file:
+
+```env
+# Required for Daraja OAuth token generation
+MPESA_CONSUMER_KEY=your_consumer_key_here
+MPESA_CONSUMER_SECRET=your_consumer_secret_here
+# Used for Lipa Na M-Pesa STK push generation
+MPESA_PASSKEY=bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919
+```
+
+## Callback URL Configuration
+
+M-Pesa relies heavily on asynchronous callbacks.
+
+### For STK Push (Pay-in)
+When initiating an STK Push `POST /mpesa/stkpush/v1/processrequest`, you must supply a `CallBackURL`.
+Example: `https://api.yourdomain.com/webhooks/mpesa/stk`
+
+### For B2C (Withdrawals)
+When registering URLs for B2C (`POST /mpesa/b2c/v1/paymentrequest`), you supply two URLs:
+- `ResultURL`: Where success/failure payloads are delivered. Example: `https://api.yourdomain.com/webhooks/mpesa/b2c/result`
+- `QueueTimeOutURL`: Where timeout responses are delivered. Example: `https://api.yourdomain.com/webhooks/mpesa/b2c/timeout`
+
+## Sandbox Testing Procedures
+
+### Simulating STK Push Confirmations
+The Daraja sandbox requires a real test number linked to the sandbox. When you trigger an STK Push, it behaves like a live transaction but utilizes test funds. Provide a simulated success timestamp and amount.
+- **Tip**: Safaricom provides test MSISDNs (like `254708374149`) to test End-to-End.
+
+### Simulating B2C Withdrawals
+To test withdrawals, generate B2C API calls to a designated test number. The Daraja portal simulates backend processing and eventually sends a callback to your registered `ResultURL`. It will mock a successful or failed response based on predefined test conditions (e.g., specific test numbers trigger insufficient funds).
+
+## Known M-Pesa Sandbox Limitations and Workarounds
+
+- **IP Allowlisting Limitations**: Safaricom's B2C callbacks require the backend server to have a static public IP. If testing locally, tools like ngrok will generally work for STK push, but B2C might require explicit IP registration.
+- **Inconsistent Callbacks**: Daraja sandbox callbacks can sometimes be heavily delayed or outright dropped during Safaricom maintenance windows. Use a fallback query mechanism (`/mpesa/stkpushquery/v1/query`) if callbacks take longer than 90 seconds.
+- **Passkey Management**: The Sandbox passkey rarely changes, but in production, any portal reset will require an update to `MPESA_PASSKEY`.
+
+## Common Error Codes and Resolution Steps
+
+- **`401 Unauthorized` / Invalid Token**: Safaricom auth tokens expire every 3600 seconds. Ensure the token is being re-fetched or cached correctly before issuing an STK or B2C call. Check `MPESA_CONSUMER_KEY` and `MPESA_CONSUMER_SECRET`.
+- **`1032 Request cancelled by user`**: The user canceled the STK push prompt. Treat this as a failure state and log it appropriately.
+- **`Timeout`**: The STK request went unfulfilled (usually phone is dead, or ignoring the prompt). Validate via STK push query.
+- **Invalid Callback URL Format**: URLs must be securely hosted via an actual HTTPS configuration and cannot contain IP address literals during registration.

--- a/docs/providers/paystack.md
+++ b/docs/providers/paystack.md
@@ -1,0 +1,62 @@
+# Paystack Integration Guide
+
+## Account Setup and API Key Generation
+
+1. **Sign Up / Login**: Navigate to the [Paystack Dashboard](https://dashboard.paystack.com/).
+2. **Test Mode**: Ensure the top bar is toggled to **Test Mode**.
+3. **API Keys**: Navigate to **Settings > API Keys & Webhooks**. You will need:
+   - Secret Key
+   - Public Key
+   - (Generate or define your own Webhook Secret / Signature check logically matching their payload model).
+
+## Required Environment Variables
+
+Add the following to your `.env` file or mapping properties:
+
+```env
+# Required for authorizing calls to paystack
+PAYSTACK_SECRET_KEY=sk_test_xxxxxx
+PAYSTACK_PUBLIC_KEY=pk_test_xxxxxx
+# Used by the WebhookProcessor to perform HMAC SHA512 validation
+PAYSTACK_WEBHOOK_SECRET=sk_test_xxxxxx # (Often the secret key itself in Paystack test mode)
+# Config variables
+PAYSTACK_BASE_URL=https://api.paystack.co
+PAYSTACK_TIMEOUT_SECS=30
+PAYSTACK_MAX_RETRIES=3
+```
+
+## Webhook Endpoint Configuration
+
+In **Settings > API Keys & Webhooks**:
+- Set your Test Webhook URL to: `https://api.yourdomain.com/webhooks/paystack`
+- Note: Paystack allows selecting which events to listen to. Subscribe to:
+  - `charge.success`
+  - `transfer.success`
+  - `transfer.failed`
+
+## Webhook Signature Verification
+
+Paystack generates a signature using **HMAC SHA512** of the payload with the Secret Key, passing it in the `x-paystack-signature` header.
+Our platform reads this header, computes `HMAC_SHA512(request_body, PAYSTACK_WEBHOOK_SECRET)`, and verifies equality. If invalid, it returns `WebhookProcessorError::InvalidSignature`.
+
+## Sandbox Testing Procedures
+
+### Simulating Payments (Success)
+Use Paystack's test cards (e.g., standard `4084084084084081` with any future expiry/CVV). Enter the testing OTP `123456` if prompted.
+
+### Simulating Payments (Failure)
+Use the Paystack failure test card (e.g., `4084084084084082`).
+
+### Simulating Withdrawals (Transfers)
+When initiating a B2C transfer to a recipient, Paystack handles sandbox transfers by allowing you to simulate the outcome. Inside the Paystack transfer dashboard, test mode allows triggering success via the Transfers menu, generating `transfer.success`. 
+
+## Known Sandbox Limitations and Workarounds
+
+- **Test Transfers**: Test transfers don't automatically complete without triggering them via Dashboard or a simulated mock response in specific environments.
+- **Simulated OTPs**: Ensure test environments are allowed to skip real OTP checks, as strict validation might fail if bridging test keys in a live widget configuration.
+
+## Common Error Codes and Resolution Steps
+
+- **Signature Mismatch (`InvalidSignature`)**: The `PAYSTACK_WEBHOOK_SECRET` might not be identical to the key used for making the body. Paystack typically uses the `SECRET_KEY` as the webhook secret.
+- **IP Allowlisting**: Paystack webhooks come from specific IP ranges. If testing remotely and not receiving webhooks, ensure VPC firewalls aren't blocking Paystack's IPs (52.31.139.75, 52.49.173.169, 52.214.14.220).
+- **Duplicate Reference**: Paystack immediately rejects identical string references. The backend must enforce UUID generation for each unique transaction.

--- a/docs/providers/webhook-testing.md
+++ b/docs/providers/webhook-testing.md
@@ -1,0 +1,70 @@
+# Webhook Testing Guide
+
+This guide details exactly how to configure, test, and debug payment provider webhooks natively on your local development machine. Webhook payloads inform the backend of external payment events (like `charge.completed` or `transfer.success`), which requires your workstation to be publicly accessible.
+
+## Local Webhook Forwarding with ngrok
+
+During local development, your `localhost:8000` is hidden behind a NAT/Firewall.
+
+1. **Install ngrok**: Follow instructions on [ngrok.com](https://ngrok.com/download)
+2. **Expose your local server**: Run the following command:
+   ```bash
+   ngrok http 8000
+   ```
+3. **Capture your public URL**: Note the `Forwarding` URL. Example: `https://a1b2-c3-d4.ngrok-free.app`
+4. **Update Provider Dashboards**:
+   - Go to your Flutterwave or Paystack dashboard (Test Mode).
+   - Set the webhook URL to: `https://a1b2-c3-d4.ngrok-free.app/webhooks/paystack` (or `/flutterwave`).
+5. **Restart Server**: Keep ngrok active and start your backend platform server locally. Any incoming paystack event to your ngrok URL will hit your local backend seamlessly.
+
+> **Note**: For M-Pesa B2C callback testing, Safaricom may sometimes reject ngrok domains. In such scenarios, use a hosted staging environment instead or an explicitly allowlisted IP. 
+
+## Replaying Webhook Events
+
+Providers allow you to easily replay webhooks from the dashboard, saving you from generating new test payments iteratively.
+
+### Replay via Paystack
+1. Navigate to **Transactions** in Test Mode.
+2. Select a transaction you want to replay.
+3. Click on the **Webhook** tab inside the transaction detail pop-out.
+4. Click **Resend Webhook**. Your local `ngrok` output window will display a `200 OK` if successfully received.
+
+### Replay via Flutterwave
+1. Navigate to **Transactions** > **Test Transactions**.
+2. Select any transfer or payment.
+3. Choose the **Webhook/Logs** action to simulate the event again.
+
+## Verifying Signature Validation Locally
+
+To test local validation without relying directly on a provider's dashboard replay, you can craft specific `curl` commands simulating the headers and payload.
+
+### Validating Paystack Signature Locally
+
+Generate your HMAC payload in the terminal via OpenSSL, then send it. (Assuming `PAYSTACK_WEBHOOK_SECRET=sk_test_mocked`):
+
+```bash
+# Provide payload JSON
+PAYLOAD='{"event":"charge.success","data":{"amount":5000}}'
+
+# Create HMAC Hash
+SIGNATURE=$(echo -n $PAYLOAD | openssl dgst -sha512 -hmac "sk_test_mocked" | awk '{print $2}')
+
+# Send Local cURL matching the platform
+curl -X POST http://localhost:8000/webhooks/paystack \
+  -H "Content-Type: application/json" \
+  -H "x-paystack-signature: $SIGNATURE" \
+  -d "$PAYLOAD"
+```
+Expect a `200 OK`. If you change the payload or don't generate the hash correctly, expect an `InvalidSignature` error output on your terminal console.
+
+### Validating Flutterwave Signature Locally
+
+Flutterwave looks for a statically matched header instead of a dynamic HMAC hash. (Assuming `FLUTTERWAVE_WEBHOOK_SECRET=mycustom_secrethash123`):
+
+```bash
+curl -X POST http://localhost:8000/webhooks/flutterwave \
+  -H "Content-Type: application/json" \
+  -H "verif-hash: mycustom_secrethash123" \
+  -d '{"event":"charge.completed","data":{"amount":100}}'
+```
+Expect a `200 OK`. Altering `verif-hash` to `wrong_sec` should return a signature failure explicitly blocked by the platform.


### PR DESCRIPTION
closes #115 

This PR introduces a comprehensive suite of payment provider integration guides in the /docs/providers directory. These documents are designed to serve as the single source of truth for developers setting up, maintaining, or debugging payment integrations (Flutterwave, Paystack, M-Pesa) on the platform.

By having these guides explicitly documented alongside the codebase, we significantly reduce the time required to onboard new environments and streamline the debugging process for provider webhooks and sandbox testing.