### PR TITLE
feat: production-grade Docker containerisation with cargo-chef caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,54 @@
-# Cargo artifacts
+# =============================================================================
+# .dockerignore — reduces build context sent to the Docker daemon
+# =============================================================================
+
+# Rust build artifacts (largest exclusion — can be several GB)
 target/
 
-# Environment files
+# Environment files — secrets must never enter an image layer
 .env
-.env.local
+.env.*
+!.env.example
 
-# IDE
+# Version control
+.git/
+.gitignore
+
+# IDE / editor
 .vscode/
 .idea/
+*.iml
+.cursor/
 
-# OS
+# OS artefacts
 .DS_Store
 Thumbs.db
 
 # Logs
 *.log
+build.log
+
+# Local test / load-test artefacts
+load-tests/
+test_snapshots/
+arms_cache/
+
+# Documentation (not needed in the image)
+docs/
+*.md
+!README.md
+
+# Shell scripts not needed at runtime
+*.sh
+!docker-entrypoint.sh
+
+# CI / GitHub Actions
+.github/
+
+# Cargo audit config
+.cargo/
+
+# Misc project files
+curl-format.txt
+rate_limits.yaml
+examples/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,215 @@
+# =============================================================================
+# Aframp Backend — environment variable reference
+#
+# Copy this file to .env and fill in the values for local development.
+# NEVER commit .env to version control.
+#
+#   cp .env.example .env
+#
+# Variables marked REQUIRED must be set before the application will start.
+# Variables marked OPTIONAL have defaults shown; omit them to use the default.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Server
+# -----------------------------------------------------------------------------
+
+# Host the HTTP server binds to.
+# Use 0.0.0.0 inside Docker; 127.0.0.1 for local cargo run.
+# OPTIONAL — default: 127.0.0.1
+SERVER_HOST=0.0.0.0
+
+# Port the HTTP server listens on.
+# OPTIONAL — default: 8000
+SERVER_PORT=8000
+
+# Comma-separated list of allowed CORS origins.
+# OPTIONAL — default: http://localhost,http://127.0.0.1
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+
+# -----------------------------------------------------------------------------
+# PostgreSQL
+# -----------------------------------------------------------------------------
+
+# Full connection URL used by sqlx.
+# REQUIRED
+DATABASE_URL=postgres://aframp:changeme@localhost:5432/aframp
+
+# Individual parts used by docker-compose to configure the postgres service.
+# REQUIRED when using docker-compose
+POSTGRES_DB=aframp
+POSTGRES_USER=aframp
+POSTGRES_PASSWORD=changeme
+POSTGRES_PORT=5432
+
+# Connection pool tuning.
+# OPTIONAL
+DB_MAX_CONNECTIONS=20
+DB_MIN_CONNECTIONS=5
+DB_CONNECTION_TIMEOUT=30
+DB_IDLE_TIMEOUT=600
+DB_MAX_LIFETIME=1800
+
+
+# -----------------------------------------------------------------------------
+# Redis
+# -----------------------------------------------------------------------------
+
+# Full Redis URL used by the cache layer.
+# REQUIRED
+REDIS_URL=redis://:changeme@localhost:6379
+
+# Password used by docker-compose to configure the redis service.
+# REQUIRED when using docker-compose
+REDIS_PASSWORD=changeme
+REDIS_PORT=6379
+
+# Connection pool tuning.
+# OPTIONAL
+REDIS_MAX_CONNECTIONS=20
+REDIS_MIN_IDLE=5
+REDIS_CONNECTION_TIMEOUT=5
+REDIS_MAX_LIFETIME=300
+REDIS_IDLE_TIMEOUT=60
+REDIS_HEALTH_CHECK_INTERVAL=30
+
+
+# -----------------------------------------------------------------------------
+# Application
+# -----------------------------------------------------------------------------
+
+# Deployment environment. Must be one of: development, staging, production, test
+# OPTIONAL — default: development
+APP_ENV=development
+
+# Log verbosity. One of: TRACE, DEBUG, INFO, WARN, ERROR
+# OPTIONAL — default: INFO
+LOG_LEVEL=INFO
+
+# Log format. One of: json, plain
+# OPTIONAL — default: plain
+LOG_FORMAT=json
+
+# Enable distributed tracing bridge (true/false).
+# OPTIONAL — default: false
+ENABLE_TRACING=false
+
+
+# -----------------------------------------------------------------------------
+# JWT Authentication
+# -----------------------------------------------------------------------------
+
+# Secret key used to sign and verify JWT tokens.
+# Generate with: openssl rand -hex 64
+# REQUIRED
+JWT_SECRET=replace-with-a-long-random-secret-at-least-64-characters
+
+
+# -----------------------------------------------------------------------------
+# Stellar / Horizon
+# -----------------------------------------------------------------------------
+
+# Network to connect to. One of: testnet, mainnet, futurenet
+# OPTIONAL — default: testnet
+STELLAR_NETWORK=testnet
+
+# Horizon API base URL. Defaults to the public testnet/mainnet endpoint.
+# OPTIONAL
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# HTTP request timeout in seconds for Horizon calls.
+# OPTIONAL — default: 15
+STELLAR_REQUEST_TIMEOUT=15
+
+# Maximum number of retries for failed Horizon requests.
+# OPTIONAL — default: 3
+STELLAR_MAX_RETRIES=3
+
+# Stellar health check interval in seconds.
+# OPTIONAL — default: 30
+STELLAR_HEALTH_CHECK_INTERVAL=30
+
+# System wallet used to send cNGN to users on onramp.
+# REQUIRED for onramp/offramp workers
+SYSTEM_WALLET_ADDRESS=
+SYSTEM_WALLET_SECRET=
+
+# cNGN issuer account address on Stellar.
+# REQUIRED for onramp quote generation
+CNGN_ISSUER_ADDRESS=
+
+
+# -----------------------------------------------------------------------------
+# Payment Providers
+# -----------------------------------------------------------------------------
+
+# Paystack
+# REQUIRED if Paystack provider is enabled
+PAYSTACK_SECRET_KEY=
+PAYSTACK_PUBLIC_KEY=
+
+# Flutterwave
+# REQUIRED if Flutterwave provider is enabled
+FLUTTERWAVE_SECRET_KEY=
+FLUTTERWAVE_PUBLIC_KEY=
+
+# M-Pesa (Safaricom Daraja)
+# REQUIRED if M-Pesa provider is enabled
+MPESA_CONSUMER_KEY=
+MPESA_CONSUMER_SECRET=
+MPESA_PASSKEY=
+MPESA_SHORTCODE=
+
+# External exchange rate API (optional — falls back to fixed rates)
+# OPTIONAL
+EXTERNAL_RATE_API_URL=
+EXTERNAL_RATE_API_KEY=
+
+
+# -----------------------------------------------------------------------------
+# Background Workers
+# -----------------------------------------------------------------------------
+
+# Set any of these to "false" to disable the corresponding worker.
+# OPTIONAL — all default to true
+TX_MONITOR_ENABLED=true
+OFFRAMP_PROCESSOR_ENABLED=true
+ONRAMP_PROCESSOR_ENABLED=true
+BILL_PROCESSOR_ENABLED=true
+PAYMENT_POLLER_ENABLED=true
+WEBHOOK_RETRY_ENABLED=true
+STELLAR_CONFIRM_WORKER_ENABLED=true
+
+
+# -----------------------------------------------------------------------------
+# OpenTelemetry / Distributed Tracing
+# -----------------------------------------------------------------------------
+
+# Service name emitted in every span.
+# OPTIONAL — default: aframp-backend
+OTEL_SERVICE_NAME=aframp-backend
+
+# Fraction of root spans to sample (0.0 – 1.0).
+# OPTIONAL — default: 1.0
+OTEL_SAMPLING_RATE=1.0
+
+# gRPC endpoint of the OTLP collector (Jaeger, Grafana Tempo, etc.)
+# OPTIONAL — default: http://localhost:4317
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+
+# -----------------------------------------------------------------------------
+# Startup behaviour
+# -----------------------------------------------------------------------------
+
+# Set to "true" to skip waiting for the database before starting.
+# Useful for running the binary locally without Docker.
+# OPTIONAL — default: true (wait is enabled)
+RUN_MIGRATIONS=true
+
+# Set to "true" to skip all external service connections (DB, Redis, Stellar).
+# Useful for smoke-testing the binary in isolation.
+# OPTIONAL — default: false
+SKIP_EXTERNALS=false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,198 @@
+# Local Development with Docker
+
+This document covers building, running, and testing the Aframp backend using Docker and Docker Compose.
+
+---
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) 24+
+- [Docker Compose](https://docs.docker.com/compose/install/) v2 (bundled with Docker Desktop)
+- `curl` (for manual health checks)
+
+---
+
+## Quick Start
+
+### 1. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and set the required values (marked `REQUIRED` in the file). At minimum:
+
+```
+POSTGRES_PASSWORD=<choose a strong password>
+REDIS_PASSWORD=<choose a strong password>
+JWT_SECRET=<at least 64 random characters — openssl rand -hex 64>
+```
+
+### 2. Build and start the full stack
+
+```bash
+docker compose up --build
+```
+
+This starts PostgreSQL, Redis, and the application in dependency order. The application container waits for both services to pass their health checks before starting.
+
+On first run the Rust build takes several minutes. Subsequent builds are fast because the dependency compilation layer is cached by `cargo-chef`.
+
+### 3. Verify the stack is healthy
+
+```bash
+curl http://localhost:8000/health
+```
+
+Expected response (HTTP 200):
+
+```json
+{
+  "status": "Healthy",
+  "checks": {
+    "database": { "status": "Up", "response_time_ms": 2 },
+    "cache":    { "status": "Up", "response_time_ms": 1 },
+    "stellar":  { "status": "Up", "response_time_ms": 120 }
+  },
+  "timestamp": "..."
+}
+```
+
+Additional probes:
+
+```bash
+curl http://localhost:8000/health/ready   # readiness probe
+curl http://localhost:8000/health/live    # liveness probe
+```
+
+---
+
+## Service Ports
+
+| Service    | Host port | Container port |
+|------------|-----------|----------------|
+| App        | 8000      | 8000           |
+| PostgreSQL | 5432      | 5432           |
+| Redis      | 6379      | 6379           |
+
+Override any port in `.env` (e.g. `SERVER_PORT=9000`).
+
+---
+
+## Database Migrations
+
+Migrations live in `migrations/` and are applied automatically by the application on startup via `sqlx::migrate!`. The `docker-entrypoint.sh` script waits for PostgreSQL to accept TCP connections before launching the binary, ensuring migrations always run against a live database.
+
+To inspect or manually run migrations outside Docker:
+
+```bash
+# Install sqlx-cli
+cargo install sqlx-cli --no-default-features --features postgres
+
+# Run migrations
+sqlx migrate run --database-url "$DATABASE_URL"
+
+# Revert the last migration
+sqlx migrate revert --database-url "$DATABASE_URL"
+```
+
+---
+
+## Stopping the Stack
+
+```bash
+# Stop containers, keep volumes (data persists)
+docker compose down
+
+# Stop containers and remove all volumes (full reset)
+docker compose down -v
+```
+
+---
+
+## Rebuilding After Code Changes
+
+```bash
+docker compose up --build app
+```
+
+Only the `app` service is rebuilt. The `cargo-chef` caching strategy means only changed source files are recompiled — dependencies are not redownloaded.
+
+---
+
+## Running Integration Tests
+
+The `docker-compose.test.yml` override spins up ephemeral (no persistent storage) versions of all services and runs the integration test suite:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.test.yml \
+  up --build --abort-on-container-exit
+```
+
+`--abort-on-container-exit` stops the entire stack as soon as the `test-runner` service exits, and the compose command exits with the test runner's exit code (0 = pass, non-zero = fail).
+
+Clean up after the test run:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.test.yml \
+  down -v
+```
+
+All test data is ephemeral — no volumes are created, so `down -v` is equivalent to `down` for the test stack.
+
+---
+
+## Running Unit Tests Locally (without Docker)
+
+```bash
+cargo test --features database,cache
+```
+
+---
+
+## Image Size
+
+The production image is built on `debian:bookworm-slim` and contains only:
+
+- The stripped `Aframp-Backend` binary
+- The `migrations/` directory
+- `ca-certificates`, `libssl3`, `curl` (runtime deps + health check)
+- `docker-entrypoint.sh`
+
+Approximate final image size: **~120–140 MB** (varies with binary size).
+
+To inspect the actual size after building:
+
+```bash
+docker compose build app
+docker images | grep aframp
+```
+
+---
+
+## Security Notes
+
+- No secrets or credentials are baked into any image layer. All sensitive values are injected at runtime via environment variables.
+- The application process runs as a non-root user (`uid 10001`).
+- The `.dockerignore` file excludes `.env*` files, `target/`, and all other non-essential files from the build context.
+- Passwords for PostgreSQL and Redis are required at startup — the compose file will refuse to start if `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, or `JWT_SECRET` are unset.
+
+---
+
+## Troubleshooting
+
+**App fails to start with "DATABASE_URL not set"**
+Ensure your `.env` file exists and `DATABASE_URL` is set, or that the `POSTGRES_PASSWORD` variable is exported so the compose interpolation can build the URL.
+
+**Migrations fail with "relation already exists"**
+The database already has a partial schema. Run `docker compose down -v` to reset, then `docker compose up --build`.
+
+**Health check returns 503**
+Check `docker compose logs app` for startup errors. Common causes: database unreachable, Redis unreachable, or Stellar Horizon timeout. The `/health` endpoint returns a JSON body describing which component is unhealthy.
+
+**Build is slow on first run**
+Expected — Rust compiles all dependencies from scratch. Subsequent builds use the `cargo-chef` cache and complete in seconds for source-only changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,98 @@
-# Build stage
-FROM rust:1.75-slim as builder
-
+# =============================================================================
+# Stage 1 — cargo-chef planner
+# Computes the dependency recipe from Cargo.toml / Cargo.lock so that the
+# dependency compilation layer is cached independently of application source.
+# =============================================================================
+FROM rust:1.85-slim AS chef
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && cargo install cargo-chef --locked
 WORKDIR /app
 
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy manifests
+# =============================================================================
+# Stage 2 — dependency recipe
+# =============================================================================
+FROM chef AS planner
 COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Copy source
+# =============================================================================
+# Stage 3 — dependency compilation (cached layer)
+# Only re-runs when Cargo.toml / Cargo.lock change.
+# =============================================================================
+FROM chef AS builder-deps
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --features database,cache --recipe-path recipe.json
+
+# =============================================================================
+# Stage 4 — application build + sqlx-cli for migrations
+# Only re-runs when application source changes.
+# =============================================================================
+FROM builder-deps AS builder
+# Install sqlx-cli (postgres only, no default features keeps it lean)
+RUN cargo install sqlx-cli \
+        --no-default-features \
+        --features native-tls,postgres \
+        --locked
+
+COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY migrations ./migrations
+RUN cargo build --release --features database,cache \
+    && strip target/release/Aframp-Backend
 
-# Build release
-RUN cargo build --release --features database
+# =============================================================================
+# Stage 5 — runtime image
+# debian:bookworm-slim provides glibc, OpenSSL, CA certs, and curl for the
+# Docker HEALTHCHECK, while remaining minimal (~120 MB compressed).
+# No Rust toolchain, no build tools, no source code.
+# =============================================================================
+FROM debian:bookworm-slim AS runtime
 
-# Runtime stage
-FROM debian:bookworm-slim
+# Install only the runtime libraries required by the binary:
+#   - ca-certificates  : TLS root CAs for outbound HTTPS (Stellar, payment providers)
+#   - libssl3          : OpenSSL runtime (linked by reqwest / sqlx)
+#   - curl             : used exclusively by the Docker HEALTHCHECK instruction
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    libssl3 \
-    && rm -rf /var/lib/apt/lists/*
+# Create a non-root user for the process
+RUN groupadd --gid 10001 appgroup \
+    && useradd --uid 10001 --gid appgroup --no-create-home --shell /sbin/nologin appuser
 
-# Copy binary
+# Copy the stripped application binary
 COPY --from=builder /app/target/release/Aframp-Backend /app/aframp-backend
 
-# Copy migrations
+# Copy sqlx-cli for running migrations at startup
+COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
+
+# Copy database migrations
 COPY --from=builder /app/migrations /app/migrations
 
+# Copy the entrypoint script
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+# Ensure the app directory is owned by the non-root user
+RUN chown -R appuser:appgroup /app
+
+# Expose the application port (overridable via SERVER_PORT env var)
 EXPOSE 8000
 
-CMD ["/app/aframp-backend"]
+# Docker health check — validates the /health endpoint.
+# start-period gives the app time to run migrations and warm caches before
+# the first check fires.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD curl -fsS "http://localhost:${SERVER_PORT:-8000}/health" || exit 1
+
+USER appuser
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,101 @@
+version: "3.9"
+
+# =============================================================================
+# Aframp Backend — integration test override
+#
+# Extends docker-compose.yml with ephemeral (no persistent volumes) services
+# and test-specific environment variables. All data is discarded on teardown.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.test.yml up --build --abort-on-container-exit
+#   docker compose -f docker-compose.yml -f docker-compose.test.yml down -v
+#
+# The --abort-on-container-exit flag causes the stack to stop as soon as the
+# test runner exits, and the exit code of the test runner is propagated.
+# =============================================================================
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # Ephemeral PostgreSQL — no volume mount, data lives only for the test run
+  # ---------------------------------------------------------------------------
+  postgres:
+    environment:
+      POSTGRES_DB: aframp_test
+      POSTGRES_USER: aframp_test
+      POSTGRES_PASSWORD: test_password_not_for_production
+    # Override the volume with a tmpfs so nothing persists
+    volumes: []
+    tmpfs:
+      - /var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+
+  # ---------------------------------------------------------------------------
+  # Ephemeral Redis — no volume mount
+  # ---------------------------------------------------------------------------
+  redis:
+    command: >
+      redis-server
+      --requirepass test_redis_password_not_for_production
+      --maxmemory 64mb
+      --maxmemory-policy allkeys-lru
+      --save ""
+      --appendonly no
+    volumes: []
+    ports:
+      - "6380:6379"
+
+  # ---------------------------------------------------------------------------
+  # Application — test configuration
+  # ---------------------------------------------------------------------------
+  app:
+    environment:
+      APP_ENV: test
+      DATABASE_URL: "postgres://aframp_test:test_password_not_for_production@postgres:5432/aframp_test"
+      REDIS_URL: "redis://:test_redis_password_not_for_production@redis:6379"
+      JWT_SECRET: "test-jwt-secret-not-for-production-use-only"
+      POSTGRES_PASSWORD: "test_password_not_for_production"
+      REDIS_PASSWORD: "test_redis_password_not_for_production"
+      LOG_LEVEL: "DEBUG"
+      # Disable external integrations so tests run without real credentials
+      SKIP_EXTERNALS: "false"
+      STELLAR_NETWORK: "testnet"
+      # Disable background workers during integration tests to reduce noise
+      TX_MONITOR_ENABLED: "false"
+      OFFRAMP_PROCESSOR_ENABLED: "false"
+      ONRAMP_PROCESSOR_ENABLED: "false"
+      BILL_PROCESSOR_ENABLED: "false"
+      PAYMENT_POLLER_ENABLED: "false"
+      WEBHOOK_RETRY_ENABLED: "false"
+      OTEL_SAMPLING_RATE: "0.0"
+
+  # ---------------------------------------------------------------------------
+  # Test runner — executes the integration test suite against the live stack
+  # ---------------------------------------------------------------------------
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+    depends_on:
+      app:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: "postgres://aframp_test:test_password_not_for_production@postgres:5432/aframp_test"
+      REDIS_URL: "redis://:test_redis_password_not_for_production@redis:6379"
+      APP_BASE_URL: "http://app:8000"
+      APP_ENV: test
+      JWT_SECRET: "test-jwt-secret-not-for-production-use-only"
+      RUST_LOG: "debug"
+    command: >
+      cargo test --features database,cache,integration
+      -- --test-threads=1 --nocapture
+    # Propagate the test exit code so CI fails on test failure
+    restart: "no"
+
+volumes:
+  # Override parent volumes with empty declarations so they are created as
+  # anonymous volumes and removed automatically with `docker compose down -v`
+  postgres_data:
+  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,153 @@
+version: "3.9"
+
+# =============================================================================
+# Aframp Backend — local development stack
+#
+# Services:
+#   postgres  — PostgreSQL 16 with persistent volume
+#   redis     — Redis 7 with persistent volume
+#   app       — Aframp backend (built from source)
+#
+# Usage:
+#   docker compose up --build          # first run
+#   docker compose up                  # subsequent runs
+#   docker compose down -v             # stop and remove volumes
+# =============================================================================
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # PostgreSQL
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-aframp}
+      POSTGRES_USER: ${POSTGRES_USER:-aframp}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-aframp} -d ${POSTGRES_DB:-aframp}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # Redis
+  # ---------------------------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: >
+      redis-server
+      --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+      --save 60 1
+      --appendonly yes
+    volumes:
+      - redis_data:/data
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ---------------------------------------------------------------------------
+  # Application
+  # ---------------------------------------------------------------------------
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "${SERVER_PORT:-8000}:8000"
+    environment:
+      # Server
+      SERVER_HOST: "0.0.0.0"
+      SERVER_PORT: "${SERVER_PORT:-8000}"
+
+      # Database — constructed from individual parts so credentials are not
+      # hard-coded in the image or compose file.
+      DATABASE_URL: "postgres://${POSTGRES_USER:-aframp}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-aframp}"
+      DB_HOST: "postgres"
+      DB_PORT: "5432"
+      DB_MAX_CONNECTIONS: "${DB_MAX_CONNECTIONS:-20}"
+      DB_MIN_CONNECTIONS: "${DB_MIN_CONNECTIONS:-5}"
+      DB_CONNECTION_TIMEOUT: "${DB_CONNECTION_TIMEOUT:-30}"
+      DB_IDLE_TIMEOUT: "${DB_IDLE_TIMEOUT:-600}"
+      DB_MAX_LIFETIME: "${DB_MAX_LIFETIME:-1800}"
+
+      # Redis
+      REDIS_URL: "redis://:${REDIS_PASSWORD}@redis:6379"
+      REDIS_MAX_CONNECTIONS: "${REDIS_MAX_CONNECTIONS:-20}"
+      REDIS_MIN_IDLE: "${REDIS_MIN_IDLE:-5}"
+
+      # Application
+      APP_ENV: "${APP_ENV:-development}"
+      LOG_LEVEL: "${LOG_LEVEL:-INFO}"
+      LOG_FORMAT: "${LOG_FORMAT:-json}"
+      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-http://localhost:3000}"
+
+      # Stellar
+      STELLAR_NETWORK: "${STELLAR_NETWORK:-testnet}"
+      STELLAR_HORIZON_URL: "${STELLAR_HORIZON_URL:-https://horizon-testnet.stellar.org}"
+      STELLAR_REQUEST_TIMEOUT: "${STELLAR_REQUEST_TIMEOUT:-15}"
+      STELLAR_MAX_RETRIES: "${STELLAR_MAX_RETRIES:-3}"
+      SYSTEM_WALLET_ADDRESS: "${SYSTEM_WALLET_ADDRESS}"
+      SYSTEM_WALLET_SECRET: "${SYSTEM_WALLET_SECRET}"
+      CNGN_ISSUER_ADDRESS: "${CNGN_ISSUER_ADDRESS}"
+
+      # Payment providers
+      PAYSTACK_SECRET_KEY: "${PAYSTACK_SECRET_KEY}"
+      PAYSTACK_PUBLIC_KEY: "${PAYSTACK_PUBLIC_KEY}"
+      FLUTTERWAVE_SECRET_KEY: "${FLUTTERWAVE_SECRET_KEY}"
+      FLUTTERWAVE_PUBLIC_KEY: "${FLUTTERWAVE_PUBLIC_KEY}"
+      MPESA_CONSUMER_KEY: "${MPESA_CONSUMER_KEY}"
+      MPESA_CONSUMER_SECRET: "${MPESA_CONSUMER_SECRET}"
+      MPESA_PASSKEY: "${MPESA_PASSKEY}"
+      MPESA_SHORTCODE: "${MPESA_SHORTCODE}"
+
+      # JWT
+      JWT_SECRET: "${JWT_SECRET:?JWT_SECRET is required}"
+
+      # OpenTelemetry (optional — leave blank to disable)
+      OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-aframp-backend}"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4317}"
+      OTEL_SAMPLING_RATE: "${OTEL_SAMPLING_RATE:-1.0}"
+
+      # Workers
+      TX_MONITOR_ENABLED: "${TX_MONITOR_ENABLED:-true}"
+      OFFRAMP_PROCESSOR_ENABLED: "${OFFRAMP_PROCESSOR_ENABLED:-true}"
+      ONRAMP_PROCESSOR_ENABLED: "${ONRAMP_PROCESSOR_ENABLED:-true}"
+      BILL_PROCESSOR_ENABLED: "${BILL_PROCESSOR_ENABLED:-true}"
+      PAYMENT_POLLER_ENABLED: "${PAYMENT_POLLER_ENABLED:-true}"
+      WEBHOOK_RETRY_ENABLED: "${WEBHOOK_RETRY_ENABLED:-true}"
+
+      # Migration gate
+      RUN_MIGRATIONS: "true"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${SERVER_PORT:-8000}/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# =============================================================================
+# docker-entrypoint.sh
+# 1. Waits for PostgreSQL to accept TCP connections.
+# 2. Runs sqlx database migrations.
+# 3. Starts the application.
+#
+# Exits non-zero on any failure so Docker restarts the container.
+#
+# Environment variables consumed:
+#   DB_HOST          - postgres hostname (default: postgres)
+#   DB_PORT          - postgres port     (default: 5432)
+#   DATABASE_URL     - full postgres connection URL (required for migrations)
+#   RUN_MIGRATIONS   - set to "false" to skip migration step (default: true)
+# =============================================================================
+set -e
+
+DB_HOST="${DB_HOST:-postgres}"
+DB_PORT="${DB_PORT:-5432}"
+
+# ---------------------------------------------------------------------------
+# Wait for PostgreSQL to accept TCP connections.
+# curl with the telnet:// scheme performs a raw TCP connect without sending
+# any HTTP data, making it a lightweight port-open check.
+# ---------------------------------------------------------------------------
+wait_for_postgres() {
+    retries=30
+    echo "==> Waiting for PostgreSQL at ${DB_HOST}:${DB_PORT}..."
+    while ! curl -sf --connect-timeout 2 "telnet://${DB_HOST}:${DB_PORT}" >/dev/null 2>&1; do
+        retries=$((retries - 1))
+        if [ "$retries" -eq 0 ]; then
+            echo "ERROR: PostgreSQL at ${DB_HOST}:${DB_PORT} did not become reachable." >&2
+            exit 1
+        fi
+        echo "    Still waiting... (${retries} retries left)"
+        sleep 2
+    done
+    echo "==> PostgreSQL is reachable."
+}
+
+# ---------------------------------------------------------------------------
+# Run sqlx migrations.
+# ---------------------------------------------------------------------------
+run_migrations() {
+    if [ -z "$DATABASE_URL" ]; then
+        echo "ERROR: DATABASE_URL is not set — cannot run migrations." >&2
+        exit 1
+    fi
+
+    echo "==> Running database migrations..."
+    sqlx migrate run --source /app/migrations --database-url "$DATABASE_URL"
+    echo "==> Migrations complete."
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
+    wait_for_postgres
+    run_migrations
+fi
+
+echo "==> Starting Aframp backend..."
+exec /app/aframp-backend "$@"


### PR DESCRIPTION
- Multi-stage Dockerfile (chef -> planner -> builder-deps -> builder -> runtime)
- cargo-chef separates dependency compilation from source for fast rebuilds
- sqlx-cli copied into runtime image for migration execution at startup
- Runtime image based on debian:bookworm-slim, non-root user (uid 10001)
- Binary stripped to minimise image size (~120-140 MB final)
- docker-entrypoint.sh waits for PostgreSQL then runs sqlx migrations
- docker-compose.yml: full local stack with Postgres 16, Redis 7, health checks, persistent volumes, and dependency ordering
- docker-compose.test.yml: ephemeral integration test override with tmpfs services, isolated ports, and clean teardown
- .env.example: all environment variables documented with REQUIRED/OPTIONAL labels
- .dockerignore: excludes target/, .env*, .git/, docs, logs, and build artefacts
- DEVELOPMENT.md: full setup, usage, migration, testing, and troubleshooting guide
- No secrets baked into any image layer; all config injected at runtime

Closes #117