### PR TITLE
feat: Replay Attack Prevention via Nonce & Timestamp Validation (#141)

### DIFF
--- a/docs/request-signing.md
+++ b/docs/request-signing.md
@@ -1,0 +1,241 @@
+# Request Signing & Replay Prevention
+
+Every signed API request must include three security headers. HMAC signature
+verification alone does not prevent replay attacks — a correctly signed request
+captured by an attacker is still a correctly signed request. The platform
+combines timestamp validation with server-side nonce tracking so that each
+signed request can only be processed **exactly once**.
+
+## Required Headers
+
+| Header | Format | Description |
+|---|---|---|
+| `X-Aframp-Timestamp` | Unix timestamp (seconds) | When the request was signed |
+| `X-Aframp-Nonce` | UUID v4 or 32-byte hex | Unique random value per request |
+| `X-Aframp-Consumer` | String | Your consumer ID |
+
+## Timestamp Rules
+
+- The timestamp must be within **±5 minutes** of server time (configurable via `REPLAY_TIMESTAMP_WINDOW_SECS`).
+- Requests older than the window are rejected with `401 TIMESTAMP_TOO_OLD`.
+- Requests more than 30 seconds in the future are rejected with `401 TIMESTAMP_IN_FUTURE`.
+- Always use a reliable time source. If your clock is consistently skewed, the platform will emit a warning.
+
+## Nonce Rules
+
+- Must be **unique per request** — never reuse a nonce.
+- Accepted formats: UUID v4 (e.g. `550e8400-e29b-41d4-a716-446655440000`) or a 32-byte cryptographically random hex string.
+- Minimum entropy: 128 bits.
+- The nonce is stored server-side for `timestamp_window + 60 seconds`. After that window, the nonce expires and the same value could theoretically be reused — but you should never reuse nonces regardless.
+- A replayed nonce is rejected with `401 REPLAY_DETECTED`.
+
+## Canonical Request String
+
+The nonce **must** be included in the canonical request string that is signed.
+This ensures a request with a swapped nonce fails signature verification.
+
+```
+METHOD\n
+/path/to/endpoint\n
+X-Aframp-Timestamp:<timestamp>\n
+X-Aframp-Nonce:<nonce>\n
+X-Aframp-Consumer:<consumer_id>\n
+<sha256_hex_of_request_body>
+```
+
+---
+
+## Nonce Generation Reference Implementations
+
+### JavaScript / TypeScript
+
+```javascript
+// UUID v4 (Node.js 14.17+ / all modern browsers)
+const nonce = crypto.randomUUID();
+
+// 32-byte hex alternative (Node.js)
+import { randomBytes } from 'crypto';
+const nonce = randomBytes(32).toString('hex');
+
+// Full signed request example
+async function signedFetch(url, body, consumerSecret, consumerId) {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const nonce = crypto.randomUUID();
+  const bodyHash = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(body)
+  );
+  const bodyHashHex = Array.from(new Uint8Array(bodyHash))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  const method = 'POST';
+  const path = new URL(url).pathname;
+  const canonical = [
+    method,
+    path,
+    `X-Aframp-Timestamp:${timestamp}`,
+    `X-Aframp-Nonce:${nonce}`,
+    `X-Aframp-Consumer:${consumerId}`,
+    bodyHashHex,
+  ].join('\n');
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(consumerSecret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(canonical));
+  const signature = Array.from(new Uint8Array(sig))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  return fetch(url, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Aframp-Timestamp': timestamp,
+      'X-Aframp-Nonce': nonce,
+      'X-Aframp-Consumer': consumerId,
+      'X-Aframp-Signature': signature,
+    },
+    body,
+  });
+}
+```
+
+### Python
+
+```python
+import hashlib
+import hmac
+import time
+import uuid
+import secrets
+import httpx
+
+def generate_nonce() -> str:
+    """UUID v4 nonce — 122 bits of entropy."""
+    return str(uuid.uuid4())
+
+def generate_nonce_hex() -> str:
+    """32-byte hex nonce — 256 bits of entropy."""
+    return secrets.token_hex(32)
+
+def signed_request(
+    method: str,
+    url: str,
+    body: bytes,
+    consumer_id: str,
+    consumer_secret: str,
+) -> httpx.Response:
+    timestamp = str(int(time.time()))
+    nonce = generate_nonce()
+    body_hash = hashlib.sha256(body).hexdigest()
+    path = httpx.URL(url).path
+
+    canonical = "\n".join([
+        method.upper(),
+        path,
+        f"X-Aframp-Timestamp:{timestamp}",
+        f"X-Aframp-Nonce:{nonce}",
+        f"X-Aframp-Consumer:{consumer_id}",
+        body_hash,
+    ])
+
+    signature = hmac.new(
+        consumer_secret.encode(),
+        canonical.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return httpx.post(
+        url,
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Aframp-Timestamp": timestamp,
+            "X-Aframp-Nonce": nonce,
+            "X-Aframp-Consumer": consumer_id,
+            "X-Aframp-Signature": signature,
+        },
+    )
+```
+
+### Rust
+
+```rust
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Generate a UUID v4 nonce.
+pub fn generate_nonce() -> String {
+    Uuid::new_v4().to_string()
+}
+
+/// Generate a 32-byte cryptographically random hex nonce.
+pub fn generate_nonce_hex() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+pub fn sign_request(
+    method: &str,
+    path: &str,
+    body: &[u8],
+    consumer_id: &str,
+    consumer_secret: &str,
+) -> (String, String, String) {
+    let timestamp = chrono::Utc::now().timestamp().to_string();
+    let nonce = generate_nonce();
+
+    let body_hash = hex::encode(Sha256::digest(body));
+    let canonical = format!(
+        "{}\n{}\nX-Aframp-Timestamp:{}\nX-Aframp-Nonce:{}\nX-Aframp-Consumer:{}\n{}",
+        method.to_uppercase(),
+        path,
+        timestamp,
+        nonce,
+        consumer_id,
+        body_hash,
+    );
+
+    let mut mac = HmacSha256::new_from_slice(consumer_secret.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(canonical.as_bytes());
+    let signature = hex::encode(mac.finalize().into_bytes());
+
+    (timestamp, nonce, signature)
+}
+```
+
+---
+
+## Error Responses
+
+| Code | HTTP | Meaning |
+|---|---|---|
+| `MISSING_TIMESTAMP` | 401 | `X-Aframp-Timestamp` header absent |
+| `MISSING_NONCE` | 401 | `X-Aframp-Nonce` header absent |
+| `INVALID_TIMESTAMP` | 401 | Timestamp is not a valid integer |
+| `TIMESTAMP_TOO_OLD` | 401 | Request is older than the allowed window |
+| `TIMESTAMP_IN_FUTURE` | 401 | Request timestamp is too far ahead of server time |
+| `REPLAY_DETECTED` | 401 | Nonce has already been used |
+| `NONCE_STORE_UNAVAILABLE` | 503 | Transient Redis error — safe to retry with a **new** nonce |
+
+## Environment Variables (Server-Side)
+
+| Variable | Default | Description |
+|---|---|---|
+| `REPLAY_TIMESTAMP_WINDOW_SECS` | 300 | Max request age in seconds |
+| `REPLAY_FUTURE_TOLERANCE_SECS` | 30 | Max future skew in seconds |
+| `REPLAY_NONCE_TTL_BUFFER_SECS` | 60 | Extra Redis TTL buffer beyond the window |
+| `REPLAY_CLOCK_SKEW_ALERT_SECS` | 60 | Clock skew delta that triggers a warning log |
+| `REPLAY_ATTEMPT_ALERT_THRESHOLD` | 5 | Replay attempts per consumer before alerting |

--- a/src/cache/keys.rs
+++ b/src/cache/keys.rs
@@ -433,3 +433,38 @@ mod tests {
         assert_eq!(key.to_string(), "v1:auth:rate_limit:user_123:login");
     }
 }
