### PR TITLE
feat: extract pure helpers and add unit tests for cNGN conversion and  fee logic 

### DIFF
--- a/src/services/exchange_rate.rs
+++ b/src/services/exchange_rate.rs
@@ -211,17 +211,16 @@ impl ExchangeRateService {
             .await?;
 
         // Calculate gross amount
-        let gross_amount = &request.amount * &rate;
+        let gross_amount = compute_gross_amount(&request.amount, &rate);
 
         // Calculate fees
         let fees = self.calculate_fees(&request, &gross_amount).await?;
 
         // Calculate net amount (gross - fees)
-        let net_amount = &gross_amount - &fees.total_fees;
+        let net_amount = compute_net_amount(&gross_amount, &fees.total_fees);
 
         // Calculate expiry time
-        let expires_at =
-            Utc::now() + chrono::Duration::seconds(self.config.rate_expiry_seconds as i64);
+        let expires_at = build_quote_expiry(Utc::now(), self.config.rate_expiry_seconds);
 
         Ok(ConversionResult {
             from_currency: request.from_currency.clone(),
@@ -471,9 +470,34 @@ struct FeeCalculation {
     total_fees: BigDecimal,
 }
 
+fn compute_gross_amount(amount: &BigDecimal, rate: &BigDecimal) -> BigDecimal {
+    amount * rate
+}
+
+fn compute_net_amount(gross_amount: &BigDecimal, total_fees: &BigDecimal) -> BigDecimal {
+    gross_amount - total_fees
+}
+
+fn compute_required_gross_amount(
+    target_net_amount: &BigDecimal,
+    total_fees: &BigDecimal,
+) -> BigDecimal {
+    target_net_amount + total_fees
+}
+
+fn build_quote_expiry(now: DateTime<Utc>, rate_expiry_seconds: u64) -> DateTime<Utc> {
+    now + chrono::Duration::seconds(rate_expiry_seconds as i64)
+}
+
+fn is_quote_expired(expires_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    now >= expires_at
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::rate_providers::FixedRateProvider;
+    use chrono::TimeZone;
 
     #[test]
     fn test_conversion_direction() {
@@ -500,5 +524,105 @@ mod tests {
         // Negative rate
         let result = service.validate_rate("USD", "NGN", &BigDecimal::from(-1));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compute_gross_amount_for_standard_fiat_to_cngn_conversion() {
+        let gross_amount = compute_gross_amount(
+            &BigDecimal::from_str("50000").unwrap(),
+            &BigDecimal::from_str("1").unwrap(),
+        );
+
+        assert_eq!(gross_amount, BigDecimal::from_str("50000").unwrap());
+    }
+
+    #[test]
+    fn test_compute_gross_amount_for_cngn_to_fiat_conversion() {
+        let gross_amount = compute_gross_amount(
+            &BigDecimal::from_str("1250.50").unwrap(),
+            &BigDecimal::from_str("1").unwrap(),
+        );
+
+        assert_eq!(gross_amount, BigDecimal::from_str("1250.50").unwrap());
+    }
+
+    #[test]
+    fn test_fractional_conversion_preserves_bigdecimal_precision() {
+        let gross_amount = compute_gross_amount(
+            &BigDecimal::from_str("1000.125").unwrap(),
+            &BigDecimal::from_str("1.0001").unwrap(),
+        );
+
+        assert_eq!(gross_amount, BigDecimal::from_str("1000.2250125").unwrap());
+    }
+
+    #[test]
+    fn test_compute_net_amount_after_fees() {
+        let net_amount = compute_net_amount(
+            &BigDecimal::from_str("50000").unwrap(),
+            &BigDecimal::from_str("750").unwrap(),
+        );
+
+        assert_eq!(net_amount, BigDecimal::from_str("49250").unwrap());
+    }
+
+    #[test]
+    fn test_compute_required_gross_amount_for_target_net_cngn() {
+        let gross_amount = compute_required_gross_amount(
+            &BigDecimal::from_str("49250").unwrap(),
+            &BigDecimal::from_str("750").unwrap(),
+        );
+
+        assert_eq!(gross_amount, BigDecimal::from_str("50000").unwrap());
+    }
+
+    #[test]
+    fn test_build_quote_expiry_from_fixed_time() {
+        let now = Utc.with_ymd_and_hms(2026, 3, 25, 10, 0, 0).unwrap();
+        let expires_at = build_quote_expiry(now, 180);
+
+        assert_eq!(
+            expires_at,
+            Utc.with_ymd_and_hms(2026, 3, 25, 10, 3, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_quote_expiry_validation() {
+        let expires_at = Utc.with_ymd_and_hms(2026, 3, 25, 10, 3, 0).unwrap();
+
+        assert!(!is_quote_expired(
+            expires_at,
+            Utc.with_ymd_and_hms(2026, 3, 25, 10, 2, 59).unwrap()
+        ));
+        assert!(is_quote_expired(
+            expires_at,
+            Utc.with_ymd_and_hms(2026, 3, 25, 10, 3, 0).unwrap()
+        ));
+    }
+
+    #[test]
+    fn test_extremely_large_transaction_amount_conversion() {
+        let gross_amount = compute_gross_amount(
+            &BigDecimal::from_str("999999999999.99").unwrap(),
+            &BigDecimal::from_str("1").unwrap(),
+        );
+
+        assert_eq!(
+            gross_amount,
+            BigDecimal::from_str("999999999999.99").unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fixed_rate_provider_rejects_unsupported_currency_pair() {
+        let provider = FixedRateProvider::new();
+        let result = provider.fetch_rate("USD", "cNGN").await;
+
+        assert!(matches!(
+            result,
+            Err(ExchangeRateError::RateNotFound { ref from, ref to })
+            if from == "USD" && to == "cNGN"
+        ));
     }
 }

--- a/src/services/fee_calculation.rs
+++ b/src/services/fee_calculation.rs
@@ -475,15 +475,42 @@ impl FeeCalculationService {
 mod tests {
     use super::*;
 
+    fn test_service() -> FeeCalculationService {
+        let pool = PgPool::connect_lazy("postgresql://test").unwrap();
+        FeeCalculationService::new(pool)
+    }
+
+    fn test_fee_config(
+        provider_fee_percent: Option<&str>,
+        provider_fee_flat: Option<&str>,
+        provider_fee_cap: Option<&str>,
+        platform_fee_percent: Option<&str>,
+        min_amount: Option<&str>,
+        max_amount: Option<&str>,
+    ) -> FeeConfig {
+        FeeConfig {
+            id: Uuid::new_v4(),
+            transaction_type: "onramp".to_string(),
+            payment_provider: Some("flutterwave".to_string()),
+            payment_method: Some("card".to_string()),
+            min_amount: min_amount.map(|value| BigDecimal::from_str(value).unwrap()),
+            max_amount: max_amount.map(|value| BigDecimal::from_str(value).unwrap()),
+            provider_fee_percent: provider_fee_percent
+                .map(|value| BigDecimal::from_str(value).unwrap()),
+            provider_fee_flat: provider_fee_flat.map(|value| BigDecimal::from_str(value).unwrap()),
+            provider_fee_cap: provider_fee_cap.map(|value| BigDecimal::from_str(value).unwrap()),
+            platform_fee_percent: platform_fee_percent
+                .map(|value| BigDecimal::from_str(value).unwrap()),
+        }
+    }
+
     #[tokio::test]
     async fn test_amount_in_range() {
         let amount = BigDecimal::from_str("10000").unwrap();
         let min = Some(BigDecimal::from_str("1000").unwrap());
         let max = Some(BigDecimal::from_str("50000").unwrap());
 
-        // Create a mock service just for testing the method
-        let pool = PgPool::connect_lazy("postgresql://test").unwrap();
-        let service = FeeCalculationService::new(pool);
+        let service = test_service();
 
         assert!(service.amount_in_range(&amount, &min, &max));
     }
@@ -517,5 +544,163 @@ mod tests {
 
         let json = serde_json::to_string(&breakdown).unwrap();
         assert!(json.contains("flutterwave"));
+    }
+
+    #[tokio::test]
+    async fn test_amount_in_range_includes_minimum_and_maximum_boundaries() {
+        let service = test_service();
+        let min = Some(BigDecimal::from_str("1000").unwrap());
+        let max = Some(BigDecimal::from_str("50000").unwrap());
+
+        assert!(service.amount_in_range(&BigDecimal::from(1000), &min, &max));
+        assert!(service.amount_in_range(&BigDecimal::from(50000), &min, &max));
+        assert!(!service.amount_in_range(&BigDecimal::from(999), &min, &max));
+        assert!(!service.amount_in_range(&BigDecimal::from(50001), &min, &max));
+    }
+
+    #[tokio::test]
+    async fn test_calculate_provider_fee_applies_tiered_percent_flat_and_cap() {
+        let service = test_service();
+        let config = test_fee_config(
+            Some("1.4"),
+            Some("100"),
+            Some("2000"),
+            Some("0.5"),
+            Some("1000"),
+            Some("50000"),
+        );
+
+        let fee = service
+            .calculate_provider_fee(
+                &BigDecimal::from_str("1000000").unwrap(),
+                &config,
+                Some("flutterwave"),
+                Some("card"),
+            )
+            .unwrap();
+
+        assert_eq!(fee.name, "flutterwave");
+        assert_eq!(fee.method, "card");
+        assert_eq!(fee.percent, BigDecimal::from_str("1.4").unwrap());
+        assert_eq!(fee.flat, BigDecimal::from_str("100").unwrap());
+        assert_eq!(fee.cap, Some(BigDecimal::from_str("2000").unwrap()));
+        assert_eq!(fee.calculated, BigDecimal::from_str("2000").unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_calculate_provider_fee_supports_provider_specific_inputs() {
+        let service = test_service();
+        let config = test_fee_config(
+            Some("1.5"),
+            Some("0"),
+            Some("2000"),
+            Some("0.5"),
+            Some("1000"),
+            Some("50000"),
+        );
+
+        let fee = service
+            .calculate_provider_fee(
+                &BigDecimal::from_str("10000").unwrap(),
+                &config,
+                Some("paystack"),
+                Some("bank_transfer"),
+            )
+            .unwrap();
+
+        assert_eq!(fee.name, "paystack");
+        assert_eq!(fee.method, "bank_transfer");
+        assert_eq!(fee.calculated, BigDecimal::from_str("150").unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_calculate_platform_fee_handles_cngn_transaction_fee_percentage() {
+        let service = test_service();
+        let config = test_fee_config(None, None, None, Some("0.3"), None, None);
+
+        let fee = service.calculate_platform_fee(&BigDecimal::from_str("100000").unwrap(), &config);
+
+        assert_eq!(fee.percent, BigDecimal::from_str("0.3").unwrap());
+        assert_eq!(fee.calculated, BigDecimal::from_str("300").unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_calculate_platform_fee_returns_zero_for_zero_fee_configuration() {
+        let service = test_service();
+        let config = test_fee_config(None, None, None, None, None, None);
+
+        let fee = service.calculate_platform_fee(&BigDecimal::from_str("100000").unwrap(), &config);
+
+        assert_eq!(fee.percent, BigDecimal::from(0));
+        assert_eq!(fee.calculated, BigDecimal::from(0));
+    }
+
+    #[tokio::test]
+    async fn test_calculate_provider_fee_returns_none_when_provider_fee_not_configured() {
+        let service = test_service();
+        let config = test_fee_config(None, None, None, Some("0.5"), None, None);
+
+        let fee = service.calculate_provider_fee(
+            &BigDecimal::from_str("10000").unwrap(),
+            &config,
+            Some("flutterwave"),
+            Some("card"),
+        );
+
+        assert!(fee.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_calculate_provider_fee_preserves_small_decimal_precision() {
+        let service = test_service();
+        let config = test_fee_config(Some("1.4"), Some("0"), None, Some("0"), None, None);
+
+        let fee = service
+            .calculate_provider_fee(
+                &BigDecimal::from_str("1000.125").unwrap(),
+                &config,
+                Some("flutterwave"),
+                Some("card"),
+            )
+            .unwrap();
+
+        assert_eq!(fee.calculated, BigDecimal::from_str("14.00175").unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_calculate_provider_fee_handles_extremely_large_amounts() {
+        let service = test_service();
+        let config = test_fee_config(Some("1.4"), Some("0"), Some("2000"), Some("0"), None, None);
+
+        let fee = service
+            .calculate_provider_fee(
+                &BigDecimal::from_str("999999999999.99").unwrap(),
+                &config,
+                Some("flutterwave"),
+                Some("card"),
+            )
+            .unwrap();
+
+        assert_eq!(fee.calculated, BigDecimal::from_str("2000").unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_calculate_stellar_fee_is_absorbed_and_deterministic() {
+        let service = test_service();
+        let stellar_fee = service.calculate_stellar_fee().await;
+
+        assert_eq!(stellar_fee.xlm, BigDecimal::from_str("0.00001").unwrap());
+        assert_eq!(stellar_fee.ngn, BigDecimal::from(0));
+        assert!(stellar_fee.absorbed);
+    }
+
+    #[tokio::test]
+    async fn test_get_xlm_rate_returns_cached_default_rate() {
+        let service = test_service();
+        let first = service.get_xlm_rate().await.unwrap();
+        let second = service.get_xlm_rate().await.unwrap();
+
+        assert_eq!(first, BigDecimal::from_str("150").unwrap());
+        assert_eq!(second, first);
     }
 }

--- a/src/services/fee_structure.rs
+++ b/src/services/fee_structure.rs
@@ -97,3 +97,34 @@ fn calculate_rate_fee(amount: &BigDecimal, fee_rate_bps: i32) -> BigDecimal {
 pub fn parse_amount(amount: &str) -> BigDecimal {
     BigDecimal::from_str(amount).unwrap_or_else(|_| BigDecimal::from(0))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_rate_fee_for_standard_amount() {
+        let fee = calculate_rate_fee(&BigDecimal::from_str("50000").unwrap(), 140);
+
+        assert_eq!(fee, BigDecimal::from_str("700.00").unwrap());
+    }
+
+    #[test]
+    fn test_calculate_rate_fee_for_zero_bps_returns_zero() {
+        let fee = calculate_rate_fee(&BigDecimal::from_str("50000").unwrap(), 0);
+
+        assert_eq!(fee, BigDecimal::from(0));
+    }
+
+    #[test]
+    fn test_calculate_rate_fee_preserves_fractional_precision() {
+        let fee = calculate_rate_fee(&BigDecimal::from_str("1000.125").unwrap(), 10);
+
+        assert_eq!(fee, BigDecimal::from_str("1.000125").unwrap());
+    }
+
+    #[test]
+    fn test_parse_amount_returns_zero_for_invalid_input() {
+        assert_eq!(parse_amount("not-a-number"), BigDecimal::from(0));
+    }
+}

--- a/src/services/onramp_quote.rs
+++ b/src/services/onramp_quote.rs
@@ -91,6 +91,46 @@ fn decimal_to_i64_trunc(value: &BigDecimal) -> i64 {
         .unwrap_or(0)
 }
 
+fn build_quote_expiry(now: chrono::DateTime<Utc>) -> chrono::DateTime<Utc> {
+    now + chrono::Duration::seconds(QUOTE_TTL_SECS as i64)
+}
+
+fn is_quote_expired(expires_at: chrono::DateTime<Utc>, now: chrono::DateTime<Utc>) -> bool {
+    now >= expires_at
+}
+
+fn derive_quote_amounts(
+    amount_ngn: &BigDecimal,
+    platform_fee_ngn: &BigDecimal,
+    provider_fee_ngn: &BigDecimal,
+    conversion_net_amount: Option<&str>,
+) -> Result<(BigDecimal, BigDecimal), AppError> {
+    let total_fee_ngn = platform_fee_ngn + provider_fee_ngn;
+    let amount_ngn_after_fees = amount_ngn - &total_fee_ngn;
+
+    if amount_ngn_after_fees <= BigDecimal::from(0) {
+        return Err(AppError::new(AppErrorKind::Domain(
+            DomainError::InvalidAmount {
+                amount: amount_ngn.to_string(),
+                reason: "Amount after fees must be greater than zero".to_string(),
+            },
+        )));
+    }
+
+    let amount_cngn = conversion_net_amount
+        .and_then(|value| BigDecimal::from_str(value).ok())
+        .filter(|value| value > &BigDecimal::from(0))
+        .unwrap_or_else(|| amount_ngn_after_fees.clone());
+
+    Ok((amount_ngn_after_fees, amount_cngn))
+}
+
+fn split_fallback_onramp_fee(total_fee: &BigDecimal) -> (BigDecimal, BigDecimal) {
+    let platform_fee = total_fee * BigDecimal::from_str("0.2").unwrap();
+    let provider_fee = total_fee - &platform_fee;
+    (platform_fee, provider_fee)
+}
+
 /// API request for onramp quote
 #[derive(Debug, Clone, Deserialize)]
 pub struct OnrampQuoteRequest {
@@ -267,21 +307,12 @@ impl OnrampQuoteService {
             };
 
         let total_fee_ngn = &platform_fee_ngn + &provider_fee_ngn;
-        let amount_ngn_after_fees = &amount_bd - &total_fee_ngn;
-        if amount_ngn_after_fees <= BigDecimal::from(0) {
-            return Err(AppError::new(AppErrorKind::Domain(
-                DomainError::InvalidAmount {
-                    amount: request.amount_ngn.to_string(),
-                    reason: "Amount after fees must be greater than zero".to_string(),
-                },
-            )));
-        }
-
-        // Use conversion net amount when available; fall back to NGN-after-fees for peg scenarios.
-        let amount_cngn_bd = BigDecimal::from_str(&conversion.net_amount)
-            .ok()
-            .filter(|v| v > &BigDecimal::from(0))
-            .unwrap_or_else(|| amount_ngn_after_fees.clone());
+        let (amount_ngn_after_fees, amount_cngn_bd) = derive_quote_amounts(
+            &amount_bd,
+            &platform_fee_ngn,
+            &provider_fee_ngn,
+            Some(&conversion.net_amount),
+        )?;
         let rate =
             BigDecimal::from_str(&conversion.base_rate).unwrap_or_else(|_| BigDecimal::from(1));
 
@@ -311,7 +342,7 @@ impl OnrampQuoteService {
 
         // 6. Generate quote_id and persist to Redis
         let quote_id = format!("q_{}", Uuid::new_v4().simple());
-        let expires_at = Utc::now() + chrono::Duration::seconds(QUOTE_TTL_SECS as i64);
+        let expires_at = build_quote_expiry(Utc::now());
 
         let stored = StoredQuote {
             quote_id: quote_id.clone(),
@@ -440,9 +471,7 @@ impl OnrampQuoteService {
                 })?;
 
             let total_fee = total.map(|r| r.fee).unwrap_or_else(|| BigDecimal::from(0));
-            let platform = &total_fee * BigDecimal::from_str("0.2").unwrap();
-            let provider = &total_fee - &platform;
-            return Ok((platform, provider));
+            return Ok(split_fallback_onramp_fee(&total_fee));
         }
 
         Ok((platform_fee_bd, provider_fee_bd))
@@ -491,6 +520,7 @@ impl OnrampQuoteService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     #[test]
     fn test_min_onramp_amount() {
@@ -534,5 +564,91 @@ mod tests {
             chain: Some("stellar".to_string()),
         };
         assert!(request.amount_ngn >= MIN_ONRAMP_AMOUNT_NGN);
+    }
+
+    #[test]
+    fn test_decimal_to_i64_trunc_drops_fractional_component() {
+        assert_eq!(
+            decimal_to_i64_trunc(&BigDecimal::from_str("49250.99").unwrap()),
+            49250
+        );
+    }
+
+    #[test]
+    fn test_derive_quote_amounts_uses_conversion_net_amount_when_present() {
+        let (amount_ngn_after_fees, amount_cngn) = derive_quote_amounts(
+            &BigDecimal::from(50000),
+            &BigDecimal::from(50),
+            &BigDecimal::from(700),
+            Some("49250"),
+        )
+        .unwrap();
+
+        assert_eq!(amount_ngn_after_fees, BigDecimal::from(49250));
+        assert_eq!(amount_cngn, BigDecimal::from(49250));
+    }
+
+    #[test]
+    fn test_derive_quote_amounts_falls_back_to_net_ngn_for_zero_conversion_net() {
+        let (amount_ngn_after_fees, amount_cngn) = derive_quote_amounts(
+            &BigDecimal::from(50000),
+            &BigDecimal::from(50),
+            &BigDecimal::from(700),
+            Some("0"),
+        )
+        .unwrap();
+
+        assert_eq!(amount_ngn_after_fees, BigDecimal::from(49250));
+        assert_eq!(amount_cngn, BigDecimal::from(49250));
+    }
+
+    #[test]
+    fn test_derive_quote_amounts_rejects_amount_when_fees_consume_all_value() {
+        let result = derive_quote_amounts(
+            &BigDecimal::from(1000),
+            &BigDecimal::from(400),
+            &BigDecimal::from(600),
+            None,
+        );
+
+        assert!(matches!(
+            result,
+            Err(AppError {
+                kind: AppErrorKind::Domain(DomainError::InvalidAmount { .. }),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_split_fallback_onramp_fee_preserves_total_amount() {
+        let (platform_fee, provider_fee) =
+            split_fallback_onramp_fee(&BigDecimal::from_str("750").unwrap());
+
+        assert_eq!(platform_fee, BigDecimal::from_str("150").unwrap());
+        assert_eq!(provider_fee, BigDecimal::from_str("600").unwrap());
+        assert_eq!(
+            platform_fee + provider_fee,
+            BigDecimal::from_str("750").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_quote_expiry_helpers_are_deterministic() {
+        let now = Utc.with_ymd_and_hms(2026, 3, 25, 10, 0, 0).unwrap();
+        let expires_at = build_quote_expiry(now);
+
+        assert_eq!(
+            expires_at,
+            Utc.with_ymd_and_hms(2026, 3, 25, 10, 3, 0).unwrap()
+        );
+        assert!(!is_quote_expired(
+            expires_at,
+            Utc.with_ymd_and_hms(2026, 3, 25, 10, 2, 59).unwrap()
+        ));
+        assert!(is_quote_expired(
+            expires_at,
+            Utc.with_ymd_and_hms(2026, 3, 25, 10, 3, 0).unwrap()
+        ));
     }
 }


### PR DESCRIPTION
Closes #96

---




- Extract build_quote_expiry, is_quote_expired, derive_quote_amounts, split_fallback_onramp_fee as testable free functions in onramp_quote.rs
- Add unit tests for quote amount derivation, expiry generation/validation, fee split fallback, and below-minimum rejection
- Add unit tests for FeeCalculationService: tiered provider fee, platform fee, fee cap enforcement, zero-fee config, precision, large amounts, stellar fee
- Add unit tests for fee_structure calculate_rate_fee: standard bps, zero bps, fractional precision, invalid parse_amount input
- Add unit tests for exchange_rate pure helpers: gross/net amount computation, required gross derivation, quote expiry, large amounts, unsupported pair