+
+pub mod replay {
+    use super::*;
+
+    pub const NAMESPACE: &str = "nonce";
+
+    /// Namespaced nonce key: `v1:nonce:<consumer_id>:<nonce>`
+    ///
+    /// Stored in Redis with TTL = timestamp_window + safety_buffer.
+    /// Presence of this key means the nonce has already been consumed.
+    #[derive(Debug, Clone)]
+    pub struct NonceKey {
+        pub consumer_id: String,
+        pub nonce: String,
+    }
+
+    impl NonceKey {
+        pub fn new(consumer_id: impl Into<String>, nonce: impl Into<String>) -> Self {
+            Self {
+                consumer_id: consumer_id.into(),
+                nonce: nonce.into(),
+            }
+        }
+    }
+
+    impl fmt::Display for NonceKey {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "{}:{}:{}:{}",
+                VERSION, NAMESPACE, self.consumer_id, self.nonce
+            )
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1165,10 +1165,21 @@ async fn main() -> anyhow::Result<()> {
     let app = if let Some(cache) = redis_cache.clone() {
 
         let rate_limit_state = crate::middleware::rate_limit::RateLimitState {
-            cache: std::sync::Arc::new(cache),
+            cache: std::sync::Arc::new(cache.clone()),
             config: rate_limit_config,
         };
-        app.layer(axum::middleware::from_fn_with_state(rate_limit_state, crate::middleware::rate_limit::rate_limit_middleware))
+
+        let replay_state = crate::middleware::replay_prevention::ReplayPreventionState {
+            redis: std::sync::Arc::new(cache.pool.clone()),
+            config: std::sync::Arc::new(crate::middleware::replay_prevention::ReplayConfig::from_env()),
+        };
+
+        app
+            .layer(axum::middleware::from_fn_with_state(
+                replay_state,
+                crate::middleware::replay_prevention::replay_prevention_middleware,
+            ))
+            .layer(axum::middleware::from_fn_with_state(rate_limit_state, crate::middleware::rate_limit::rate_limit_middleware))
     } else {
         app
     };

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -538,6 +538,78 @@ pub mod database {
 }
 
 // ---------------------------------------------------------------------------
+// Security / replay-prevention metrics  (Issue #141)
+// ---------------------------------------------------------------------------
+
+pub mod security {
+    use super::*;
+
+    static REPLAY_ATTEMPTS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+    static TIMESTAMP_REJECTIONS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+    static TIMESTAMP_DELTA_SECONDS: OnceLock<HistogramVec> = OnceLock::new();
+
+    /// Increment when a replay is detected (nonce already seen).
+    pub fn replay_attempts_total() -> &'static CounterVec {
+        REPLAY_ATTEMPTS_TOTAL
+            .get()
+            .expect("metrics not initialised")
+    }
+
+    /// Increment when a request is rejected due to clock skew.
+    pub fn timestamp_rejections_total() -> &'static CounterVec {
+        TIMESTAMP_REJECTIONS_TOTAL
+            .get()
+            .expect("metrics not initialised")
+    }
+
+    /// Histogram of |server_time − request_timestamp| for valid requests.
+    pub fn timestamp_delta_seconds() -> &'static HistogramVec {
+        TIMESTAMP_DELTA_SECONDS
+            .get()
+            .expect("metrics not initialised")
+    }
+
+    pub(super) fn register(r: &Registry) {
+        REPLAY_ATTEMPTS_TOTAL
+            .set(
+                register_counter_vec_with_registry!(
+                    "aframp_security_replay_attempts_total",
+                    "Total replay attempts detected, labelled by consumer_id and endpoint",
+                    &["consumer_id", "endpoint"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        TIMESTAMP_REJECTIONS_TOTAL
+            .set(
+                register_counter_vec_with_registry!(
+                    "aframp_security_timestamp_rejections_total",
+                    "Total requests rejected due to timestamp clock skew",
+                    &["consumer_id", "reason"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        TIMESTAMP_DELTA_SECONDS
+            .set(
+                register_histogram_vec_with_registry!(
+                    "aframp_security_timestamp_delta_seconds",
+                    "Distribution of |server_time - request_timestamp| for accepted requests",
+                    &["consumer_id"],
+                    vec![0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Register all metrics
 // ---------------------------------------------------------------------------
 
@@ -549,6 +621,7 @@ fn register_all(r: &Registry) {
     worker::register(r);
     cache::register(r);
     database::register(r);
+    security::register(r);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/middleware/replay_prevention.rs
+++ b/src/middleware/replay_prevention.rs
@@ -1,0 +1,532 @@
+//! Replay Attack Prevention Middleware (Issue #141)
+//!
+//! Protects signed API requests from being replayed by combining:
+//!   1. Timestamp validation — rejects requests outside a configurable time window.
+//!   2. Nonce tracking     — atomically stores each accepted nonce in Redis so that
+//!                           a replayed request (same nonce) is rejected immediately.
+//!
+//! # Headers consumed
+//! - `X-Aframp-Timestamp` — Unix timestamp (seconds) when the request was signed.
+//! - `X-Aframp-Nonce`     — UUID v4 or 32-byte hex string, unique per request.
+//! - `X-Aframp-Consumer`  — Consumer ID used to namespace the Redis nonce key.
+//!
+//! # Flow
+//! ```text
+//! extract headers
+//!   → validate timestamp (window + future tolerance)
+//!   → atomic Redis SET NX with TTL  (nonce check + store in one command)
+//!   → if SET NX returned 0 → replay detected → 401
+//!   → proceed to next handler
+//! ```
+
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use redis::AsyncCommands;
+use serde::Serialize;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+use crate::cache::RedisPool;
+use crate::cache::keys::replay::NonceKey;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Replay-prevention configuration — typically loaded from environment / config file.
+#[derive(Debug, Clone)]
+pub struct ReplayConfig {
+    /// Maximum age of a request timestamp (seconds). Default: 300 (5 minutes).
+    pub timestamp_window_secs: i64,
+    /// How far into the future a timestamp may be (seconds). Default: 30.
+    pub future_tolerance_secs: i64,
+    /// Extra TTL buffer added to the Redis nonce key beyond the timestamp window (seconds).
+    pub nonce_ttl_buffer_secs: u64,
+    /// Clock skew alert threshold (seconds). If the median delta for a consumer exceeds
+    /// this value, a warning is emitted. Default: 60.
+    pub clock_skew_alert_threshold_secs: f64,
+    /// Replay attempt alert threshold per consumer within the rolling window. Default: 5.
+    pub replay_alert_threshold: u64,
+}
+
+impl Default for ReplayConfig {
+    fn default() -> Self {
+        Self {
+            timestamp_window_secs: 300,
+            future_tolerance_secs: 30,
+            nonce_ttl_buffer_secs: 60,
+            clock_skew_alert_threshold_secs: 60.0,
+            replay_alert_threshold: 5,
+        }
+    }
+}
+
+impl ReplayConfig {
+    /// Total TTL for a nonce key in Redis: window + buffer.
+    pub fn nonce_ttl_secs(&self) -> u64 {
+        self.timestamp_window_secs as u64 + self.nonce_ttl_buffer_secs
+    }
+
+    /// Load configuration from environment variables, falling back to defaults.
+    ///
+    /// | Variable                          | Default | Description                                      |
+    /// |-----------------------------------|---------|--------------------------------------------------|
+    /// | `REPLAY_TIMESTAMP_WINDOW_SECS`    | 300     | Max age of a request timestamp (seconds).        |
+    /// | `REPLAY_FUTURE_TOLERANCE_SECS`    | 30      | Max future skew allowed (seconds).               |
+    /// | `REPLAY_NONCE_TTL_BUFFER_SECS`    | 60      | Extra TTL buffer on top of the window (seconds). |
+    /// | `REPLAY_CLOCK_SKEW_ALERT_SECS`    | 60      | Clock skew alert threshold (seconds).            |
+    /// | `REPLAY_ATTEMPT_ALERT_THRESHOLD`  | 5       | Replay attempts before alerting.                 |
+    pub fn from_env() -> Self {
+        let default = Self::default();
+        Self {
+            timestamp_window_secs: std::env::var("REPLAY_TIMESTAMP_WINDOW_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default.timestamp_window_secs),
+            future_tolerance_secs: std::env::var("REPLAY_FUTURE_TOLERANCE_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default.future_tolerance_secs),
+            nonce_ttl_buffer_secs: std::env::var("REPLAY_NONCE_TTL_BUFFER_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default.nonce_ttl_buffer_secs),
+            clock_skew_alert_threshold_secs: std::env::var("REPLAY_CLOCK_SKEW_ALERT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default.clock_skew_alert_threshold_secs),
+            replay_alert_threshold: std::env::var("REPLAY_ATTEMPT_ALERT_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default.replay_alert_threshold),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct ReplayPreventionState {
+    pub redis: Arc<RedisPool>,
+    pub config: Arc<ReplayConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// Error response helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct SecurityError {
+    error: SecurityErrorDetail,
+}
+
+#[derive(Serialize)]
+struct SecurityErrorDetail {
+    code: String,
+    message: String,
+}
+
+fn security_401(code: &str, message: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(SecurityError {
+            error: SecurityErrorDetail {
+                code: code.to_string(),
+                message: message.to_string(),
+            },
+        }),
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Header extraction helpers
+// ---------------------------------------------------------------------------
+
+fn extract_header<'a>(req: &'a Request<Body>, name: &str) -> Option<&'a str> {
+    req.headers()
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp validation
+// ---------------------------------------------------------------------------
+
+/// Returns `Ok(delta_secs)` where delta = |server_time - request_time|,
+/// or an `Err` response to send back to the client.
+fn validate_timestamp(
+    request_ts: i64,
+    server_ts: i64,
+    config: &ReplayConfig,
+) -> Result<f64, Response> {
+    let delta = server_ts - request_ts;
+
+    if delta > config.timestamp_window_secs {
+        return Err(security_401(
+            "TIMESTAMP_TOO_OLD",
+            &format!(
+                "Request timestamp is {} seconds old; maximum allowed age is {} seconds",
+                delta, config.timestamp_window_secs
+            ),
+        ));
+    }
+
+    if -delta > config.future_tolerance_secs {
+        return Err(security_401(
+            "TIMESTAMP_IN_FUTURE",
+            &format!(
+                "Request timestamp is {} seconds in the future; maximum tolerance is {} seconds",
+                -delta, config.future_tolerance_secs
+            ),
+        ));
+    }
+
+    Ok(delta.unsigned_abs() as f64)
+}
+
+// ---------------------------------------------------------------------------
+// Nonce validation (atomic Redis SET NX)
+// ---------------------------------------------------------------------------
+
+/// Atomically checks and stores a nonce in Redis.
+///
+/// Uses `SET key 1 NX EX ttl` — if the key already exists the command returns
+/// `nil` (None), indicating a replay.  Returns `true` if the nonce was fresh
+/// (stored successfully), `false` if it was a replay.
+async fn check_and_store_nonce(
+    pool: &RedisPool,
+    nonce_key: &str,
+    ttl_secs: u64,
+) -> Result<bool, String> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|e| format!("Redis connection error: {e}"))?;
+
+    // SET key "1" NX EX ttl  — atomic check-and-set
+    let result: Option<String> = redis::cmd("SET")
+        .arg(nonce_key)
+        .arg("1")
+        .arg("NX")
+        .arg("EX")
+        .arg(ttl_secs)
+        .query_async(&mut *conn)
+        .await
+        .map_err(|e| format!("Redis SET NX error: {e}"))?;
+
+    // SET NX returns "OK" when the key was set (nonce is fresh),
+    // or nil (None) when the key already existed (replay).
+    Ok(result.is_some())
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+/// Axum middleware that enforces timestamp + nonce replay prevention.
+///
+/// Attach to any route group that uses HMAC request signing:
+/// ```rust,ignore
+/// Router::new()
+///     .route("/transfers", post(handler))
+///     .layer(axum::middleware::from_fn_with_state(
+///         state,
+///         replay_prevention_middleware,
+///     ))
+/// ```
+pub async fn replay_prevention_middleware(
+    State(state): State<ReplayPreventionState>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let endpoint = req.uri().path().to_string();
+
+    // ── 1. Extract required headers ──────────────────────────────────────────
+    let timestamp_str = match extract_header(&req, "x-aframp-timestamp") {
+        Some(v) => v.to_string(),
+        None => {
+            warn!(endpoint = %endpoint, "Missing X-Aframp-Timestamp header");
+            return security_401(
+                "MISSING_TIMESTAMP",
+                "X-Aframp-Timestamp header is required",
+            );
+        }
+    };
+
+    let nonce = match extract_header(&req, "x-aframp-nonce") {
+        Some(v) => v.to_string(),
+        None => {
+            warn!(endpoint = %endpoint, "Missing X-Aframp-Nonce header");
+            return security_401("MISSING_NONCE", "X-Aframp-Nonce header is required");
+        }
+    };
+
+    let consumer_id = extract_header(&req, "x-aframp-consumer")
+        .unwrap_or("unknown")
+        .to_string();
+
+    // ── 2. Parse timestamp ───────────────────────────────────────────────────
+    let request_ts: i64 = match timestamp_str.parse() {
+        Ok(v) => v,
+        Err(_) => {
+            warn!(
+                consumer_id = %consumer_id,
+                endpoint = %endpoint,
+                raw = %timestamp_str,
+                "Unparseable X-Aframp-Timestamp"
+            );
+            return security_401(
+                "INVALID_TIMESTAMP",
+                "X-Aframp-Timestamp must be a Unix timestamp in seconds",
+            );
+        }
+    };
+
+    let server_ts = chrono::Utc::now().timestamp();
+
+    // ── 3. Validate timestamp window ─────────────────────────────────────────
+    let delta = match validate_timestamp(request_ts, server_ts, &state.config) {
+        Ok(d) => d,
+        Err(resp) => {
+            let skew = server_ts - request_ts;
+            warn!(
+                consumer_id = %consumer_id,
+                endpoint = %endpoint,
+                request_ts = request_ts,
+                server_ts = server_ts,
+                delta_secs = skew,
+                "Timestamp validation failed"
+            );
+            let reason = if skew > 0 { "too_old" } else { "too_future" };
+            crate::metrics::security::timestamp_rejections_total()
+                .with_label_values(&[&consumer_id, reason])
+                .inc();
+            return resp;
+        }
+    };
+
+    // ── 4. Track clock-skew histogram for valid timestamps ───────────────────
+    crate::metrics::security::timestamp_delta_seconds()
+        .with_label_values(&[&consumer_id])
+        .observe(delta);
+
+    // Alert if delta exceeds the configured clock skew threshold
+    if delta > state.config.clock_skew_alert_threshold_secs {
+        warn!(
+            consumer_id = %consumer_id,
+            endpoint = %endpoint,
+            delta_secs = delta,
+            threshold_secs = state.config.clock_skew_alert_threshold_secs,
+            "Clock skew alert: consumer timestamp delta exceeds threshold — possible misconfigured clock"
+        );
+    }
+
+    // ── 5. Atomic nonce check-and-store ──────────────────────────────────────
+    let nonce_key = NonceKey::new(&consumer_id, &nonce).to_string();
+    let ttl = state.config.nonce_ttl_secs();
+
+    match check_and_store_nonce(&state.redis, &nonce_key, ttl).await {
+        Ok(true) => {
+            // Nonce was fresh — proceed
+            info!(
+                consumer_id = %consumer_id,
+                endpoint = %endpoint,
+                nonce = %nonce,
+                "Request accepted: fresh nonce"
+            );
+        }
+        Ok(false) => {
+            // Nonce already seen — replay detected
+            let attempt_count = crate::metrics::security::replay_attempts_total()
+                .with_label_values(&[&consumer_id, &endpoint])
+                .get() as u64 + 1;
+
+            warn!(
+                consumer_id = %consumer_id,
+                endpoint = %endpoint,
+                nonce = %nonce,
+                request_ts = request_ts,
+                server_ts = server_ts,
+                detection_ts = chrono::Utc::now().timestamp(),
+                "Replay attack detected: nonce already consumed"
+            );
+            crate::metrics::security::replay_attempts_total()
+                .with_label_values(&[&consumer_id, &endpoint])
+                .inc();
+
+            // Alert if replay attempts from this consumer exceed the threshold
+            if attempt_count >= state.config.replay_alert_threshold {
+                warn!(
+                    consumer_id = %consumer_id,
+                    endpoint = %endpoint,
+                    attempt_count = attempt_count,
+                    threshold = state.config.replay_alert_threshold,
+                    "Replay alert: consumer has exceeded replay attempt threshold — potential active attack"
+                );
+            }
+
+            return security_401(
+                "REPLAY_DETECTED",
+                "This request has already been processed. Each request must use a unique nonce.",
+            );
+        }
+        Err(e) => {
+            // Redis error — fail closed (reject the request) to stay safe
+            error!(
+                consumer_id = %consumer_id,
+                endpoint = %endpoint,
+                error = %e,
+                "Redis error during nonce check; rejecting request"
+            );
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(SecurityError {
+                    error: SecurityErrorDetail {
+                        code: "NONCE_STORE_UNAVAILABLE".to_string(),
+                        message: "Unable to verify request uniqueness. Please retry.".to_string(),
+                    },
+                }),
+            )
+                .into_response();
+        }
+    }
+
+    next.run(req).await
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Timestamp validation ─────────────────────────────────────────────────
+
+    #[test]
+    fn accepts_timestamp_within_window() {
+        let cfg = ReplayConfig::default();
+        let server = 1_000_000i64;
+        // 10 seconds old — well within 300 s window
+        assert!(validate_timestamp(server - 10, server, &cfg).is_ok());
+    }
+
+    #[test]
+    fn rejects_timestamp_too_old() {
+        let cfg = ReplayConfig::default();
+        let server = 1_000_000i64;
+        // 301 seconds old — just outside the 300 s window
+        let result = validate_timestamp(server - 301, server, &cfg);
+        assert!(result.is_err());
+        let resp = result.unwrap_err();
+        // Verify it's a 401
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn rejects_timestamp_at_exact_boundary() {
+        let cfg = ReplayConfig::default();
+        let server = 1_000_000i64;
+        // Exactly at the window boundary (300 s) — should be rejected (> not >=)
+        let result = validate_timestamp(server - 300, server, &cfg);
+        // delta == window_secs is NOT > window_secs, so it should be accepted
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rejects_timestamp_in_future_beyond_tolerance() {
+        let cfg = ReplayConfig::default();
+        let server = 1_000_000i64;
+        // 31 seconds in the future — beyond 30 s tolerance
+        let result = validate_timestamp(server + 31, server, &cfg);
+        assert!(result.is_err());
+        let resp = result.unwrap_err();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn accepts_timestamp_within_future_tolerance() {
+        let cfg = ReplayConfig::default();
+        let server = 1_000_000i64;
+        // 10 seconds in the future — within 30 s tolerance
+        assert!(validate_timestamp(server + 10, server, &cfg).is_ok());
+    }
+
+    #[test]
+    fn delta_value_is_correct() {
+        let cfg = ReplayConfig::default();
+        let server = 1_000_000i64;
+        let delta = validate_timestamp(server - 42, server, &cfg).unwrap();
+        assert!((delta - 42.0).abs() < f64::EPSILON);
+    }
+
+    // ── Nonce key construction ───────────────────────────────────────────────
+
+    #[test]
+    fn nonce_key_is_namespaced_per_consumer() {
+        let key_a = NonceKey::new("consumer-a", "nonce-1").to_string();
+        let key_b = NonceKey::new("consumer-b", "nonce-1").to_string();
+        // Same nonce, different consumers → different keys
+        assert_ne!(key_a, key_b);
+        assert!(key_a.contains("consumer-a"));
+        assert!(key_b.contains("consumer-b"));
+    }
+
+    #[test]
+    fn nonce_key_format() {
+        let key = NonceKey::new("abc-123", "deadbeef").to_string();
+        assert_eq!(key, "v1:nonce:abc-123:deadbeef");
+    }
+
+    // ── Config helpers ───────────────────────────────────────────────────────
+
+    #[test]
+    fn nonce_ttl_is_window_plus_buffer() {
+        let cfg = ReplayConfig {
+            timestamp_window_secs: 300,
+            nonce_ttl_buffer_secs: 60,
+            ..Default::default()
+        };
+        assert_eq!(cfg.nonce_ttl_secs(), 360);
+    }
+
+    #[test]
+    fn custom_config_respected() {
+        let cfg = ReplayConfig {
+            timestamp_window_secs: 60,
+            future_tolerance_secs: 10,
+            nonce_ttl_buffer_secs: 30,
+            clock_skew_alert_threshold_secs: 30.0,
+            replay_alert_threshold: 3,
+        };
+        let server = 1_000_000i64;
+        // 61 seconds old — outside 60 s window
+        assert!(validate_timestamp(server - 61, server, &cfg).is_err());
+        // 11 seconds in future — outside 10 s tolerance
+        assert!(validate_timestamp(server + 11, server, &cfg).is_err());
+        // 59 seconds old — inside window
+        assert!(validate_timestamp(server - 59, server, &cfg).is_ok());
+    }
+
+    #[test]
+    fn clock_skew_alert_threshold_defaults_to_60() {
+        let cfg = ReplayConfig::default();
+        assert!((cfg.clock_skew_alert_threshold_secs - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn replay_alert_threshold_defaults_to_5() {
+        let cfg = ReplayConfig::default();
+        assert_eq!(cfg.replay_alert_threshold, 5);
+    }
+}

--- a/tests/replay_prevention_test.rs
+++ b/tests/replay_prevention_test.rs
@@ -1,0 +1,273 @@
+//! Integration tests for Replay Attack Prevention middleware (Issue #141).
+//!
+//! Requires a running Redis instance.
+//! Run with: cargo test --features cache replay_prevention -- --ignored
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware,
+    response::IntoResponse,
+    routing::post,
+    Router,
+};
+use tower::ServiceExt;
+
+use Bitmesh_backend::cache::{init_cache_pool, CacheConfig};
+use Bitmesh_backend::middleware::replay_prevention::{
+    replay_prevention_middleware, ReplayConfig, ReplayPreventionState,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn build_router(config: ReplayConfig) -> Router {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let pool = init_cache_pool(CacheConfig {
+        redis_url,
+        ..Default::default()
+    })
+    .await
+    .expect("Redis init failed");
+
+    let state = ReplayPreventionState {
+        redis: Arc::new(pool),
+        config: Arc::new(config),
+    };
+
+    Router::new()
+        .route("/transfer", post(|| async { "ok".into_response() }))
+        .layer(middleware::from_fn_with_state(
+            state,
+            replay_prevention_middleware,
+        ))
+}
+
+fn signed_request(nonce: &str, timestamp: i64, consumer: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/transfer")
+        .header("x-aframp-timestamp", timestamp.to_string())
+        .header("x-aframp-nonce", nonce)
+        .header("x-aframp-consumer", consumer)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn unique_nonce() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A fresh request with a valid timestamp and unique nonce must be accepted.
+#[tokio::test]
+#[ignore]
+async fn test_first_request_accepted() {
+    let router = build_router(ReplayConfig::default()).await;
+    let now = chrono::Utc::now().timestamp();
+    let req = signed_request(&unique_nonce(), now, "consumer-test-1");
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// Replaying the exact same request (same nonce) must be rejected with 401.
+#[tokio::test]
+#[ignore]
+async fn test_replay_rejected_on_second_submission() {
+    let router = build_router(ReplayConfig::default()).await;
+    let now = chrono::Utc::now().timestamp();
+    let nonce = unique_nonce();
+    let consumer = format!("consumer-replay-{}", unique_nonce());
+
+    // First submission — should succeed
+    let req1 = signed_request(&nonce, now, &consumer);
+    let resp1 = router.clone().oneshot(req1).await.unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK, "first request should be accepted");
+
+    // Second submission with same nonce — should be rejected
+    let req2 = signed_request(&nonce, now, &consumer);
+    let resp2 = router.oneshot(req2).await.unwrap();
+    assert_eq!(resp2.status(), StatusCode::UNAUTHORIZED, "replay should be rejected");
+
+    let body = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "REPLAY_DETECTED");
+}
+
+/// A timestamp older than the configured window must be rejected.
+#[tokio::test]
+#[ignore]
+async fn test_timestamp_too_old_rejected() {
+    let router = build_router(ReplayConfig::default()).await;
+    let old_ts = chrono::Utc::now().timestamp() - 400; // 400 s old, window is 300 s
+    let req = signed_request(&unique_nonce(), old_ts, "consumer-ts-old");
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "TIMESTAMP_TOO_OLD");
+}
+
+/// A timestamp too far in the future must be rejected.
+#[tokio::test]
+#[ignore]
+async fn test_timestamp_in_future_rejected() {
+    let router = build_router(ReplayConfig::default()).await;
+    let future_ts = chrono::Utc::now().timestamp() + 120; // 120 s ahead, tolerance is 30 s
+    let req = signed_request(&unique_nonce(), future_ts, "consumer-ts-future");
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "TIMESTAMP_IN_FUTURE");
+}
+
+/// A request at exactly the timestamp boundary (window_secs old) must be accepted.
+#[tokio::test]
+#[ignore]
+async fn test_timestamp_at_exact_boundary_accepted() {
+    let cfg = ReplayConfig {
+        timestamp_window_secs: 300,
+        ..Default::default()
+    };
+    let router = build_router(cfg).await;
+    // Exactly 300 s old — delta == window, not > window, so accepted
+    let boundary_ts = chrono::Utc::now().timestamp() - 300;
+    let consumer = format!("consumer-boundary-{}", unique_nonce());
+    let req = signed_request(&unique_nonce(), boundary_ts, &consumer);
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// Missing X-Aframp-Timestamp header must return 401.
+#[tokio::test]
+#[ignore]
+async fn test_missing_timestamp_header_rejected() {
+    let router = build_router(ReplayConfig::default()).await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/transfer")
+        .header("x-aframp-nonce", unique_nonce())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "MISSING_TIMESTAMP");
+}
+
+/// Missing X-Aframp-Nonce header must return 401.
+#[tokio::test]
+#[ignore]
+async fn test_missing_nonce_header_rejected() {
+    let router = build_router(ReplayConfig::default()).await;
+    let now = chrono::Utc::now().timestamp();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/transfer")
+        .header("x-aframp-timestamp", now.to_string())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = router.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "MISSING_NONCE");
+}
+
+/// Two concurrent requests with the same nonce — only one must succeed.
+/// This verifies the atomic SET NX prevents race conditions.
+#[tokio::test]
+#[ignore]
+async fn test_concurrent_duplicate_requests_only_one_accepted() {
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let pool = init_cache_pool(CacheConfig {
+        redis_url,
+        ..Default::default()
+    })
+    .await
+    .expect("Redis init failed");
+
+    let state = ReplayPreventionState {
+        redis: Arc::new(pool),
+        config: Arc::new(ReplayConfig::default()),
+    };
+
+    let router = Router::new()
+        .route("/transfer", post(|| async { "ok".into_response() }))
+        .layer(middleware::from_fn_with_state(
+            state,
+            replay_prevention_middleware,
+        ));
+
+    let now = chrono::Utc::now().timestamp();
+    let nonce = unique_nonce();
+    let consumer = format!("consumer-concurrent-{}", unique_nonce());
+
+    // Fire two requests concurrently with the same nonce
+    let (resp1, resp2) = tokio::join!(
+        router.clone().oneshot(signed_request(&nonce, now, &consumer)),
+        router.clone().oneshot(signed_request(&nonce, now, &consumer)),
+    );
+
+    let s1 = resp1.unwrap().status();
+    let s2 = resp2.unwrap().status();
+
+    // Exactly one must be 200, the other 401
+    let ok_count = [s1, s2]
+        .iter()
+        .filter(|&&s| s == StatusCode::OK)
+        .count();
+    let reject_count = [s1, s2]
+        .iter()
+        .filter(|&&s| s == StatusCode::UNAUTHORIZED)
+        .count();
+
+    assert_eq!(ok_count, 1, "exactly one concurrent request should succeed");
+    assert_eq!(reject_count, 1, "exactly one concurrent request should be rejected");
+}
+
+/// Different consumers may reuse the same nonce value without conflict.
+#[tokio::test]
+#[ignore]
+async fn test_same_nonce_different_consumers_both_accepted() {
+    let router = build_router(ReplayConfig::default()).await;
+    let now = chrono::Utc::now().timestamp();
+    let shared_nonce = unique_nonce();
+
+    let req_a = signed_request(&shared_nonce, now, "consumer-alpha");
+    let req_b = signed_request(&shared_nonce, now, "consumer-beta");
+
+    let resp_a = router.clone().oneshot(req_a).await.unwrap();
+    let resp_b = router.clone().oneshot(req_b).await.unwrap();
+
+    assert_eq!(resp_a.status(), StatusCode::OK, "consumer-alpha should be accepted");
+    assert_eq!(resp_b.status(), StatusCode::OK, "consumer-beta should be accepted with same nonce");
+}


### PR DESCRIPTION
## Summary

Implements comprehensive replay attack prevention for all signed API requests. HMAC signature verification alone doesn't prevent replay attacks — this closes that gap by combining strict timestamp validation with atomic server-side nonce tracking.

## Changes

### Middleware (`src/middleware/replay_prevention.rs`)
- Extracts `X-Aframp-Timestamp`, `X-Aframp-Nonce`, and `X-Aframp-Consumer` headers
- Rejects requests older than the configured window (`REPLAY_TIMESTAMP_WINDOW_SECS`, default 300s)
- Rejects requests too far in the future (`REPLAY_FUTURE_TOLERANCE_SECS`, default 30s)
- Atomic Redis `SET NX EX` nonce check-and-store — race-condition safe
- Fails closed on Redis error (503) to prevent bypass via cache outage
- Clock skew alerting when delta exceeds `REPLAY_CLOCK_SKEW_ALERT_SECS`
- Replay attempt alerting when a consumer exceeds `REPLAY_ATTEMPT_ALERT_THRESHOLD`

### Metrics (`src/metrics/mod.rs`)
- `aframp_security_replay_attempts_total` — labelled by `consumer_id` and `endpoint`
- `aframp_security_timestamp_rejections_total` — labelled by `consumer_id` and `reason`
- `aframp_security_timestamp_delta_seconds` — histogram of clock skew distribution

### Cache Keys (`src/cache/keys.rs`)
- `replay::NonceKey` — namespaced per consumer: `v1:nonce:<consumer_id>:<nonce>`

### Configuration (`src/middleware/replay_prevention.rs`)
- `ReplayConfig::from_env()` — all thresholds configurable via env vars, no recompile needed

### Router (`src/main.rs`)
- Middleware wired into the axum router when Redis is available

### Tests (`tests/replay_prevention_test.rs`)
- First request accepted
- Replay rejected on second submission (same nonce)
- Timestamp too old rejected
- Timestamp in future rejected
- Exact boundary condition accepted
- Missing header cases
- Concurrent duplicate requests — only one accepted (atomicity)
- Same nonce, different consumers — both accepted (namespace isolation)

### Docs (`docs/request-signing.md`)
- Consumer-facing signing guide with nonce format requirements
- Reference nonce generation in JavaScript, Python, and Rust

## Environment Variables

| Variable | Default | Description |
|---|---|---|
| `REPLAY_TIMESTAMP_WINDOW_SECS` | 300 | Max request age |
| `REPLAY_FUTURE_TOLERANCE_SECS` | 30 | Max future skew |
| `REPLAY_NONCE_TTL_BUFFER_SECS` | 60 | Extra Redis TTL buffer |
| `REPLAY_CLOCK_SKEW_ALERT_SECS` | 60 | Clock skew alert threshold |
| `REPLAY_ATTEMPT_ALERT_THRESHOLD` | 5 | Replay attempts before alerting |

## Testing

Unit tests run without Redis:

Closes #141