### PR TITLE
feat: implement developer portal

### DIFF
--- a/migrations/20261201000000_developer_portal_schema.sql
+++ b/migrations/20261201000000_developer_portal_schema.sql
@@ -1,0 +1,349 @@
+-- migrate:up
+-- Developer Portal Schema
+-- Creates tables for developer accounts, applications, credentials, and access management
+
+-- Developer account status lookup table
+CREATE TABLE developer_account_statuses (
+    code TEXT PRIMARY KEY,
+    description TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE developer_account_statuses IS 'Lookup table for developer account statuses';
+COMMENT ON COLUMN developer_account_statuses.code IS 'Machine-readable status code';
+COMMENT ON COLUMN developer_account_statuses.description IS 'Human-readable status description';
+
+INSERT INTO developer_account_statuses (code, description) VALUES
+    ('unverified', 'Account created but email not verified'),
+    ('verified', 'Email verified, sandbox access granted'),
+    ('identity_pending', 'Identity verification submitted'),
+    ('identity_verified', 'Identity verification completed'),
+    ('identity_rejected', 'Identity verification rejected'),
+    ('suspended', 'Account suspended by admin'),
+    ('active', 'Account fully active with production access');
+
+-- Access tier lookup table
+CREATE TABLE access_tiers (
+    code TEXT PRIMARY KEY,
+    description TEXT NOT NULL,
+    max_applications INTEGER NOT NULL DEFAULT 5,
+    rate_limit_per_minute INTEGER NOT NULL DEFAULT 100,
+    requires_identity_verification BOOLEAN NOT NULL DEFAULT FALSE,
+    requires_business_agreement BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE access_tiers IS 'Access tiers with different privileges and limits';
+COMMENT ON COLUMN access_tiers.code IS 'Machine-readable tier code';
+COMMENT ON COLUMN access_tiers.description IS 'Human-readable tier description';
+COMMENT ON COLUMN access_tiers.max_applications IS 'Maximum number of applications per developer';
+COMMENT ON COLUMN access_tiers.rate_limit_per_minute IS 'API rate limit per minute';
+COMMENT ON COLUMN access_tiers.requires_identity_verification IS 'Whether identity verification is required';
+COMMENT ON COLUMN access_tiers.requires_business_agreement IS 'Whether business agreement is required';
+
+INSERT INTO access_tiers (code, description, max_applications, rate_limit_per_minute, requires_identity_verification, requires_business_agreement) VALUES
+    ('sandbox', 'Sandbox tier - testnet access only', 3, 50, FALSE, FALSE),
+    ('standard', 'Standard tier - mainnet access with standard limits', 10, 1000, TRUE, FALSE),
+    ('partner', 'Partner tier - mainnet access with elevated limits', 50, 10000, TRUE, TRUE);
+
+-- Developer accounts table
+CREATE TABLE developer_accounts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT NOT NULL UNIQUE,
+    full_name TEXT NOT NULL,
+    organisation TEXT,
+    country TEXT NOT NULL,
+    use_case_description TEXT NOT NULL,
+    status_code TEXT NOT NULL DEFAULT 'unverified' REFERENCES developer_account_statuses(code),
+    access_tier_code TEXT NOT NULL DEFAULT 'sandbox' REFERENCES access_tiers(code),
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    email_verification_token TEXT UNIQUE,
+    email_verification_expires_at TIMESTAMPTZ,
+    identity_verification_status TEXT DEFAULT 'unverified' CHECK (identity_verification_status IN ('unverified', 'pending', 'verified', 'rejected')),
+    identity_verification_data JSONB DEFAULT '{}'::jsonb,
+    identity_verified_at TIMESTAMPTZ,
+    suspended_at TIMESTAMPTZ,
+    suspension_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE developer_accounts IS 'Developer accounts for API access';
+COMMENT ON COLUMN developer_accounts.email IS 'Primary email address for the developer';
+COMMENT ON COLUMN developer_accounts.full_name IS 'Full legal name of the developer';
+COMMENT ON COLUMN developer_accounts.organisation IS 'Optional organisation name';
+COMMENT ON COLUMN developer_accounts.country IS 'Country code (ISO 3166-1 alpha-2)';
+COMMENT ON COLUMN developer_accounts.use_case_description IS 'Description of intended API usage';
+COMMENT ON COLUMN developer_accounts.status_code IS 'Current account status';
+COMMENT ON COLUMN developer_accounts.access_tier_code IS 'Current access tier';
+COMMENT ON COLUMN developer_accounts.email_verified IS 'Whether email has been verified';
+COMMENT ON COLUMN developer_accounts.email_verification_token IS 'Token for email verification';
+COMMENT ON COLUMN developer_accounts.email_verification_expires_at IS 'Expiry time for email verification token';
+COMMENT ON COLUMN developer_accounts.identity_verification_status IS 'Status of identity verification';
+COMMENT ON COLUMN developer_accounts.identity_verification_data IS 'Identity verification documents and data';
+COMMENT ON COLUMN developer_accounts.identity_verified_at IS 'Timestamp when identity was verified';
+COMMENT ON COLUMN developer_accounts.suspended_at IS 'Timestamp when account was suspended';
+COMMENT ON COLUMN developer_accounts.suspension_reason IS 'Reason for suspension';
+
+-- Developer applications table
+CREATE TABLE developer_applications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    developer_account_id UUID NOT NULL REFERENCES developer_accounts(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    intended_use_case TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'inactive', 'deleted')),
+    sandbox_wallet_address VARCHAR(255),
+    sandbox_wallet_secret TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE developer_applications IS 'Applications registered by developers';
+COMMENT ON COLUMN developer_applications.developer_account_id IS 'Reference to developer account';
+COMMENT ON COLUMN developer_applications.name IS 'Application name';
+COMMENT ON COLUMN developer_applications.description IS 'Application description';
+COMMENT ON COLUMN developer_applications.intended_use_case IS 'Intended use case for this application';
+COMMENT ON COLUMN developer_applications.status IS 'Application status';
+COMMENT ON COLUMN developer_applications.sandbox_wallet_address IS 'Testnet wallet address for sandbox';
+COMMENT ON COLUMN developer_applications.sandbox_wallet_secret IS 'Testnet wallet secret for sandbox';
+
+-- API keys table
+CREATE TABLE api_keys (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    application_id UUID NOT NULL REFERENCES developer_applications(id) ON DELETE CASCADE,
+    key_prefix TEXT NOT NULL,
+    key_hash TEXT NOT NULL,
+    key_name TEXT NOT NULL,
+    environment TEXT NOT NULL DEFAULT 'sandbox' CHECK (environment IN ('sandbox', 'production')),
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked', 'expired')),
+    expires_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    usage_count INTEGER NOT NULL DEFAULT 0,
+    rate_limit_per_minute INTEGER NOT NULL DEFAULT 100,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (key_prefix, key_hash)
+);
+
+COMMENT ON TABLE api_keys IS 'API keys for developer applications';
+COMMENT ON COLUMN api_keys.application_id IS 'Reference to application';
+COMMENT ON COLUMN api_keys.key_prefix IS 'Public prefix of the API key';
+COMMENT ON COLUMN api_keys.key_hash IS 'Hashed version of the full API key';
+COMMENT ON COLUMN api_keys.key_name IS 'Human-readable name for the key';
+COMMENT ON COLUMN api_keys.environment IS 'Environment (sandbox or production)';
+COMMENT ON COLUMN api_keys.status IS 'Key status';
+COMMENT ON COLUMN api_keys.expires_at IS 'Key expiry time';
+COMMENT ON COLUMN api_keys.last_used_at IS 'Timestamp of last usage';
+COMMENT ON COLUMN api_keys.usage_count IS 'Total usage count';
+COMMENT ON COLUMN api_keys.rate_limit_per_minute IS 'Rate limit per minute for this key';
+
+-- OAuth clients table
+CREATE TABLE oauth_clients (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    application_id UUID NOT NULL REFERENCES developer_applications(id) ON DELETE CASCADE,
+    client_id TEXT NOT NULL UNIQUE,
+    client_secret_hash TEXT NOT NULL,
+    client_name TEXT NOT NULL,
+    environment TEXT NOT NULL DEFAULT 'sandbox' CHECK (environment IN ('sandbox', 'production')),
+    redirect_uris TEXT[] NOT NULL DEFAULT '{}',
+    scopes TEXT[] NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked', 'expired')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE oauth_clients IS 'OAuth clients for developer applications';
+COMMENT ON COLUMN oauth_clients.application_id IS 'Reference to application';
+COMMENT ON COLUMN oauth_clients.client_id IS 'OAuth client ID';
+COMMENT ON COLUMN oauth_clients.client_secret_hash IS 'Hashed client secret';
+COMMENT ON COLUMN oauth_clients.client_name IS 'Human-readable client name';
+COMMENT ON COLUMN oauth_clients.environment IS 'Environment (sandbox or production)';
+COMMENT ON COLUMN oauth_clients.redirect_uris IS 'Allowed redirect URIs';
+COMMENT ON COLUMN oauth_clients.scopes IS 'Granted scopes';
+COMMENT ON COLUMN oauth_clients.status IS 'Client status';
+
+-- Webhook configurations table
+CREATE TABLE webhook_configurations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    application_id UUID NOT NULL REFERENCES developer_applications(id) ON DELETE CASCADE,
+    webhook_url TEXT NOT NULL,
+    secret_token TEXT,
+    events TEXT[] NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'inactive', 'deleted')),
+    delivery_success_rate NUMERIC(5,2) DEFAULT 0.00,
+    average_delivery_latency INTEGER DEFAULT 0, -- in milliseconds
+    failed_delivery_count INTEGER DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE webhook_configurations IS 'Webhook configurations for applications';
+COMMENT ON COLUMN webhook_configurations.application_id IS 'Reference to application';
+COMMENT ON COLUMN webhook_configurations.webhook_url IS 'Webhook endpoint URL';
+COMMENT ON COLUMN webhook_configurations.secret_token IS 'Secret for webhook signature verification';
+COMMENT ON COLUMN webhook_configurations.events IS 'Events to trigger webhooks';
+COMMENT ON COLUMN webhook_configurations.status IS 'Webhook status';
+COMMENT ON COLUMN webhook_configurations.delivery_success_rate IS 'Success rate percentage';
+COMMENT ON COLUMN webhook_configurations.average_delivery_latency IS 'Average delivery latency in ms';
+COMMENT ON COLUMN webhook_configurations.failed_delivery_count IS 'Count of failed deliveries';
+
+-- Production access requests table
+CREATE TABLE production_access_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    application_id UUID NOT NULL REFERENCES developer_applications(id) ON DELETE CASCADE,
+    developer_account_id UUID NOT NULL REFERENCES developer_accounts(id) ON DELETE CASCADE,
+    production_use_case TEXT NOT NULL,
+    expected_transaction_volume TEXT NOT NULL,
+    supported_countries TEXT[] NOT NULL DEFAULT '{}',
+    business_details JSONB DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected')),
+    reviewed_by_admin_id UUID,
+    review_notes TEXT,
+    reviewed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE production_access_requests IS 'Production access requests for applications';
+COMMENT ON COLUMN production_access_requests.application_id IS 'Reference to application';
+COMMENT ON COLUMN production_access_requests.developer_account_id IS 'Reference to developer account';
+COMMENT ON COLUMN production_access_requests.production_use_case IS 'Detailed production use case';
+COMMENT ON COLUMN production_access_requests.expected_transaction_volume TEXT IS 'Expected monthly transaction volume';
+COMMENT ON COLUMN production_access_requests.supported_countries IS 'List of supported countries';
+COMMENT ON COLUMN production_access_requests.business_details IS 'Additional business information';
+COMMENT ON COLUMN production_access_requests.status IS 'Request status';
+COMMENT ON COLUMN production_access_requests.reviewed_by_admin_id IS 'Admin who reviewed the request';
+COMMENT ON COLUMN production_access_requests.review_notes IS 'Admin review notes';
+COMMENT ON COLUMN production_access_requests.reviewed_at IS 'Timestamp of review';
+
+-- Usage statistics table
+CREATE TABLE usage_statistics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    application_id UUID NOT NULL REFERENCES developer_applications(id) ON DELETE CASCADE,
+    api_key_id UUID REFERENCES api_keys(id) ON DELETE SET NULL,
+    endpoint TEXT NOT NULL,
+    method TEXT NOT NULL,
+    status_code INTEGER NOT NULL,
+    response_time_ms INTEGER,
+    request_size_bytes INTEGER,
+    response_size_bytes INTEGER,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+    environment TEXT NOT NULL DEFAULT 'sandbox' CHECK (environment IN ('sandbox', 'production'))
+);
+
+COMMENT ON TABLE usage_statistics IS 'API usage statistics for monitoring and analytics';
+COMMENT ON COLUMN usage_statistics.application_id IS 'Reference to application';
+COMMENT ON COLUMN usage_statistics.api_key_id IS 'Reference to API key used';
+COMMENT ON COLUMN usage_statistics.endpoint IS 'API endpoint called';
+COMMENT ON COLUMN usage_statistics.method IS 'HTTP method used';
+COMMENT ON COLUMN usage_statistics.status_code IS 'HTTP response status code';
+COMMENT ON COLUMN usage_statistics.response_time_ms IS 'Response time in milliseconds';
+COMMENT ON COLUMN usage_statistics.request_size_bytes IS 'Request size in bytes';
+COMMENT ON COLUMN usage_statistics.response_size_bytes IS 'Response size in bytes';
+COMMENT ON COLUMN usage_statistics.timestamp IS 'Timestamp of the request';
+COMMENT ON COLUMN usage_statistics.environment IS 'Environment (sandbox or production)';
+
+-- Webhook delivery logs table
+CREATE TABLE webhook_delivery_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_configuration_id UUID NOT NULL REFERENCES webhook_configurations(id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    delivery_url TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'delivered', 'failed', 'retrying')),
+    http_status_code INTEGER,
+    response_body TEXT,
+    delivery_attempts INTEGER NOT NULL DEFAULT 1,
+    next_retry_at TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE webhook_delivery_logs IS 'Logs for webhook delivery attempts';
+COMMENT ON COLUMN webhook_delivery_logs.webhook_configuration_id IS 'Reference to webhook configuration';
+COMMENT ON COLUMN webhook_delivery_logs.event_type IS 'Type of event being delivered';
+COMMENT ON COLUMN webhook_delivery_logs.payload IS 'Event payload';
+COMMENT ON COLUMN webhook_delivery_logs.delivery_url IS 'URL where webhook was delivered';
+COMMENT ON COLUMN webhook_delivery_logs.status IS 'Delivery status';
+COMMENT ON COLUMN webhook_delivery_logs.http_status_code IS 'HTTP status code from webhook endpoint';
+COMMENT ON COLUMN webhook_delivery_logs.response_body IS 'Response body from webhook endpoint';
+COMMENT ON COLUMN webhook_delivery_logs.delivery_attempts IS 'Number of delivery attempts';
+COMMENT ON COLUMN webhook_delivery_logs.next_retry_at IS 'Timestamp for next retry attempt';
+COMMENT ON COLUMN webhook_delivery_logs.delivered_at IS 'Timestamp when webhook was delivered';
+COMMENT ON COLUMN webhook_delivery_logs.error_message IS 'Error message if delivery failed';
+
+-- Triggers for updated_at
+CREATE TRIGGER set_updated_at_developer_account_statuses
+    BEFORE UPDATE ON developer_account_statuses
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_access_tiers
+    BEFORE UPDATE ON access_tiers
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_developer_accounts
+    BEFORE UPDATE ON developer_accounts
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_developer_applications
+    BEFORE UPDATE ON developer_applications
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_api_keys
+    BEFORE UPDATE ON api_keys
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_oauth_clients
+    BEFORE UPDATE ON oauth_clients
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_webhook_configurations
+    BEFORE UPDATE ON webhook_configurations
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_production_access_requests
+    BEFORE UPDATE ON production_access_requests
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_webhook_delivery_logs
+    BEFORE UPDATE ON webhook_delivery_logs
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Indexes for performance
+CREATE INDEX idx_developer_accounts_email ON developer_accounts(email);
+CREATE INDEX idx_developer_accounts_status ON developer_accounts(status_code);
+CREATE INDEX idx_developer_accounts_tier ON developer_accounts(access_tier_code);
+CREATE INDEX idx_developer_applications_developer_id ON developer_applications(developer_account_id);
+CREATE INDEX idx_developer_applications_status ON developer_applications(status);
+CREATE INDEX idx_api_keys_application_id ON api_keys(application_id);
+CREATE INDEX idx_api_keys_environment ON api_keys(environment);
+CREATE INDEX idx_api_keys_status ON api_keys(status);
+CREATE INDEX idx_oauth_clients_application_id ON oauth_clients(application_id);
+CREATE INDEX idx_oauth_clients_environment ON oauth_clients(environment);
+CREATE INDEX idx_webhook_configurations_application_id ON webhook_configurations(application_id);
+CREATE INDEX idx_production_access_requests_application_id ON production_access_requests(application_id);
+CREATE INDEX idx_production_access_requests_status ON production_access_requests(status);
+CREATE INDEX idx_usage_statistics_application_id ON usage_statistics(application_id);
+CREATE INDEX idx_usage_statistics_timestamp ON usage_statistics(timestamp);
+CREATE INDEX idx_usage_statistics_environment ON usage_statistics(environment);
+CREATE INDEX idx_webhook_delivery_logs_webhook_id ON webhook_delivery_logs(webhook_configuration_id);
+CREATE INDEX idx_webhook_delivery_logs_status ON webhook_delivery_logs(status);
+CREATE INDEX idx_webhook_delivery_logs_next_retry ON webhook_delivery_logs(next_retry_at) WHERE status = 'retrying';
+
+-- migrate:down
+-- Drop all developer portal tables and indexes
+DROP TABLE IF EXISTS webhook_delivery_logs;
+DROP TABLE IF EXISTS usage_statistics;
+DROP TABLE IF EXISTS production_access_requests;
+DROP TABLE IF EXISTS webhook_configurations;
+DROP TABLE IF EXISTS oauth_clients;
+DROP TABLE IF EXISTS api_keys;
+DROP TABLE IF EXISTS developer_applications;
+DROP TABLE IF EXISTS developer_accounts;
+DROP TABLE IF EXISTS access_tiers;
+DROP TABLE IF EXISTS developer_account_statuses;

--- a/src/developer_portal/admin_handlers.rs
+++ b/src/developer_portal/admin_handlers.rs
@@ -1,0 +1,387 @@
+use super::models::*;
+use super::services::DeveloperService;
+use super::production_access::ProductionAccessService;
+use crate::auth::middleware::AuthenticatedAdmin;
+use crate::error::AppError;
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::Json,
+    routing::{get, post},
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+use utoipa::path;
+use utoipa::ToSchema;
+
+/// Shared state tuple injected into admin routes:
+/// (DeveloperService, ProductionAccessService)
+pub type AdminPortalState = (Arc<DeveloperService>, Arc<ProductionAccessService>);
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/admin/developer-portal/accounts",
+    tag = "admin-developer-portal",
+    summary = "List developer accounts",
+    description = "Get paginated list of all developer accounts",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("page" = Option<i64>, Query, description = "Page number (default: 1)"),
+        ("per_page" = Option<i64>, Query, description = "Items per page (default: 20)")
+    ),
+    responses(
+        (status = 200, description = "Developer accounts retrieved", body = AdminDeveloperAccountList),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
+pub async fn list_developer_accounts(
+    State((service, _)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Query(params): Query<PaginationParams>,
+) -> Result<Json<AdminDeveloperAccountList>, AppError> {
+    let page = params.page.unwrap_or(1);
+    let per_page = params.per_page.unwrap_or(20).min(100);
+
+    let accounts = service
+        .list_developer_accounts_for_admin(page, per_page)
+        .await?;
+    
+    Ok(Json(accounts))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/admin/developer-portal/accounts/{account_id}",
+    tag = "admin-developer-portal",
+    summary = "Get developer account details",
+    description = "Get full details of a specific developer account",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("account_id" = Uuid, Path, description = "Developer account ID")
+    ),
+    responses(
+        (status = 200, description = "Account details retrieved", body = DeveloperAccount),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn get_developer_account_details(
+    State((service, _)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(account_id): Path<Uuid>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service.get_developer_account(account_id).await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/admin/developer-portal/accounts/{account_id}/suspend",
+    tag = "admin-developer-portal",
+    summary = "Suspend developer account",
+    description = "Suspend a developer account and revoke all credentials",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("account_id" = Uuid, Path, description = "Developer account ID")
+    ),
+    request_body = SuspendAccountRequest,
+    responses(
+        (status = 200, description = "Account suspended successfully", body = DeveloperAccount),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn suspend_developer_account(
+    State((service, _)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(account_id): Path<Uuid>,
+    Json(request): Json<SuspendAccountRequest>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service.suspend_account(account_id, &request.reason).await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/admin/developer-portal/accounts/{account_id}/reinstate",
+    tag = "admin-developer-portal",
+    summary = "Reinstate developer account",
+    description = "Reinstate a suspended developer account",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("account_id" = Uuid, Path, description = "Developer account ID")
+    ),
+    responses(
+        (status = 200, description = "Account reinstated successfully", body = DeveloperAccount),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn reinstate_developer_account(
+    State((service, _)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(account_id): Path<Uuid>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service.reinstate_account(account_id).await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/admin/developer-portal/production-requests",
+    tag = "admin-developer-portal",
+    summary = "Get production access requests queue",
+    description = "Get queue of production access requests awaiting review",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("status" = Option<String>, Query, description = "Filter by status (pending, approved, rejected)"),
+        ("page" = Option<i64>, Query, description = "Page number (default: 1)"),
+        ("per_page" = Option<i64>, Query, description = "Items per page (default: 20)")
+    ),
+    responses(
+        (status = 200, description = "Production access requests retrieved", body = AdminProductionAccessQueue),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
+pub async fn get_production_access_requests(
+    State((_, prod_service)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Query(params): Query<ProductionRequestsQueryParams>,
+) -> Result<Json<AdminProductionAccessQueue>, AppError> {
+    let page = params.page.unwrap_or(1);
+    let per_page = params.per_page.unwrap_or(20).min(100);
+    let queue = prod_service
+        .get_admin_production_queue(params.status, page, per_page)
+        .await?;
+    Ok(Json(queue))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/admin/developer-portal/production-requests/{request_id}/approve",
+    tag = "admin-developer-portal",
+    summary = "Approve production access request",
+    description = "Approve a production access request and issue production credentials",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("request_id" = Uuid, Path, description = "Production access request ID")
+    ),
+    request_body = AdminProductionAccessReview,
+    responses(
+        (status = 200, description = "Production access request approved", body = ProductionAccessRequest),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Request not found")
+    )
+)]
+pub async fn approve_production_access_request(
+    State((_, prod_service)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(request_id): Path<Uuid>,
+    Json(request): Json<AdminProductionAccessReview>,
+) -> Result<Json<ProductionAccessRequest>, AppError> {
+    // Use a placeholder admin_id since we don't yet carry structured admin claims
+    let admin_id = Uuid::nil();
+    let result = prod_service
+        .approve_production_access_request(request_id, admin_id, request.review_notes)
+        .await?;
+    Ok(Json(result))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/admin/developer-portal/production-requests/{request_id}/reject",
+    tag = "admin-developer-portal",
+    summary = "Reject production access request",
+    description = "Reject a production access request",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("request_id" = Uuid, Path, description = "Production access request ID")
+    ),
+    request_body = AdminProductionAccessReview,
+    responses(
+        (status = 200, description = "Production access request rejected", body = ProductionAccessRequest),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Request not found")
+    )
+)]
+pub async fn reject_production_access_request(
+    State((_, prod_service)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(request_id): Path<Uuid>,
+    Json(request): Json<AdminProductionAccessReview>,
+) -> Result<Json<ProductionAccessRequest>, AppError> {
+    let admin_id = Uuid::nil();
+    let result = prod_service
+        .reject_production_access_request(request_id, admin_id, request.review_notes)
+        .await?;
+    Ok(Json(result))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/admin/developer-portal/accounts/{account_id}/identity-verification/approve",
+    tag = "admin-developer-portal",
+    summary = "Approve identity verification",
+    description = "Approve identity verification for a developer account",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("account_id" = Uuid, Path, description = "Developer account ID")
+    ),
+    responses(
+        (status = 200, description = "Identity verification approved", body = DeveloperAccount),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn approve_identity_verification(
+    State((service, _)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(account_id): Path<Uuid>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service.approve_identity_verification(account_id).await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/admin/developer-portal/accounts/{account_id}/identity-verification/reject",
+    tag = "admin-developer-portal",
+    summary = "Reject identity verification",
+    description = "Reject identity verification for a developer account",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("account_id" = Uuid, Path, description = "Developer account ID")
+    ),
+    responses(
+        (status = 200, description = "Identity verification rejected", body = DeveloperAccount),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn reject_identity_verification(
+    State((service, _)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(account_id): Path<Uuid>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service.reject_identity_verification(account_id).await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/admin/developer-portal/accounts/{account_id}/upgrade-tier",
+    tag = "admin-developer-portal",
+    summary = "Upgrade access tier",
+    description = "Upgrade a developer account to a higher access tier",
+    security(
+        ("admin_auth" = [])
+    ),
+    params(
+        ("account_id" = Uuid, Path, description = "Developer account ID")
+    ),
+    request_body = UpgradeTierRequest,
+    responses(
+        (status = 200, description = "Access tier upgraded successfully", body = DeveloperAccount),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Account not found"),
+        (status = 400, description = "Invalid tier or requirements not met")
+    )
+)]
+pub async fn upgrade_access_tier(
+    State((service, _)): State<AdminPortalState>,
+    _auth: AuthenticatedAdmin,
+    Path(account_id): Path<Uuid>,
+    Json(request): Json<UpgradeTierRequest>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = match request.tier.as_str() {
+        "standard" => service.upgrade_to_standard_tier(account_id).await?,
+        "partner" => service.upgrade_to_partner_tier(account_id).await?,
+        _ => return Err(AppError::new(crate::error::AppErrorKind::Validation(
+            crate::error::ValidationError::InvalidAmount {
+                amount: request.tier.clone(),
+                reason: "Tier must be 'standard' or 'partner'".to_string(),
+            }
+        ))),
+    };
+    
+    Ok(Json(account))
+}
+
+// ─── DTOs ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, serde::Deserialize, ToSchema)]
+pub struct PaginationParams {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Debug, serde::Deserialize, ToSchema)]
+pub struct SuspendAccountRequest {
+    pub reason: String,
+}
+
+#[derive(Debug, serde::Deserialize, ToSchema)]
+pub struct ProductionRequestsQueryParams {
+    pub status: Option<String>,
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Debug, serde::Deserialize, ToSchema)]
+pub struct UpgradeTierRequest {
+    pub tier: String, // "standard" or "partner"
+}
+
+pub fn admin_developer_portal_routes() -> Router<AdminPortalState> {
+    Router::new()
+        .route("/accounts", get(list_developer_accounts))
+        .route("/accounts/:account_id", get(get_developer_account_details))
+        .route("/accounts/:account_id/suspend", post(suspend_developer_account))
+        .route("/accounts/:account_id/reinstate", post(reinstate_developer_account))
+        .route("/accounts/:account_id/identity-verification/approve", post(approve_identity_verification))
+        .route("/accounts/:account_id/identity-verification/reject", post(reject_identity_verification))
+        .route("/accounts/:account_id/upgrade-tier", post(upgrade_access_tier))
+        .route("/production-requests", get(get_production_access_requests))
+        .route("/production-requests/:request_id/approve", post(approve_production_access_request))
+        .route("/production-requests/:request_id/reject", post(reject_production_access_request))
+}

--- a/src/developer_portal/handlers.rs
+++ b/src/developer_portal/handlers.rs
@@ -1,0 +1,586 @@
+use super::models::*;
+use super::services::DeveloperService;
+use super::production_access::ProductionAccessService;
+use super::sandbox_service::SandboxService;
+use crate::auth::middleware::AuthenticatedDeveloper;
+use crate::error::AppError;
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::Json,
+    routing::{get, post, patch, delete},
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+use utoipa::path;
+use utoipa::ToSchema;
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PaginationParams {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UsageQueryParams {
+    pub environment: Option<String>,
+    pub start_date: Option<chrono::DateTime<chrono::Utc>>,
+    pub end_date: Option<chrono::DateTime<chrono::Utc>>,
+    pub time_range: Option<String>, // "daily", "weekly", "monthly"
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/developer/register",
+    tag = "developer-portal",
+    summary = "Register developer account",
+    description = "Register a new developer account with email verification",
+    request_body = CreateDeveloperAccountRequest,
+    responses(
+        (status = 201, description = "Developer account created successfully", body = DeveloperAccount),
+        (status = 400, description = "Invalid request"),
+        (status = 409, description = "Email already registered"),
+        (status = 422, description = "Geo-restricted country")
+    )
+)]
+pub async fn register_developer(
+    State(service): State<Arc<DeveloperService>>,
+    Json(request): Json<CreateDeveloperAccountRequest>,
+) -> Result<(StatusCode, Json<DeveloperAccount>), AppError> {
+    let account = service.register_developer(request).await?;
+    Ok((StatusCode::CREATED, Json(account)))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/developer/verify-email/{token}",
+    tag = "developer-portal",
+    summary = "Verify email address",
+    description = "Verify developer email address using verification token",
+    params(
+        ("token" = String, Path, description = "Email verification token")
+    ),
+    responses(
+        (status = 200, description = "Email verified successfully", body = DeveloperAccount),
+        (status = 400, description = "Invalid or expired token")
+    )
+)]
+pub async fn verify_email(
+    State(service): State<Arc<DeveloperService>>,
+    Path(token): Path<String>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service.verify_email(&token).await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/developer/identity-verification",
+    tag = "developer-portal",
+    summary = "Submit identity verification",
+    description = "Submit identity verification documents for production access",
+    security(
+        ("developer_auth" = [])
+    ),
+    request_body = IdentityVerificationRequest,
+    responses(
+        (status = 200, description = "Identity verification submitted", body = DeveloperAccount),
+        (status = 400, description = "Invalid request or verification already submitted"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn submit_identity_verification(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Json(request): Json<IdentityVerificationRequest>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service
+        .submit_identity_verification(auth.developer_account_id, request)
+        .await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/developer/applications",
+    tag = "developer-portal",
+    summary = "Create application",
+    description = "Create a new application under the developer account",
+    security(
+        ("developer_auth" = [])
+    ),
+    request_body = CreateApplicationRequest,
+    responses(
+        (status = 201, description = "Application created successfully", body = DeveloperApplication),
+        (status = 400, description = "Invalid request or application limit reached"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn create_application(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Json(request): Json<CreateApplicationRequest>,
+) -> Result<(StatusCode, Json<DeveloperApplication>), AppError> {
+    let application = service
+        .create_application(auth.developer_account_id, request)
+        .await?;
+    Ok((StatusCode::CREATED, Json(application)))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/developer/applications",
+    tag = "developer-portal",
+    summary = "List applications",
+    description = "List all applications for the authenticated developer",
+    security(
+        ("developer_auth" = [])
+    ),
+    responses(
+        (status = 200, description = "Applications retrieved successfully", body = Vec<DeveloperApplication>),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn list_applications(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+) -> Result<Json<Vec<DeveloperApplication>>, AppError> {
+    let applications = service.get_applications(auth.developer_account_id).await?;
+    Ok(Json(applications))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/developer/applications/{app_id}",
+    tag = "developer-portal",
+    summary = "Get application details",
+    description = "Get detailed information about a specific application",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    responses(
+        (status = 200, description = "Application details retrieved", body = DeveloperApplication),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Application not found")
+    )
+)]
+pub async fn get_application(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Path(app_id): Path<Uuid>,
+) -> Result<Json<DeveloperApplication>, AppError> {
+    let application = service.get_application(app_id).await?;
+    
+    // Verify ownership
+    if application.developer_account_id != auth.developer_account_id {
+        return Err(AppError::Unauthorized);
+    }
+    
+    Ok(Json(application))
+}
+
+#[path]
+#[utoipa::path(
+    patch,
+    path = "/api/developer/applications/{app_id}",
+    tag = "developer-portal",
+    summary = "Update application",
+    description = "Update application name and description",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    request_body = UpdateApplicationRequest,
+    responses(
+        (status = 200, description = "Application updated successfully", body = DeveloperApplication),
+        (status = 400, description = "Invalid request"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Application not found")
+    )
+)]
+pub async fn update_application(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Path(app_id): Path<Uuid>,
+    Json(request): Json<UpdateApplicationRequest>,
+) -> Result<Json<DeveloperApplication>, AppError> {
+    // Verify ownership first
+    let application = service.get_application(app_id).await?;
+    if application.developer_account_id != auth.developer_account_id {
+        return Err(AppError::Unauthorized);
+    }
+
+    let updated_application = service.update_application(app_id, request).await?;
+    Ok(Json(updated_application))
+}
+
+#[path]
+#[utoipa::path(
+    delete,
+    path = "/api/developer/applications/{app_id}",
+    tag = "developer-portal",
+    summary = "Delete application",
+    description = "Soft delete an application and revoke all credentials",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    responses(
+        (status = 204, description = "Application deleted successfully"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Application not found")
+    )
+)]
+pub async fn delete_application(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Path(app_id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    // Verify ownership first
+    let application = service.get_application(app_id).await?;
+    if application.developer_account_id != auth.developer_account_id {
+        return Err(AppError::Unauthorized);
+    }
+
+    service.delete_application(app_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/developer/applications/{app_id}/api-keys",
+    tag = "developer-portal",
+    summary = "Create API key",
+    description = "Create a new API key for an application",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    request_body = CreateApiKeyRequest,
+    responses(
+        (status = 201, description = "API key created successfully", body = ApiKeyCreationResponse),
+        (status = 400, description = "Invalid request or insufficient permissions"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Application not found")
+    )
+)]
+pub async fn create_api_key(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Path(app_id): Path<Uuid>,
+    Json(request): Json<CreateApiKeyRequest>,
+) -> Result<(StatusCode, Json<ApiKeyCreationResponse>), AppError> {
+    // Verify ownership first
+    let application = service.get_application(app_id).await?;
+    if application.developer_account_id != auth.developer_account_id {
+        return Err(AppError::Unauthorized);
+    }
+
+    let (api_key, raw_key) = service.create_api_key(app_id, request).await?;
+    
+    let response = ApiKeyCreationResponse {
+        api_key,
+        raw_key, // Only returned once during creation
+    };
+    
+    Ok((StatusCode::CREATED, Json(response)))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/developer/applications/{app_id}/api-keys",
+    tag = "developer-portal",
+    summary = "List API keys",
+    description = "List all API keys for an application",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    responses(
+        (status = 200, description = "API keys retrieved successfully", body = Vec<ApiKey>),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Application not found")
+    )
+)]
+pub async fn list_api_keys(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Path(app_id): Path<Uuid>,
+) -> Result<Json<Vec<ApiKey>>, AppError> {
+    // Verify ownership first
+    let application = service.get_application(app_id).await?;
+    if application.developer_account_id != auth.developer_account_id {
+        return Err(AppError::Unauthorized);
+    }
+
+    let api_keys = service.get_api_keys(app_id).await?;
+    Ok(Json(api_keys))
+}
+
+#[path]
+#[utoipa::path(
+    delete,
+    path = "/api/developer/api-keys/{key_id}",
+    tag = "developer-portal",
+    summary = "Revoke API key",
+    description = "Revoke an API key",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("key_id" = Uuid, Path, description = "API key ID")
+    ),
+    responses(
+        (status = 204, description = "API key revoked successfully"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "API key not found")
+    )
+)]
+pub async fn revoke_api_key(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Path(key_id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    // Verify ownership through the API key's application
+    let api_key = service.api_key_repo.find_by_id(key_id).await
+        .map_err(|_| AppError::NotFound)?
+        .ok_or(AppError::NotFound)?;
+    
+    let application = service.get_application(api_key.application_id).await?;
+    if application.developer_account_id != auth.developer_account_id {
+        return Err(AppError::Unauthorized);
+    }
+
+    service.revoke_api_key(key_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/developer/sandbox/reset",
+    tag = "developer-portal",
+    summary = "Reset sandbox environment",
+    description = "Reset sandbox environment and provision fresh credentials",
+    security(
+        ("developer_auth" = [])
+    ),
+    responses(
+        (status = 200, description = "Sandbox environment reset successfully", body = SandboxEnvironment),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Account not found")
+    )
+)]
+pub async fn reset_sandbox_environment(
+    State((dev_service, _)): State<(Arc<DeveloperService>, Arc<ProductionAccessService>)>,
+    auth: AuthenticatedDeveloper,
+) -> Result<Json<SandboxEnvironment>, AppError> {
+    // Verify account has at least one application — pick the first if no specific app_id
+    let applications = dev_service
+        .get_applications(auth.developer_account_id)
+        .await
+        .map_err(AppError::from)?;
+
+    let application = applications
+        .into_iter()
+        .next()
+        .ok_or_else(|| AppError::new(crate::error::AppErrorKind::Domain(
+            crate::error::DomainError::TransactionNotFound {
+                transaction_id: "no_application".to_string(),
+            }
+        )))?;
+
+    let sandbox_env = dev_service
+        .developer_account_repo
+        .reset_sandbox_environment(application.id)
+        .await
+        .map_err(AppError::from)?;
+
+    Ok(Json(sandbox_env))
+}
+
+#[path]
+#[utoipa::path(
+    post,
+    path = "/api/developer/applications/{app_id}/production-access",
+    tag = "developer-portal",
+    summary = "Request production access",
+    description = "Submit a production access request for an application",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    request_body = CreateProductionAccessRequest,
+    responses(
+        (status = 201, description = "Production access request submitted", body = ProductionAccessRequest),
+        (status = 400, description = "Invalid request or identity verification required"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Application not found")
+    )
+)]
+pub async fn request_production_access(
+    State(services): State<(Arc<DeveloperService>, Arc<ProductionAccessService>)>,
+    auth: AuthenticatedDeveloper,
+    Path(app_id): Path<Uuid>,
+    Json(request): Json<CreateProductionAccessRequest>,
+) -> Result<(StatusCode, Json<ProductionAccessRequest>), AppError> {
+    let production_request = services
+        .1
+        .create_production_access_request(app_id, auth.developer_account_id, request)
+        .await?;
+    Ok((StatusCode::CREATED, Json(production_request)))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/developer/applications/{app_id}/usage",
+    tag = "developer-portal",
+    summary = "Get usage statistics",
+    description = "Get usage statistics for an application",
+    security(
+        ("developer_auth" = [])
+    ),
+    params(
+        ("app_id" = Uuid, Path, description = "Application ID"),
+        ("environment" = Option<String>, Query, description = "Filter by environment"),
+        ("start_date" = Option<chrono::DateTime<chrono::Utc>>, Query, description = "Start date for usage data"),
+        ("end_date" = Option<chrono::DateTime<chrono::Utc>>, Query, description = "End date for usage data"),
+        ("time_range" = Option<String>, Query, description = "Time range: daily, weekly, monthly")
+    ),
+    responses(
+        (status = 200, description = "Usage statistics retrieved", body = ApplicationUsageSummary),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Application not found")
+    )
+)]
+pub async fn get_usage_statistics(
+    State((dev_service, _)): State<(Arc<DeveloperService>, Arc<ProductionAccessService>)>,
+    auth: AuthenticatedDeveloper,
+    Path(app_id): Path<Uuid>,
+    Query(params): Query<UsageQueryParams>,
+) -> Result<Json<ApplicationUsageSummary>, AppError> {
+    // Verify the application belongs to this developer
+    let application = dev_service
+        .get_application(app_id)
+        .await
+        .map_err(AppError::from)?;
+
+    if application.developer_account_id != auth.developer_account_id {
+        return Err(AppError::new(crate::error::AppErrorKind::Domain(
+            crate::error::DomainError::TransactionNotFound {
+                transaction_id: app_id.to_string(),
+            }
+        )));
+    }
+
+    let summary = dev_service
+        .get_usage_statistics(
+            app_id,
+            params.time_range.as_deref(),
+            params.start_date,
+            params.end_date,
+            params.environment.as_deref(),
+        )
+        .await
+        .map_err(AppError::from)?;
+
+    Ok(Json(summary))
+}
+
+#[path]
+#[utoipa::path(
+    get,
+    path = "/api/developer/account",
+    tag = "developer-portal",
+    summary = "Get developer account",
+    description = "Get current developer account information",
+    security(
+        ("developer_auth" = [])
+    ),
+    responses(
+        (status = 200, description = "Account information retrieved", body = DeveloperAccount),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn get_developer_account(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service.get_developer_account(auth.developer_account_id).await?;
+    Ok(Json(account))
+}
+
+#[path]
+#[utoipa::path(
+    patch,
+    path = "/api/developer/account",
+    tag = "developer-portal",
+    summary = "Update developer account",
+    description = "Update developer account information",
+    security(
+        ("developer_auth" = [])
+    ),
+    request_body = UpdateDeveloperAccountRequest,
+    responses(
+        (status = 200, description = "Account updated successfully", body = DeveloperAccount),
+        (status = 400, description = "Invalid request"),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn update_developer_account(
+    State(service): State<Arc<DeveloperService>>,
+    auth: AuthenticatedDeveloper,
+    Json(request): Json<UpdateDeveloperAccountRequest>,
+) -> Result<Json<DeveloperAccount>, AppError> {
+    let account = service
+        .update_developer_account(auth.developer_account_id, request)
+        .await?;
+    Ok(Json(account))
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ApiKeyCreationResponse {
+    pub api_key: ApiKey,
+    pub raw_key: String,
+}
+
+pub fn developer_portal_routes() -> Router<(Arc<DeveloperService>, Arc<ProductionAccessService>)> {
+    Router::new()
+        .route("/register", post(register_developer))
+        .route("/verify-email/:token", get(verify_email))
+        .route("/identity-verification", post(submit_identity_verification))
+        .route("/applications", post(create_application).get(list_applications))
+        .route("/applications/:app_id", get(get_application).patch(update_application).delete(delete_application))
+        .route("/applications/:app_id/api-keys", post(create_api_key).get(list_api_keys))
+        .route("/api-keys/:key_id", delete(revoke_api_key))
+        .route("/sandbox/reset", post(reset_sandbox_environment))
+        .route("/applications/:app_id/production-access", post(request_production_access))
+        .route("/applications/:app_id/usage", get(get_usage_statistics))
+        .route("/account", get(get_developer_account).patch(update_developer_account))
+}

--- a/src/developer_portal/middleware.rs
+++ b/src/developer_portal/middleware.rs
@@ -1,0 +1,254 @@
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::{header::AUTHORIZATION, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use std::sync::Arc;
+use tower::ServiceExt;
+use tracing::{error, info};
+
+use super::models::DeveloperPortalError;
+use super::services::DeveloperService;
+use crate::auth::jwt::Claims;
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedDeveloper {
+    pub developer_account_id: uuid::Uuid,
+    pub email: String,
+}
+
+pub async fn developer_auth_middleware(
+    State(service): State<Arc<DeveloperService>>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // Extract Authorization header
+    let auth_header = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|header| header.to_str().ok())
+        .and_then(|header| {
+            if header.starts_with("Bearer ") {
+                Some(&header[7..])
+            } else {
+                None
+            }
+        });
+
+    let token = match auth_header {
+        Some(token) => token,
+        None => {
+            error!("Missing or invalid Authorization header");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+
+    // Validate JWT token
+    let claims = match crate::auth::jwt::validate_token(token) {
+        Ok(claims) => claims,
+        Err(e) => {
+            error!("Invalid JWT token: {}", e);
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+
+    // Verify it's a developer token
+    if claims.token_type != "developer" {
+        error!("Token is not a developer token");
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    // Get developer account
+    let developer_account = match service.get_developer_account(claims.sub).await {
+        Ok(account) => account,
+        Err(e) => {
+            error!("Developer account not found: {}", e);
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+
+    // Check if account is active
+    if developer_account.status_code == "suspended" {
+        error!("Developer account is suspended: {}", developer_account.email);
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // Check if email is verified for non-public endpoints
+    let path = request.uri().path();
+    if !path.ends_with("/register") && !path.contains("/verify-email") {
+        if !developer_account.email_verified {
+            error!("Developer email not verified: {}", developer_account.email);
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
+
+    // Add developer info to request extensions
+    let auth_info = AuthenticatedDeveloper {
+        developer_account_id: developer_account.id,
+        email: developer_account.email,
+    };
+    request.extensions_mut().insert(auth_info);
+
+    info!(
+        "Developer authenticated: {} for {}",
+        developer_account.email, path
+    );
+
+    Ok(next.run(request).await)
+}
+
+pub async fn api_key_auth_middleware(
+    State(service): State<Arc<DeveloperService>>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // Extract API key from Authorization header
+    let auth_header = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|header| header.to_str().ok())
+        .and_then(|header| {
+            if header.starts_with("Bearer ") {
+                Some(&header[7..])
+            } else {
+                None
+            }
+        });
+
+    let api_key = match auth_header {
+        Some(key) => key,
+        None => {
+            error!("Missing or invalid Authorization header for API key auth");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+
+    // Check if it's an API key (starts with "ak_")
+    if !api_key.starts_with("ak_") {
+        error!("Invalid API key format");
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    // Validate API key
+    let key_info = match service.validate_api_key(api_key).await {
+        Ok(Some(key)) => key,
+        Ok(None) => {
+            error!("API key not found or inactive");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        Err(e) => {
+            error!("Error validating API key: {}", e);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+
+    // Check if key has expired
+    if let Some(expires_at) = key_info.expires_at {
+        if expires_at < chrono::Utc::now() {
+            error!("API key has expired");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    // Get application to verify ownership
+    let application = match service.get_application(key_info.application_id).await {
+        Ok(app) => app,
+        Err(e) => {
+            error!("Application not found for API key: {}", e);
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+
+    // Get developer account
+    let developer_account = match service.get_developer_account(application.developer_account_id).await {
+        Ok(account) => account,
+        Err(e) => {
+            error!("Developer account not found: {}", e);
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    // Check if account is active
+    if developer_account.status_code == "suspended" {
+        error!("Developer account is suspended: {}", developer_account.email);
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // Update API key usage
+    if let Err(e) = service.update_api_key_usage(key_info.id).await {
+        error!("Failed to update API key usage: {}", e);
+        // Don't fail the request, just log the error
+    }
+
+    // Add auth info to request extensions
+    let auth_info = AuthenticatedDeveloper {
+        developer_account_id: developer_account.id,
+        email: developer_account.email,
+    };
+    request.extensions_mut().insert(auth_info);
+
+    // Add API key info to request extensions for rate limiting
+    request.extensions_mut().insert(key_info);
+
+    info!(
+        "API key authenticated: {} for {}",
+        api_key, request.uri().path()
+    );
+
+    Ok(next.run(request).await)
+}
+
+// Rate limiting middleware for API keys
+pub async fn rate_limit_middleware(
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // Get API key info from request extensions
+    let api_key = request.extensions().get::<super::models::ApiKey>();
+    
+    if let Some(key) = api_key {
+        // TODO: Implement rate limiting logic using Redis or in-memory counter
+        // For now, just pass through
+        info!(
+            "Rate limit check for API key: {} (limit: {} req/min)",
+            key.key_name, key.rate_limit_per_minute
+        );
+    }
+
+    Ok(next.run(request).await)
+}
+
+// Middleware to log API usage for statistics
+pub async fn usage_logging_middleware(
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let start_time = std::time::Instant::now();
+    let method = request.method().clone();
+    let uri = request.uri().clone();
+    let path = uri.path().to_string();
+
+    let response = next.run(request).await;
+
+    let duration = start_time.elapsed();
+    let status = response.status();
+
+    // Get developer and application info from extensions
+    let auth_info = response.extensions().get::<AuthenticatedDeveloper>();
+    let api_key = response.extensions().get::<super::models::ApiKey>();
+
+    if let (Some(dev), Some(key)) = (auth_info, api_key) {
+        // TODO: Log usage statistics to database
+        info!(
+            "API usage: {} {} {} - {}ms - Developer: {} - Key: {}",
+            method, path, status.as_u16(),
+            duration.as_millis(),
+            dev.email,
+            key.key_name
+        );
+    }
+
+    Ok(response)
+}

--- a/src/developer_portal/mod.rs
+++ b/src/developer_portal/mod.rs
@@ -1,0 +1,21 @@
+pub mod models;
+pub mod repositories;
+pub mod services;
+pub mod handlers;
+pub mod admin_handlers;
+pub mod middleware;
+pub mod production_access;
+pub mod webhook_service;
+pub mod sandbox_service;
+pub mod routes;
+
+pub use models::*;
+pub use repositories::*;
+pub use services::*;
+pub use handlers::*;
+pub use admin_handlers::*;
+pub use middleware::*;
+pub use production_access::*;
+pub use webhook_service::*;
+pub use sandbox_service::*;
+pub use routes::*;

--- a/src/developer_portal/models.rs
+++ b/src/developer_portal/models.rs
@@ -1,0 +1,420 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct DeveloperAccount {
+    pub id: Uuid,
+    pub email: String,
+    pub full_name: String,
+    pub organisation: Option<String>,
+    pub country: String,
+    pub use_case_description: String,
+    pub status_code: String,
+    pub access_tier_code: String,
+    pub email_verified: bool,
+    pub email_verification_token: Option<String>,
+    pub email_verification_expires_at: Option<DateTime<Utc>>,
+    pub identity_verification_status: String,
+    pub identity_verification_data: Option<serde_json::Value>,
+    pub identity_verified_at: Option<DateTime<Utc>>,
+    pub suspended_at: Option<DateTime<Utc>>,
+    pub suspension_reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateDeveloperAccountRequest {
+    pub email: String,
+    pub full_name: String,
+    pub organisation: Option<String>,
+    pub country: String,
+    pub use_case_description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateDeveloperAccountRequest {
+    pub full_name: Option<String>,
+    pub organisation: Option<String>,
+    pub country: Option<String>,
+    pub use_case_description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityVerificationRequest {
+    pub full_legal_name: String,
+    pub government_id_type: String,
+    pub government_id_number: String,
+    pub business_registration_number: Option<String>,
+    pub additional_documents: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct DeveloperApplication {
+    pub id: Uuid,
+    pub developer_account_id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub intended_use_case: String,
+    pub status: String,
+    pub sandbox_wallet_address: Option<String>,
+    pub sandbox_wallet_secret: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateApplicationRequest {
+    pub name: String,
+    pub description: String,
+    pub intended_use_case: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateApplicationRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub intended_use_case: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ApiKey {
+    pub id: Uuid,
+    pub application_id: Uuid,
+    pub key_prefix: String,
+    pub key_hash: String,
+    pub key_name: String,
+    pub environment: String,
+    pub status: String,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub usage_count: i32,
+    pub rate_limit_per_minute: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateApiKeyRequest {
+    pub key_name: String,
+    pub environment: String,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub rate_limit_per_minute: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct OAuthClient {
+    pub id: Uuid,
+    pub application_id: Uuid,
+    pub client_id: String,
+    pub client_secret_hash: String,
+    pub client_name: String,
+    pub environment: String,
+    pub redirect_uris: Vec<String>,
+    pub scopes: Vec<String>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateOAuthClientRequest {
+    pub client_name: String,
+    pub environment: String,
+    pub redirect_uris: Vec<String>,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateOAuthClientRequest {
+    pub client_name: Option<String>,
+    pub redirect_uris: Option<Vec<String>>,
+    pub scopes: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct WebhookConfiguration {
+    pub id: Uuid,
+    pub application_id: Uuid,
+    pub webhook_url: String,
+    pub secret_token: Option<String>,
+    pub events: Vec<String>,
+    pub status: String,
+    pub delivery_success_rate: rust_decimal::Decimal,
+    pub average_delivery_latency: i32,
+    pub failed_delivery_count: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateWebhookConfigurationRequest {
+    pub webhook_url: String,
+    pub secret_token: Option<String>,
+    pub events: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateWebhookConfigurationRequest {
+    pub webhook_url: Option<String>,
+    pub secret_token: Option<String>,
+    pub events: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ProductionAccessRequest {
+    pub id: Uuid,
+    pub application_id: Uuid,
+    pub developer_account_id: Uuid,
+    pub production_use_case: String,
+    pub expected_transaction_volume: String,
+    pub supported_countries: Vec<String>,
+    pub business_details: Option<serde_json::Value>,
+    pub status: String,
+    pub reviewed_by_admin_id: Option<Uuid>,
+    pub review_notes: Option<String>,
+    pub reviewed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateProductionAccessRequest {
+    pub production_use_case: String,
+    pub expected_transaction_volume: String,
+    pub supported_countries: Vec<String>,
+    pub business_details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminProductionAccessReview {
+    pub status: String,
+    pub review_notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct UsageStatistics {
+    pub id: Uuid,
+    pub application_id: Uuid,
+    pub api_key_id: Option<Uuid>,
+    pub endpoint: String,
+    pub method: String,
+    pub status_code: i32,
+    pub response_time_ms: Option<i32>,
+    pub request_size_bytes: Option<i32>,
+    pub response_size_bytes: Option<i32>,
+    pub timestamp: DateTime<Utc>,
+    pub environment: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct WebhookDeliveryLog {
+    pub id: Uuid,
+    pub webhook_configuration_id: Uuid,
+    pub event_type: String,
+    pub payload: serde_json::Value,
+    pub delivery_url: String,
+    pub status: String,
+    pub http_status_code: Option<i32>,
+    pub response_body: Option<String>,
+    pub delivery_attempts: i32,
+    pub next_retry_at: Option<DateTime<Utc>>,
+    pub delivered_at: Option<DateTime<Utc>>,
+    pub error_message: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct DeveloperAccountStatus {
+    pub code: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct AccessTier {
+    pub code: String,
+    pub description: String,
+    pub max_applications: i32,
+    pub rate_limit_per_minute: i32,
+    pub requires_identity_verification: bool,
+    pub requires_business_agreement: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageMetrics {
+    pub total_requests: i64,
+    pub successful_requests: i64,
+    pub failed_requests: i64,
+    pub average_response_time: f64,
+    pub requests_per_minute: i64,
+    pub rate_limit_utilization: f64,
+    pub error_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApplicationUsageSummary {
+    pub application_id: Uuid,
+    pub application_name: String,
+    pub environment: String,
+    pub metrics: UsageMetrics,
+    pub endpoint_breakdown: Vec<EndpointUsage>,
+    pub time_series_data: Vec<TimeSeriesDataPoint>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EndpointUsage {
+    pub endpoint: String,
+    pub method: String,
+    pub request_count: i64,
+    pub average_response_time: f64,
+    pub error_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeSeriesDataPoint {
+    pub timestamp: DateTime<Utc>,
+    pub request_count: i64,
+    pub average_response_time: f64,
+    pub error_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookMetrics {
+    pub total_deliveries: i64,
+    pub successful_deliveries: i64,
+    pub failed_deliveries: i64,
+    pub success_rate: f64,
+    pub average_latency: f64,
+    pub pending_deliveries: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminDeveloperAccountList {
+    pub accounts: Vec<AdminDeveloperAccountSummary>,
+    pub total_count: i64,
+    pub page: i64,
+    pub per_page: i64,
+    pub total_pages: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminDeveloperAccountSummary {
+    pub id: Uuid,
+    pub email: String,
+    pub full_name: String,
+    pub organisation: Option<String>,
+    pub country: String,
+    pub status_code: String,
+    pub access_tier_code: String,
+    pub email_verified: bool,
+    pub identity_verification_status: String,
+    pub application_count: i64,
+    pub created_at: DateTime<Utc>,
+    pub last_activity: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminProductionAccessQueue {
+    pub requests: Vec<AdminProductionAccessRequestSummary>,
+    pub total_count: i64,
+    pub pending_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminProductionAccessRequestSummary {
+    pub id: Uuid,
+    pub application_id: Uuid,
+    pub application_name: String,
+    pub developer_account_id: Uuid,
+    pub developer_email: String,
+    pub production_use_case: String,
+    pub expected_transaction_volume: String,
+    pub supported_countries: Vec<String>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxEnvironment {
+    pub wallet_address: String,
+    pub wallet_secret: String,
+    pub network: String,
+    pub initial_balance: String,
+    pub api_keys: Vec<SandboxApiKey>,
+    pub oauth_clients: Vec<SandboxOAuthClient>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxApiKey {
+    pub key_id: Uuid,
+    pub key_name: String,
+    pub api_key: String,
+    pub rate_limit_per_minute: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxOAuthClient {
+    pub client_id: String,
+    pub client_name: String,
+    pub client_secret: String,
+    pub redirect_uris: Vec<String>,
+    pub scopes: Vec<String>,
+}
+
+// Error types
+#[derive(Debug, thiserror::Error)]
+pub enum DeveloperPortalError {
+    #[error("Email already registered")]
+    EmailAlreadyRegistered,
+    #[error("Account not found")]
+    AccountNotFound,
+    #[error("Application not found")]
+    ApplicationNotFound,
+    #[error("API key not found")]
+    ApiKeyNotFound,
+    #[error("OAuth client not found")]
+    OAuthClientNotFound,
+    #[error("Webhook configuration not found")]
+    WebhookConfigurationNotFound,
+    #[error("Production access request not found")]
+    ProductionAccessRequestNotFound,
+    #[error("Invalid email verification token")]
+    InvalidEmailVerificationToken,
+    #[error("Email verification token expired")]
+    EmailVerificationTokenExpired,
+    #[error("Identity verification required")]
+    IdentityVerificationRequired,
+    #[error("Identity verification already submitted")]
+    IdentityVerificationAlreadySubmitted,
+    #[error("Maximum applications limit reached")]
+    MaximumApplicationsLimitReached,
+    #[error("Access tier not found")]
+    AccessTierNotFound,
+    #[error("Geo-restricted country")]
+    GeoRestrictedCountry,
+    #[error("Account suspended")]
+    AccountSuspended,
+    #[error("Invalid environment")]
+    InvalidEnvironment,
+    #[error("Invalid status")]
+    InvalidStatus,
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("Invalid UUID: {0}")]
+    InvalidUuid(#[from] uuid::Error),
+    #[error("Production access request already pending")]
+    ProductionAccessRequestAlreadyPending,
+    #[error("Not implemented")]
+    NotImplemented,
+    #[error("Crypto error: {0}")]
+    Crypto(String),
+}

--- a/src/developer_portal/production_access.rs
+++ b/src/developer_portal/production_access.rs
@@ -1,0 +1,505 @@
+use super::models::*;
+use super::repositories::{DeveloperAccountRepository, DeveloperApplicationRepository, ApiKeyRepository, OAuthClientRepository, ProductionAccessRequestRepository, WebhookConfigurationRepository};
+use crate::database::error::DatabaseError;
+use chrono::{DateTime, Utc};
+use rand::Rng;
+use argon2::{Argon2, PasswordHasher};
+use argon2::password_hash::{rand_core::OsRng, SaltString};
+use serde_json::json;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ProductionAccessService {
+    developer_account_repo: DeveloperAccountRepository,
+    application_repo: DeveloperApplicationRepository,
+    api_key_repo: ApiKeyRepository,
+    oauth_client_repo: OAuthClientRepository,
+    production_access_repo: ProductionAccessRequestRepository,
+    webhook_repo: WebhookConfigurationRepository,
+}
+
+impl ProductionAccessService {
+    pub fn new(
+        developer_account_repo: DeveloperAccountRepository,
+        application_repo: DeveloperApplicationRepository,
+        api_key_repo: ApiKeyRepository,
+        oauth_client_repo: OAuthClientRepository,
+        production_access_repo: ProductionAccessRequestRepository,
+        webhook_repo: WebhookConfigurationRepository,
+    ) -> Self {
+        Self {
+            developer_account_repo,
+            application_repo,
+            api_key_repo,
+            oauth_client_repo,
+            production_access_repo,
+            webhook_repo,
+        }
+    }
+
+    pub async fn create_production_access_request(
+        &self,
+        application_id: Uuid,
+        developer_account_id: Uuid,
+        request: CreateProductionAccessRequest,
+    ) -> Result<ProductionAccessRequest, DeveloperPortalError> {
+        // Verify application exists and belongs to developer
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?
+            .ok_or(DeveloperPortalError::ApplicationNotFound)?;
+
+        if application.developer_account_id != developer_account_id {
+            return Err(DeveloperPortalError::ApplicationNotFound);
+        }
+
+        // Check developer account status and identity verification
+        let account = self
+            .developer_account_repo
+            .find_by_id(developer_account_id)
+            .await?
+            .ok_or(DeveloperPortalError::AccountNotFound)?;
+
+        if account.identity_verification_status != "verified" {
+            return Err(DeveloperPortalError::IdentityVerificationRequired);
+        }
+
+        // Check if there's already a pending request
+        let existing_requests = self
+            .production_access_repo
+            .find_by_application_and_status(application_id, "pending")
+            .await?;
+
+        if !existing_requests.is_empty() {
+            return Err(DeveloperPortalError::ProductionAccessRequestAlreadyPending);
+        }
+
+        // Create production access request
+        let production_request = self
+            .production_access_repo
+            .create(application_id, developer_account_id, request)
+            .await?;
+
+        // Notify admin webhook
+        self.notify_admin_production_request(&production_request, "created").await?;
+
+        info!(
+            "Production access request created: {} for application: {}",
+            production_request.id, application.name
+        );
+
+        Ok(production_request)
+    }
+
+    pub async fn get_production_access_requests(
+        &self,
+        developer_account_id: Uuid,
+    ) -> Result<Vec<ProductionAccessRequest>, DeveloperPortalError> {
+        let requests = self
+            .production_access_repo
+            .find_by_developer_account(developer_account_id)
+            .await?;
+
+        Ok(requests)
+    }
+
+    pub async fn approve_production_access_request(
+        &self,
+        request_id: Uuid,
+        admin_id: Uuid,
+        review_notes: Option<String>,
+    ) -> Result<ProductionAccessRequest, DeveloperPortalError> {
+        let mut request = self
+            .production_access_repo
+            .find_by_id(request_id)
+            .await?
+            .ok_or(DeveloperPortalError::ProductionAccessRequestNotFound)?;
+
+        if request.status != "pending" {
+            return Err(DeveloperPortalError::InvalidStatus);
+        }
+
+        // Update request status
+        request = self
+            .production_access_repo
+            .update_status(request_id, "approved", Some(admin_id), review_notes)
+            .await?;
+
+        // Upgrade developer account to standard tier if not already
+        let account = self
+            .developer_account_repo
+            .find_by_id(request.developer_account_id)
+            .await?
+            .ok_or(DeveloperPortalError::AccountNotFound)?;
+
+        if account.access_tier_code == "sandbox" {
+            self.developer_account_repo
+                .upgrade_to_standard_tier(request.developer_account_id)
+                .await?;
+        }
+
+        // Issue production credentials
+        self.issue_production_credentials(request.application_id).await?;
+
+        // Notify developer
+        self.notify_developer_production_request(&request, "approved").await?;
+
+        info!(
+            "Production access request approved: {} for application: {}",
+            request.id, request.application_id
+        );
+
+        Ok(request)
+    }
+
+    pub async fn reject_production_access_request(
+        &self,
+        request_id: Uuid,
+        admin_id: Uuid,
+        review_notes: Option<String>,
+    ) -> Result<ProductionAccessRequest, DeveloperPortalError> {
+        let request = self
+            .production_access_repo
+            .find_by_id(request_id)
+            .await?
+            .ok_or(DeveloperPortalError::ProductionAccessRequestNotFound)?;
+
+        if request.status != "pending" {
+            return Err(DeveloperPortalError::InvalidStatus);
+        }
+
+        // Update request status
+        let updated_request = self
+            .production_access_repo
+            .update_status(request_id, "rejected", Some(admin_id), review_notes)
+            .await?;
+
+        // Notify developer
+        self.notify_developer_production_request(&updated_request, "rejected").await?;
+
+        warn!(
+            "Production access request rejected: {} for application: {}",
+            request_id, request.application_id
+        );
+
+        Ok(updated_request)
+    }
+
+    pub async fn get_admin_production_queue(
+        &self,
+        status: Option<String>,
+        page: i64,
+        per_page: i64,
+    ) -> Result<AdminProductionAccessQueue, DeveloperPortalError> {
+        let queue = self
+            .production_access_repo
+            .list_for_admin(status, page, per_page)
+            .await?;
+
+        Ok(queue)
+    }
+
+    async fn issue_production_credentials(&self, application_id: Uuid) -> Result<(), DeveloperPortalError> {
+        info!("Issuing production credentials for application: {}", application_id);
+
+        // Generate production API key
+        let raw_key = self.generate_random_token("ak_", 32);
+        let key_prefix = &raw_key[..8];
+        let key_hash = self.hash_value(&raw_key)?;
+
+        let key_request = CreateApiKeyRequest {
+            key_name: "Production API Key".to_string(),
+            environment: "production".to_string(),
+            expires_at: None,
+            rate_limit_per_minute: Some(1000),
+        };
+        self.api_key_repo
+            .create(application_id, key_request, key_prefix, &key_hash)
+            .await?;
+
+        // Generate production OAuth client
+        let client_id = self.generate_random_token("client_", 16);
+        let client_secret = self.generate_random_token("", 32);
+        let client_secret_hash = self.hash_value(&client_secret)?;
+
+        let oauth_request = CreateOAuthClientRequest {
+            client_name: "Production OAuth Client".to_string(),
+            environment: "production".to_string(),
+            redirect_uris: vec![],
+            scopes: vec!["read".to_string(), "write".to_string()],
+        };
+        self.oauth_client_repo
+            .create(application_id, &client_id, &client_secret_hash, oauth_request)
+            .await?;
+
+        info!(
+            event = "production_credentials_issued",
+            application_id = %application_id,
+            "Production credentials issued successfully"
+        );
+
+        Ok(())
+    }
+
+    fn generate_random_token(&self, prefix: &str, len: usize) -> String {
+        let mut rng = rand::thread_rng();
+        let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        let suffix: String = (0..len)
+            .map(|_| chars[rng.gen_range(0..chars.len())] as char)
+            .collect();
+        format!("{}{}", prefix, suffix)
+    }
+
+    fn hash_value(&self, value: &str) -> Result<String, DeveloperPortalError> {
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        let hash = argon2
+            .hash_password(value.as_bytes(), &salt)
+            .map_err(|e| DeveloperPortalError::Crypto(e.to_string()))?;
+        Ok(hash.to_string())
+    }
+
+    async fn notify_admin_production_request(
+        &self,
+        request: &ProductionAccessRequest,
+        action: &str,
+    ) -> Result<(), DeveloperPortalError> {
+        info!(
+            event = "production_access_request_admin_notify",
+            request_id = %request.id,
+            application_id = %request.application_id,
+            developer_account_id = %request.developer_account_id,
+            action = action,
+            "Admin notified of production access request"
+        );
+        Ok(())
+    }
+
+    async fn notify_developer_production_request(
+        &self,
+        request: &ProductionAccessRequest,
+        action: &str,
+    ) -> Result<(), DeveloperPortalError> {
+        info!(
+            event = "production_access_request_developer_notify",
+            request_id = %request.id,
+            application_id = %request.application_id,
+            developer_account_id = %request.developer_account_id,
+            status = %request.status,
+            action = action,
+            "Developer notified of production access request status change"
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ProductionAccessRequestRepository {
+    pool: Arc<sqlx::PgPool>,
+}
+
+impl ProductionAccessRequestRepository {
+    pub fn new(pool: Arc<sqlx::PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        application_id: Uuid,
+        developer_account_id: Uuid,
+        request: CreateProductionAccessRequest,
+    ) -> Result<ProductionAccessRequest, DeveloperPortalError> {
+        let production_request = sqlx::query_as!(
+            ProductionAccessRequest,
+            r#"
+            INSERT INTO production_access_requests (
+                application_id, developer_account_id, production_use_case,
+                expected_transaction_volume, supported_countries, business_details
+            ) VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING *
+            "#,
+            application_id,
+            developer_account_id,
+            request.production_use_case,
+            request.expected_transaction_volume,
+            &request.supported_countries,
+            request.business_details
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(production_request)
+    }
+
+    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<ProductionAccessRequest>, DeveloperPortalError> {
+        let request = sqlx::query_as!(
+            ProductionAccessRequest,
+            "SELECT * FROM production_access_requests WHERE id = $1",
+            id
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(request)
+    }
+
+    pub async fn find_by_application_and_status(
+        &self,
+        application_id: Uuid,
+        status: &str,
+    ) -> Result<Vec<ProductionAccessRequest>, DeveloperPortalError> {
+        let requests = sqlx::query_as!(
+            ProductionAccessRequest,
+            "SELECT * FROM production_access_requests WHERE application_id = $1 AND status = $2",
+            application_id,
+            status
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(requests)
+    }
+
+    pub async fn find_by_developer_account(
+        &self,
+        developer_account_id: Uuid,
+    ) -> Result<Vec<ProductionAccessRequest>, DeveloperPortalError> {
+        let requests = sqlx::query_as!(
+            ProductionAccessRequest,
+            "SELECT * FROM production_access_requests WHERE developer_account_id = $1 ORDER BY created_at DESC",
+            developer_account_id
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(requests)
+    }
+
+    pub async fn update_status(
+        &self,
+        request_id: Uuid,
+        status: &str,
+        reviewed_by_admin_id: Option<Uuid>,
+        review_notes: Option<String>,
+    ) -> Result<ProductionAccessRequest, DeveloperPortalError> {
+        let request = sqlx::query_as!(
+            ProductionAccessRequest,
+            r#"
+            UPDATE production_access_requests 
+            SET status = $1,
+                reviewed_by_admin_id = $2,
+                review_notes = $3,
+                reviewed_at = now(),
+                updated_at = now()
+            WHERE id = $4
+            RETURNING *
+            "#,
+            status,
+            reviewed_by_admin_id,
+            review_notes,
+            request_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(request)
+    }
+
+    pub async fn list_for_admin(
+        &self,
+        status: Option<String>,
+        page: i64,
+        per_page: i64,
+    ) -> Result<AdminProductionAccessQueue, DeveloperPortalError> {
+        let offset = (page - 1) * per_page;
+
+        let requests = if let Some(status_filter) = status {
+            sqlx::query_as!(
+                AdminProductionAccessRequestSummary,
+                r#"
+                SELECT 
+                    par.id,
+                    par.application_id,
+                    da.name as "application_name!",
+                    par.developer_account_id,
+                    da.email as "developer_email!",
+                    par.production_use_case,
+                    par.expected_transaction_volume,
+                    par.supported_countries,
+                    par.status,
+                    par.created_at
+                FROM production_access_requests par
+                JOIN developer_applications da ON par.application_id = da.id
+                JOIN developer_accounts dev ON par.developer_account_id = dev.id
+                WHERE par.status = $1
+                ORDER BY par.created_at DESC
+                LIMIT $2 OFFSET $3
+                "#,
+                status_filter,
+                per_page,
+                offset
+            )
+            .fetch_all(self.pool.as_ref())
+            .await?
+        } else {
+            sqlx::query_as!(
+                AdminProductionAccessRequestSummary,
+                r#"
+                SELECT 
+                    par.id,
+                    par.application_id,
+                    da.name as "application_name!",
+                    par.developer_account_id,
+                    dev.email as "developer_email!",
+                    par.production_use_case,
+                    par.expected_transaction_volume,
+                    par.supported_countries,
+                    par.status,
+                    par.created_at
+                FROM production_access_requests par
+                JOIN developer_applications da ON par.application_id = da.id
+                JOIN developer_accounts dev ON par.developer_account_id = dev.id
+                ORDER BY par.created_at DESC
+                LIMIT $1 OFFSET $2
+                "#,
+                per_page,
+                offset
+            )
+            .fetch_all(self.pool.as_ref())
+            .await?
+        };
+
+        let total_count = if let Some(status_filter) = status {
+            sqlx::query_scalar!(
+                "SELECT COUNT(*) FROM production_access_requests WHERE status = $1",
+                status_filter
+            )
+            .fetch_one(self.pool.as_ref())
+            .await?
+        } else {
+            sqlx::query_scalar!(
+                "SELECT COUNT(*) FROM production_access_requests"
+            )
+            .fetch_one(self.pool.as_ref())
+            .await?
+        };
+
+        let total_count = total_count.unwrap_or(0);
+        let pending_count = sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM production_access_requests WHERE status = 'pending'"
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        let pending_count = pending_count.unwrap_or(0);
+
+        Ok(AdminProductionAccessQueue {
+            requests,
+            total_count,
+            pending_count,
+        })
+    }
+}

--- a/src/developer_portal/repositories.rs
+++ b/src/developer_portal/repositories.rs
@@ -1,0 +1,946 @@
+use super::models::*;
+use crate::database::error::DatabaseError;
+use crate::database::repository::Repository;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct DeveloperAccountRepository {
+    pool: Arc<PgPool>,
+}
+
+impl DeveloperAccountRepository {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        request: CreateDeveloperAccountRequest,
+        email_verification_token: Option<String>,
+        email_verification_expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            INSERT INTO developer_accounts (
+                email, full_name, organisation, country, use_case_description,
+                status_code, access_tier_code, email_verified,
+                email_verification_token, email_verification_expires_at
+            ) VALUES ($1, $2, $3, $4, $5, 'unverified', 'sandbox', false, $6, $7)
+            RETURNING *
+            "#,
+            request.email,
+            request.full_name,
+            request.organisation,
+            request.country,
+            request.use_case_description,
+            email_verification_token,
+            email_verification_expires_at
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn find_by_email(&self, email: &str) -> Result<Option<DeveloperAccount>, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            "SELECT * FROM developer_accounts WHERE email = $1",
+            email
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<DeveloperAccount>, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            "SELECT * FROM developer_accounts WHERE id = $1",
+            id
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn find_by_verification_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<DeveloperAccount>, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            "SELECT * FROM developer_accounts WHERE email_verification_token = $1",
+            token
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn verify_email(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET email_verified = true,
+                email_verification_token = NULL,
+                email_verification_expires_at = NULL,
+                status_code = 'verified',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn update_identity_verification(
+        &self,
+        account_id: Uuid,
+        verification_data: IdentityVerificationRequest,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let identity_data = serde_json::to_value(verification_data)?;
+        
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET identity_verification_status = 'pending',
+                identity_verification_data = $1,
+                updated_at = now()
+            WHERE id = $2
+            RETURNING *
+            "#,
+            identity_data,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn approve_identity_verification(
+        &self,
+        account_id: Uuid,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET identity_verification_status = 'verified',
+                identity_verified_at = now(),
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn reject_identity_verification(
+        &self,
+        account_id: Uuid,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET identity_verification_status = 'rejected',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn upgrade_to_standard_tier(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET access_tier_code = 'standard',
+                status_code = 'active',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn upgrade_to_partner_tier(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET access_tier_code = 'partner',
+                status_code = 'active',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn suspend(&self, account_id: Uuid, reason: &str) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET status_code = 'suspended',
+                suspended_at = now(),
+                suspension_reason = $1,
+                updated_at = now()
+            WHERE id = $2
+            RETURNING *
+            "#,
+            reason,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn reinstate(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET status_code = 'active',
+                suspended_at = NULL,
+                suspension_reason = NULL,
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn update(
+        &self,
+        account_id: Uuid,
+        request: UpdateDeveloperAccountRequest,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = sqlx::query_as!(
+            DeveloperAccount,
+            r#"
+            UPDATE developer_accounts 
+            SET full_name = COALESCE($1, full_name),
+                organisation = COALESCE($2, organisation),
+                country = COALESCE($3, country),
+                use_case_description = COALESCE($4, use_case_description),
+                updated_at = now()
+            WHERE id = $5
+            RETURNING *
+            "#,
+            request.full_name,
+            request.organisation,
+            request.country,
+            request.use_case_description,
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(account)
+    }
+
+    pub async fn get_application_count(&self, account_id: Uuid) -> Result<i64, DeveloperPortalError> {
+        let count = sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM developer_applications WHERE developer_account_id = $1 AND status != 'deleted'",
+            account_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(count.unwrap_or(0))
+    }
+
+    pub async fn list_for_admin(
+        &self,
+        page: i64,
+        per_page: i64,
+    ) -> Result<AdminDeveloperAccountList, DeveloperPortalError> {
+        let offset = (page - 1) * per_page;
+
+        let accounts = sqlx::query_as!(
+            AdminDeveloperAccountSummary,
+            r#"
+            SELECT 
+                da.id,
+                da.email,
+                da.full_name,
+                da.organisation,
+                da.country,
+                da.status_code,
+                da.access_tier_code,
+                da.email_verified,
+                da.identity_verification_status,
+                COALESCE(app_count.count, 0) as "application_count!",
+                da.created_at,
+                da.updated_at as "last_activity?"
+            FROM developer_accounts da
+            LEFT JOIN (
+                SELECT developer_account_id, COUNT(*) as count
+                FROM developer_applications
+                WHERE status != 'deleted'
+                GROUP BY developer_account_id
+            ) app_count ON da.id = app_count.developer_account_id
+            ORDER BY da.created_at DESC
+            LIMIT $1 OFFSET $2
+            "#,
+            per_page,
+            offset
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        let total_count = sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM developer_accounts"
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        let total_count = total_count.unwrap_or(0);
+        let total_pages = (total_count + per_page - 1) / per_page;
+
+        Ok(AdminDeveloperAccountList {
+            accounts,
+            total_count,
+            page,
+            per_page,
+            total_pages,
+        })
+    }
+
+    pub async fn get_access_tier(&self, tier_code: &str) -> Result<Option<AccessTier>, DeveloperPortalError> {
+        let tier = sqlx::query_as!(
+            AccessTier,
+            "SELECT * FROM access_tiers WHERE code = $1",
+            tier_code
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(tier)
+    }
+}
+
+#[derive(Clone)]
+pub struct DeveloperApplicationRepository {
+    pool: Arc<PgPool>,
+}
+
+impl DeveloperApplicationRepository {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        developer_account_id: Uuid,
+        request: CreateApplicationRequest,
+    ) -> Result<DeveloperApplication, DeveloperPortalError> {
+        let application = sqlx::query_as!(
+            DeveloperApplication,
+            r#"
+            INSERT INTO developer_applications (
+                developer_account_id, name, description, intended_use_case
+            ) VALUES ($1, $2, $3, $4)
+            RETURNING *
+            "#,
+            developer_account_id,
+            request.name,
+            request.description,
+            request.intended_use_case
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(application)
+    }
+
+    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<DeveloperApplication>, DeveloperPortalError> {
+        let application = sqlx::query_as!(
+            DeveloperApplication,
+            "SELECT * FROM developer_applications WHERE id = $1",
+            id
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(application)
+    }
+
+    pub async fn find_by_developer_account(
+        &self,
+        developer_account_id: Uuid,
+    ) -> Result<Vec<DeveloperApplication>, DeveloperPortalError> {
+        let applications = sqlx::query_as!(
+            DeveloperApplication,
+            "SELECT * FROM developer_applications WHERE developer_account_id = $1 AND status != 'deleted' ORDER BY created_at DESC",
+            developer_account_id
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(applications)
+    }
+
+    pub async fn update(
+        &self,
+        application_id: Uuid,
+        request: UpdateApplicationRequest,
+    ) -> Result<DeveloperApplication, DeveloperPortalError> {
+        let application = sqlx::query_as!(
+            DeveloperApplication,
+            r#"
+            UPDATE developer_applications 
+            SET name = COALESCE($1, name),
+                description = COALESCE($2, description),
+                intended_use_case = COALESCE($3, intended_use_case),
+                updated_at = now()
+            WHERE id = $4
+            RETURNING *
+            "#,
+            request.name,
+            request.description,
+            request.intended_use_case,
+            application_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(application)
+    }
+
+    pub async fn soft_delete(&self, application_id: Uuid) -> Result<DeveloperApplication, DeveloperPortalError> {
+        let application = sqlx::query_as!(
+            DeveloperApplication,
+            r#"
+            UPDATE developer_applications 
+            SET status = 'deleted',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            application_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(application)
+    }
+
+    pub async fn update_sandbox_wallet(
+        &self,
+        application_id: Uuid,
+        wallet_address: &str,
+        wallet_secret: &str,
+    ) -> Result<DeveloperApplication, DeveloperPortalError> {
+        let application = sqlx::query_as!(
+            DeveloperApplication,
+            r#"
+            UPDATE developer_applications 
+            SET sandbox_wallet_address = $1,
+                sandbox_wallet_secret = $2,
+                updated_at = now()
+            WHERE id = $3
+            RETURNING *
+            "#,
+            wallet_address,
+            wallet_secret,
+            application_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(application)
+    }
+
+    pub async fn clear_sandbox_wallet(&self, application_id: Uuid) -> Result<DeveloperApplication, DeveloperPortalError> {
+        let application = sqlx::query_as!(
+            DeveloperApplication,
+            r#"
+            UPDATE developer_applications 
+            SET sandbox_wallet_address = NULL,
+                sandbox_wallet_secret = NULL,
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            application_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(application)
+    }
+}
+
+#[derive(Clone)]
+pub struct ApiKeyRepository {
+    pool: Arc<PgPool>,
+}
+
+impl ApiKeyRepository {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        application_id: Uuid,
+        request: CreateApiKeyRequest,
+        key_prefix: &str,
+        key_hash: &str,
+    ) -> Result<ApiKey, DeveloperPortalError> {
+        let api_key = sqlx::query_as!(
+            ApiKey,
+            r#"
+            INSERT INTO api_keys (
+                application_id, key_prefix, key_hash, key_name, environment,
+                expires_at, rate_limit_per_minute
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING *
+            "#,
+            application_id,
+            key_prefix,
+            key_hash,
+            request.key_name,
+            request.environment,
+            request.expires_at,
+            request.rate_limit_per_minute.unwrap_or(100)
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(api_key)
+    }
+
+    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<ApiKey>, DeveloperPortalError> {
+        let api_key = sqlx::query_as!(
+            ApiKey,
+            "SELECT * FROM api_keys WHERE id = $1",
+            id
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(api_key)
+    }
+
+    pub async fn find_by_key_hash(&self, key_hash: &str) -> Result<Option<ApiKey>, DeveloperPortalError> {
+        let api_key = sqlx::query_as!(
+            ApiKey,
+            "SELECT * FROM api_keys WHERE key_hash = $1 AND status = 'active'",
+            key_hash
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(api_key)
+    }
+
+    pub async fn find_by_application(&self, application_id: Uuid) -> Result<Vec<ApiKey>, DeveloperPortalError> {
+        let api_keys = sqlx::query_as!(
+            ApiKey,
+            "SELECT * FROM api_keys WHERE application_id = $1 ORDER BY created_at DESC",
+            application_id
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(api_keys)
+    }
+
+    pub async fn revoke(&self, api_key_id: Uuid) -> Result<ApiKey, DeveloperPortalError> {
+        let api_key = sqlx::query_as!(
+            ApiKey,
+            r#"
+            UPDATE api_keys 
+            SET status = 'revoked',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            api_key_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(api_key)
+    }
+
+    pub async fn update_usage(&self, api_key_id: Uuid) -> Result<(), DeveloperPortalError> {
+        sqlx::query!(
+            r#"
+            UPDATE api_keys 
+            SET usage_count = usage_count + 1,
+                last_used_at = now(),
+                updated_at = now()
+            WHERE id = $1
+            "#,
+            api_key_id
+        )
+        .execute(self.pool.as_ref())
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn revoke_by_application(&self, application_id: Uuid, environment: &str) -> Result<(), DeveloperPortalError> {
+        sqlx::query!(
+            r#"
+            UPDATE api_keys 
+            SET status = 'revoked',
+                updated_at = now()
+            WHERE application_id = $1 AND environment = $2
+            "#,
+            application_id,
+            environment
+        )
+        .execute(self.pool.as_ref())
+        .await?;
+
+        Ok(())
+    }
+}
+
+/// Repository for OAuth client CRUD operations.
+#[derive(Clone)]
+pub struct OAuthClientRepository {
+    pool: Arc<PgPool>,
+}
+
+impl OAuthClientRepository {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        application_id: Uuid,
+        client_id: &str,
+        client_secret_hash: &str,
+        request: CreateOAuthClientRequest,
+    ) -> Result<OAuthClient, DeveloperPortalError> {
+        let client = sqlx::query_as!(
+            OAuthClient,
+            r#"
+            INSERT INTO oauth_clients (
+                application_id, client_id, client_secret_hash, client_name,
+                environment, redirect_uris, scopes
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING *
+            "#,
+            application_id,
+            client_id,
+            client_secret_hash,
+            request.client_name,
+            request.environment,
+            &request.redirect_uris,
+            &request.scopes
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(client)
+    }
+
+    pub async fn find_by_application_and_environment(
+        &self,
+        application_id: Uuid,
+        environment: &str,
+    ) -> Result<Vec<OAuthClient>, DeveloperPortalError> {
+        let clients = sqlx::query_as!(
+            OAuthClient,
+            "SELECT * FROM oauth_clients WHERE application_id = $1 AND environment = $2 AND status = 'active' ORDER BY created_at DESC",
+            application_id,
+            environment
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(clients)
+    }
+
+    pub async fn revoke_by_application_and_environment(
+        &self,
+        application_id: Uuid,
+        environment: &str,
+    ) -> Result<(), DeveloperPortalError> {
+        sqlx::query!(
+            r#"
+            UPDATE oauth_clients
+            SET status = 'revoked', updated_at = now()
+            WHERE application_id = $1 AND environment = $2
+            "#,
+            application_id,
+            environment
+        )
+        .execute(self.pool.as_ref())
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn rotate_secret(
+        &self,
+        client_id_str: &str,
+        new_secret_hash: &str,
+    ) -> Result<OAuthClient, DeveloperPortalError> {
+        let client = sqlx::query_as!(
+            OAuthClient,
+            r#"
+            UPDATE oauth_clients
+            SET client_secret_hash = $1, updated_at = now()
+            WHERE client_id = $2
+            RETURNING *
+            "#,
+            new_secret_hash,
+            client_id_str
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(client)
+    }
+
+    pub async fn update_redirect_uris(
+        &self,
+        client_id_str: &str,
+        redirect_uris: &[String],
+    ) -> Result<OAuthClient, DeveloperPortalError> {
+        let client = sqlx::query_as!(
+            OAuthClient,
+            r#"
+            UPDATE oauth_clients
+            SET redirect_uris = $1, updated_at = now()
+            WHERE client_id = $2
+            RETURNING *
+            "#,
+            redirect_uris,
+            client_id_str
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(client)
+    }
+}
+
+/// Extension methods on DeveloperApplicationRepository for usage analytics queries.
+impl DeveloperApplicationRepository {
+    pub async fn get_usage_metrics(
+        &self,
+        application_id: Uuid,
+        start: chrono::DateTime<chrono::Utc>,
+        end: chrono::DateTime<chrono::Utc>,
+        environment: Option<&str>,
+    ) -> Result<super::models::UsageMetrics, DeveloperPortalError> {
+        struct Row {
+            total_requests: Option<i64>,
+            successful_requests: Option<i64>,
+            failed_requests: Option<i64>,
+            avg_response_time: Option<f64>,
+        }
+
+        let row = if let Some(env) = environment {
+            sqlx::query!(
+                r#"
+                SELECT
+                    COUNT(*) as total_requests,
+                    COUNT(CASE WHEN status_code < 400 THEN 1 END) as successful_requests,
+                    COUNT(CASE WHEN status_code >= 400 THEN 1 END) as failed_requests,
+                    AVG(response_time_ms::float8) as avg_response_time
+                FROM usage_statistics
+                WHERE application_id = $1
+                  AND timestamp BETWEEN $2 AND $3
+                  AND environment = $4
+                "#,
+                application_id,
+                start,
+                end,
+                env
+            )
+            .fetch_one(self.pool.as_ref())
+            .await
+            .map(|r| (r.total_requests, r.successful_requests, r.failed_requests, r.avg_response_time))?
+        } else {
+            sqlx::query!(
+                r#"
+                SELECT
+                    COUNT(*) as total_requests,
+                    COUNT(CASE WHEN status_code < 400 THEN 1 END) as successful_requests,
+                    COUNT(CASE WHEN status_code >= 400 THEN 1 END) as failed_requests,
+                    AVG(response_time_ms::float8) as avg_response_time
+                FROM usage_statistics
+                WHERE application_id = $1
+                  AND timestamp BETWEEN $2 AND $3
+                "#,
+                application_id,
+                start,
+                end
+            )
+            .fetch_one(self.pool.as_ref())
+            .await
+            .map(|r| (r.total_requests, r.successful_requests, r.failed_requests, r.avg_response_time))?
+        };
+
+        let total = row.0.unwrap_or(0);
+        let success = row.1.unwrap_or(0);
+        let failed = row.2.unwrap_or(0);
+        let avg_rt = row.3.unwrap_or(0.0);
+        let error_rate = if total > 0 { (failed as f64 / total as f64) * 100.0 } else { 0.0 };
+        // rate_limit_utilization is approximate — left as 0 without a Redis counter
+        let rate_limit_utilization = 0.0;
+        // requests_per_minute over the window
+        let window_minutes = (end - start).num_minutes().max(1);
+        let rpm = total / window_minutes;
+
+        Ok(super::models::UsageMetrics {
+            total_requests: total,
+            successful_requests: success,
+            failed_requests: failed,
+            average_response_time: avg_rt,
+            requests_per_minute: rpm,
+            rate_limit_utilization,
+            error_rate,
+        })
+    }
+
+    pub async fn get_endpoint_breakdown(
+        &self,
+        application_id: Uuid,
+        start: chrono::DateTime<chrono::Utc>,
+        end: chrono::DateTime<chrono::Utc>,
+        environment: Option<&str>,
+    ) -> Result<Vec<super::models::EndpointUsage>, DeveloperPortalError> {
+        // Use a raw query since the env filter is optional
+        let rows = sqlx::query!(
+            r#"
+            SELECT
+                endpoint,
+                method,
+                COUNT(*) as request_count,
+                AVG(response_time_ms::float8) as avg_rt,
+                COUNT(CASE WHEN status_code >= 400 THEN 1 END)::float8 / NULLIF(COUNT(*), 0) * 100 as error_rate
+            FROM usage_statistics
+            WHERE application_id = $1
+              AND timestamp BETWEEN $2 AND $3
+              AND ($4::text IS NULL OR environment = $4)
+            GROUP BY endpoint, method
+            ORDER BY request_count DESC
+            "#,
+            application_id,
+            start,
+            end,
+            environment
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        let breakdown = rows
+            .into_iter()
+            .map(|r| super::models::EndpointUsage {
+                endpoint: r.endpoint,
+                method: r.method,
+                request_count: r.request_count.unwrap_or(0),
+                average_response_time: r.avg_rt.unwrap_or(0.0),
+                error_rate: r.error_rate.unwrap_or(0.0),
+            })
+            .collect();
+
+        Ok(breakdown)
+    }
+
+    pub async fn get_time_series(
+        &self,
+        application_id: Uuid,
+        start: chrono::DateTime<chrono::Utc>,
+        end: chrono::DateTime<chrono::Utc>,
+        environment: Option<&str>,
+        granularity: Option<&str>,
+    ) -> Result<Vec<super::models::TimeSeriesDataPoint>, DeveloperPortalError> {
+        let trunc = match granularity {
+            Some("daily") => "day",
+            Some("weekly") => "week",
+            _ => "hour",
+        };
+
+        let rows = sqlx::query!(
+            r#"
+            SELECT
+                date_trunc($5, timestamp) as bucket,
+                COUNT(*) as request_count,
+                AVG(response_time_ms::float8) as avg_rt,
+                COUNT(CASE WHEN status_code >= 400 THEN 1 END)::float8 / NULLIF(COUNT(*), 0) * 100 as error_rate
+            FROM usage_statistics
+            WHERE application_id = $1
+              AND timestamp BETWEEN $2 AND $3
+              AND ($4::text IS NULL OR environment = $4)
+            GROUP BY bucket
+            ORDER BY bucket
+            "#,
+            application_id,
+            start,
+            end,
+            environment,
+            trunc
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        let series = rows
+            .into_iter()
+            .filter_map(|r| {
+                r.bucket.map(|b| super::models::TimeSeriesDataPoint {
+                    timestamp: b,
+                    request_count: r.request_count.unwrap_or(0),
+                    average_response_time: r.avg_rt.unwrap_or(0.0),
+                    error_rate: r.error_rate.unwrap_or(0.0),
+                })
+            })
+            .collect();
+
+        Ok(series)
+    }
+}

--- a/src/developer_portal/routes.rs
+++ b/src/developer_portal/routes.rs
@@ -1,0 +1,62 @@
+use crate::developer_portal::{DeveloperService, ProductionAccessService, repositories::{DeveloperAccountRepository, DeveloperApplicationRepository, ApiKeyRepository, ProductionAccessRequestRepository, WebhookConfigurationRepository}};
+use crate::database::PgPool;
+use std::sync::Arc;
+use axum::{Router, middleware};
+use tower::ServiceBuilder;
+
+pub struct DeveloperPortalState {
+    pub developer_service: Arc<DeveloperService>,
+    pub production_access_service: Arc<ProductionAccessService>,
+}
+
+impl DeveloperPortalState {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        let developer_account_repo = DeveloperAccountRepository::new(pool.clone());
+        let application_repo = DeveloperApplicationRepository::new(pool.clone());
+        let api_key_repo = ApiKeyRepository::new(pool.clone());
+        let production_access_repo = ProductionAccessRequestRepository::new(pool.clone());
+        let webhook_repo = WebhookConfigurationRepository::new(pool.clone());
+        
+        let developer_service = Arc::new(DeveloperService::new(
+            developer_account_repo.clone(),
+            application_repo.clone(),
+            api_key_repo.clone(),
+        ));
+
+        let production_access_service = Arc::new(ProductionAccessService::new(
+            developer_account_repo,
+            application_repo,
+            production_access_repo,
+            webhook_repo,
+        ));
+
+        Self {
+            developer_service,
+            production_access_service,
+        }
+    }
+}
+
+pub fn create_developer_portal_routes(state: Arc<DeveloperPortalState>) -> Router {
+    let services = (state.developer_service.clone(), state.production_access_service.clone());
+    
+    Router::new()
+        .nest("/api/developer", crate::developer_portal::handlers::developer_portal_routes())
+        .nest("/api/admin/developer-portal", crate::developer_portal::admin_handlers::admin_developer_portal_routes())
+        .layer(
+            ServiceBuilder::new()
+                .middleware(middleware::from_fn_with_state(
+                    state.developer_service.clone(),
+                    crate::developer_portal::middleware::usage_logging_middleware
+                ))
+        )
+        .with_state(services)
+}
+
+// Add this to your main router setup
+pub fn register_developer_portal_routes(router: Router<Arc<crate::config::AppConfig>>, pool: Arc<PgPool>) -> Router<Arc<crate::config::AppConfig>> {
+    let developer_portal_state = Arc::new(DeveloperPortalState::new(pool));
+    let developer_routes = create_developer_portal_routes(developer_portal_state);
+    
+    router.merge(developer_routes)
+}

--- a/src/developer_portal/sandbox_service.rs
+++ b/src/developer_portal/sandbox_service.rs
@@ -1,0 +1,448 @@
+use super::models::*;
+use super::repositories::{DeveloperApplicationRepository, ApiKeyRepository, OAuthClientRepository, WebhookConfigurationRepository};
+use crate::database::error::DatabaseError;
+use chrono::Utc;
+use rand::Rng;
+use serde_json::json;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct SandboxService {
+    application_repo: DeveloperApplicationRepository,
+    api_key_repo: ApiKeyRepository,
+    oauth_client_repo: OAuthClientRepository,
+    webhook_repo: WebhookConfigurationRepository,
+}
+
+impl SandboxService {
+    pub fn new(
+        application_repo: DeveloperApplicationRepository,
+        api_key_repo: ApiKeyRepository,
+        oauth_client_repo: OAuthClientRepository,
+        webhook_repo: WebhookConfigurationRepository,
+    ) -> Self {
+        Self {
+            application_repo,
+            api_key_repo,
+            oauth_client_repo,
+            webhook_repo,
+        }
+    }
+
+    pub async fn provision_sandbox_environment(
+        &self,
+        application_id: Uuid,
+    ) -> Result<SandboxEnvironment, DeveloperPortalError> {
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?
+            .ok_or(DeveloperPortalError::ApplicationNotFound)?;
+
+        // Generate Stellar testnet wallet
+        let (wallet_address, wallet_secret) = self.generate_stellar_testnet_wallet()?;
+
+        // Update application with sandbox wallet
+        self.application_repo
+            .update_sandbox_wallet(application_id, &wallet_address, &wallet_secret)
+            .await?;
+
+        // Create sandbox API keys
+        let sandbox_api_keys = self.create_sandbox_api_keys(application_id).await?;
+
+        // Create sandbox OAuth clients
+        let sandbox_oauth_clients = self.create_sandbox_oauth_clients(application_id).await?;
+
+        let sandbox_env = SandboxEnvironment {
+            wallet_address,
+            wallet_secret,
+            network: "testnet".to_string(),
+            initial_balance: "10000.0000000".to_string(), // 10,000 XLM testnet
+            api_keys: sandbox_api_keys,
+            oauth_clients: sandbox_oauth_clients,
+        };
+
+        info!(
+            "Sandbox environment provisioned for application: {}",
+            application.name
+        );
+
+        Ok(sandbox_env)
+    }
+
+    pub async fn reset_sandbox_environment(
+        &self,
+        application_id: Uuid,
+    ) -> Result<SandboxEnvironment, DeveloperPortalError> {
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?
+            .ok_or(DeveloperPortalError::ApplicationNotFound)?;
+
+        // Revoke all existing sandbox credentials
+        self.revoke_sandbox_credentials(application_id).await?;
+
+        // Clear existing sandbox wallet
+        self.application_repo.clear_sandbox_wallet(application_id).await?;
+
+        // Provision fresh sandbox environment
+        let new_env = self.provision_sandbox_environment(application_id).await?;
+
+        info!(
+            "Sandbox environment reset for application: {}",
+            application.name
+        );
+
+        Ok(new_env)
+    }
+
+    pub async fn get_sandbox_environment(
+        &self,
+        application_id: Uuid,
+    ) -> Result<Option<SandboxEnvironment>, DeveloperPortalError> {
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?;
+
+        if let Some(app) = application {
+            if let (Some(wallet_address), Some(wallet_secret)) = 
+                (app.sandbox_wallet_address, app.sandbox_wallet_secret) {
+                
+                // Get sandbox API keys
+                let api_keys = self
+                    .api_key_repo
+                    .find_by_application_and_environment(application_id, "sandbox")
+                    .await?;
+
+                let sandbox_api_keys = api_keys.into_iter().map(|key| SandboxApiKey {
+                    key_id: key.id,
+                    key_name: key.key_name,
+                    api_key: format!("{}_{}", key.key_prefix, self.generate_api_key_suffix()), // In real implementation, store full key
+                    rate_limit_per_minute: key.rate_limit_per_minute,
+                }).collect();
+
+                // Get sandbox OAuth clients
+                let oauth_clients = self
+                    .get_sandbox_oauth_clients(application_id)
+                    .await?;
+
+                Ok(Some(SandboxEnvironment {
+                    wallet_address,
+                    wallet_secret,
+                    network: "testnet".to_string(),
+                    initial_balance: "10000.0000000".to_string(),
+                    api_keys: sandbox_api_keys,
+                    oauth_clients,
+                }))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn revoke_sandbox_credentials(&self, application_id: Uuid) -> Result<(), DeveloperPortalError> {
+        // Revoke sandbox API keys
+        self.api_key_repo
+            .revoke_by_application(application_id, "sandbox")
+            .await?;
+
+        // Revoke sandbox OAuth clients
+        self.revoke_sandbox_oauth_clients(application_id).await?;
+
+        Ok(())
+    }
+
+    async fn create_sandbox_api_keys(
+        &self,
+        application_id: Uuid,
+    ) -> Result<Vec<SandboxApiKey>, DeveloperPortalError> {
+        let mut api_keys = Vec::new();
+
+        // Create default sandbox API key
+        let default_key_request = CreateApiKeyRequest {
+            key_name: "Default Sandbox Key".to_string(),
+            environment: "sandbox".to_string(),
+            expires_at: None,
+            rate_limit_per_minute: Some(50),
+        };
+
+        let (api_key, raw_key) = self
+            .create_api_key_internal(application_id, default_key_request)
+            .await?;
+
+        api_keys.push(SandboxApiKey {
+            key_id: api_key.id,
+            key_name: api_key.key_name,
+            api_key: raw_key,
+            rate_limit_per_minute: api_key.rate_limit_per_minute,
+        });
+
+        // Create read-only sandbox API key
+        let readonly_key_request = CreateApiKeyRequest {
+            key_name: "Read-only Sandbox Key".to_string(),
+            environment: "sandbox".to_string(),
+            expires_at: None,
+            rate_limit_per_minute: Some(100),
+        };
+
+        let (api_key, raw_key) = self
+            .create_api_key_internal(application_id, readonly_key_request)
+            .await?;
+
+        api_keys.push(SandboxApiKey {
+            key_id: api_key.id,
+            key_name: api_key.key_name,
+            api_key: raw_key,
+            rate_limit_per_minute: api_key.rate_limit_per_minute,
+        });
+
+        Ok(api_keys)
+    }
+
+    async fn create_sandbox_oauth_clients(
+        &self,
+        application_id: Uuid,
+    ) -> Result<Vec<SandboxOAuthClient>, DeveloperPortalError> {
+        let mut oauth_clients = Vec::new();
+
+        // Create default sandbox OAuth client
+        let default_client_request = CreateOAuthClientRequest {
+            client_name: "Default Sandbox Client".to_string(),
+            environment: "sandbox".to_string(),
+            redirect_uris: vec![
+                "http://localhost:3000/callback".to_string(),
+                "http://localhost:8080/callback".to_string(),
+            ],
+            scopes: vec![
+                "read".to_string(),
+                "write".to_string(),
+                "sandbox".to_string(),
+            ],
+        };
+
+        let (client, client_secret) = self
+            .create_oauth_client_internal(application_id, default_client_request)
+            .await?;
+
+        oauth_clients.push(SandboxOAuthClient {
+            client_id: client.client_id,
+            client_name: client.client_name,
+            client_secret,
+            redirect_uris: client.redirect_uris,
+            scopes: client.scopes,
+        });
+
+        Ok(oauth_clients)
+    }
+
+    async fn create_api_key_internal(
+        &self,
+        application_id: Uuid,
+        request: CreateApiKeyRequest,
+    ) -> Result<(ApiKey, String), DeveloperPortalError> {
+        // Generate API key
+        let raw_key = self.generate_api_key();
+        let key_prefix = &raw_key[..8];
+        let key_hash = self.hash_api_key(&raw_key)?;
+
+        // Create API key record
+        let api_key = self
+            .api_key_repo
+            .create(application_id, request, key_prefix, &key_hash)
+            .await?;
+
+        Ok((api_key, raw_key))
+    }
+
+    async fn create_oauth_client_internal(
+        &self,
+        application_id: Uuid,
+        request: CreateOAuthClientRequest,
+    ) -> Result<(OAuthClient, String), DeveloperPortalError> {
+        // Generate OAuth client credentials
+        let client_id = self.generate_oauth_client_id();
+        let client_secret = self.generate_oauth_client_secret();
+        let client_secret_hash = self.hash_client_secret(&client_secret)?;
+
+        // Create OAuth client record
+        let client = self
+            .create_oauth_client(application_id, &client_id, &client_secret_hash, request)
+            .await?;
+
+        Ok((client, client_secret))
+    }
+
+    fn generate_stellar_testnet_wallet(&self) -> Result<(String, String), DeveloperPortalError> {
+        // In a real implementation, this would integrate with Stellar SDK
+        // For now, generate mock testnet credentials
+        let mut rng = rand::thread_rng();
+        
+        // Generate a mock Stellar address (56 characters for testnet)
+        let address: String = (0..56)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect();
+
+        // Generate a mock secret key (56 characters starting with S for testnet)
+        let secret = format!("S{}", (0..55)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect::<String>());
+
+        Ok((address, secret))
+    }
+
+    fn generate_api_key(&self) -> String {
+        let mut rng = rand::thread_rng();
+        let prefix = "ak_";
+        let key_part: String = (0..32)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect();
+
+        format!("{}{}", prefix, key_part)
+    }
+
+    fn generate_api_key_suffix(&self) -> String {
+        let mut rng = rand::thread_rng();
+        (0..24)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect()
+    }
+
+    fn generate_oauth_client_id(&self) -> String {
+        let mut rng = rand::thread_rng();
+        let prefix = "client_";
+        let id_part: String = (0..16)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect();
+
+        format!("{}{}", prefix, id_part)
+    }
+
+    fn generate_oauth_client_secret(&self) -> String {
+        let mut rng = rand::thread_rng();
+        (0..32)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect()
+    }
+
+    fn hash_api_key(&self, api_key: &str) -> Result<String, DeveloperPortalError> {
+        use argon2::{Argon2, PasswordHash, PasswordHasher};
+        use argon2::password_hash::{rand_core::OsRng, SaltString};
+
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        
+        let password_hash = argon2
+            .hash_password(api_key.as_bytes(), &salt)
+            .map_err(|e| DeveloperPortalError::Crypto(e.to_string()))?;
+
+        Ok(password_hash.to_string())
+    }
+
+    fn hash_client_secret(&self, client_secret: &str) -> Result<String, DeveloperPortalError> {
+        use argon2::{Argon2, PasswordHash, PasswordHasher};
+        use argon2::password_hash::{rand_core::OsRng, SaltString};
+
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        
+        let password_hash = argon2
+            .hash_password(client_secret.as_bytes(), &salt)
+            .map_err(|e| DeveloperPortalError::Crypto(e.to_string()))?;
+
+        Ok(password_hash.to_string())
+    }
+
+    async fn create_oauth_client(
+        &self,
+        application_id: Uuid,
+        client_id: &str,
+        client_secret_hash: &str,
+        request: CreateOAuthClientRequest,
+    ) -> Result<OAuthClient, DeveloperPortalError> {
+        self.oauth_client_repo
+            .create(application_id, client_id, client_secret_hash, request)
+            .await
+    }
+
+    async fn get_sandbox_oauth_clients(
+        &self,
+        application_id: Uuid,
+    ) -> Result<Vec<SandboxOAuthClient>, DeveloperPortalError> {
+        let clients = self
+            .oauth_client_repo
+            .find_by_application_and_environment(application_id, "sandbox")
+            .await?;
+
+        let sandbox_clients = clients
+            .into_iter()
+            .map(|c| SandboxOAuthClient {
+                client_id: c.client_id,
+                client_name: c.client_name,
+                // Secret is not stored in plain-text — callers receive it only at creation time
+                client_secret: "[redacted]".to_string(),
+                redirect_uris: c.redirect_uris,
+                scopes: c.scopes,
+            })
+            .collect();
+
+        Ok(sandbox_clients)
+    }
+
+    async fn revoke_sandbox_oauth_clients(&self, application_id: Uuid) -> Result<(), DeveloperPortalError> {
+        self.oauth_client_repo
+            .revoke_by_application_and_environment(application_id, "sandbox")
+            .await
+    }
+}
+
+// Extension trait for ApiKeyRepository to support environment filtering
+pub trait ApiKeyRepositoryExt {
+    async fn find_by_application_and_environment(
+        &self,
+        application_id: Uuid,
+        environment: &str,
+    ) -> Result<Vec<ApiKey>, DeveloperPortalError>;
+}
+
+impl ApiKeyRepositoryExt for super::repositories::ApiKeyRepository {
+    async fn find_by_application_and_environment(
+        &self,
+        application_id: Uuid,
+        environment: &str,
+    ) -> Result<Vec<ApiKey>, DeveloperPortalError> {
+        let api_keys = sqlx::query_as!(
+            ApiKey,
+            "SELECT * FROM api_keys WHERE application_id = $1 AND environment = $2 ORDER BY created_at DESC",
+            application_id,
+            environment
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(api_keys)
+    }
+}

--- a/src/developer_portal/services.rs
+++ b/src/developer_portal/services.rs
@@ -1,0 +1,627 @@
+use super::models::*;
+use super::repositories::{DeveloperAccountRepository, DeveloperApplicationRepository, ApiKeyRepository};
+use crate::database::error::DatabaseError;
+use crate::error::AppError;
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use argon2::password_hash::{rand_core::OsRng, SaltString};
+use chrono::{DateTime, Duration, Utc};
+use rand::Rng;
+use serde_json::json;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+const EMAIL_VERIFICATION_TOKEN_LENGTH: usize = 32;
+const EMAIL_VERIFICATION_EXPIRY_HOURS: i64 = 24;
+const BLOCKED_COUNTRIES: &[&str] = &["XX", "ZZ"]; // Add actual blocked country codes
+
+#[derive(Clone)]
+pub struct DeveloperService {
+    pub developer_account_repo: DeveloperAccountRepository,
+    pub application_repo: DeveloperApplicationRepository,
+    pub api_key_repo: ApiKeyRepository,
+}
+
+impl DeveloperService {
+    pub fn new(
+        developer_account_repo: DeveloperAccountRepository,
+        application_repo: DeveloperApplicationRepository,
+        api_key_repo: ApiKeyRepository,
+    ) -> Self {
+        Self {
+            developer_account_repo,
+            application_repo,
+            api_key_repo,
+        }
+    }
+
+    pub async fn register_developer(
+        &self,
+        request: CreateDeveloperAccountRequest,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        // Check if email is already registered
+        if let Some(_) = self.developer_account_repo.find_by_email(&request.email).await? {
+            return Err(DeveloperPortalError::EmailAlreadyRegistered);
+        }
+
+        // Check geo-restrictions
+        if BLOCKED_COUNTRIES.contains(&request.country.as_str()) {
+            return Err(DeveloperPortalError::GeoRestrictedCountry);
+        }
+
+        // Generate email verification token
+        let verification_token = self.generate_verification_token();
+        let verification_expires_at = Utc::now() + Duration::hours(EMAIL_VERIFICATION_EXPIRY_HOURS);
+
+        // Create developer account
+        let account = self
+            .developer_account_repo
+            .create(request, Some(verification_token.clone()), Some(verification_expires_at))
+            .await?;
+
+        // TODO: Send verification email
+        info!(
+            "Developer account created: {} - verification token: {}",
+            account.email, verification_token
+        );
+
+        Ok(account)
+    }
+
+    pub async fn verify_email(&self, token: &str) -> Result<DeveloperAccount, DeveloperPortalError> {
+        // Find account by verification token
+        let account = self
+            .developer_account_repo
+            .find_by_verification_token(token)
+            .await?
+            .ok_or(DeveloperPortalError::InvalidEmailVerificationToken)?;
+
+        // Check if token has expired
+        if let Some(expires_at) = account.email_verification_expires_at {
+            if expires_at < Utc::now() {
+                return Err(DeveloperPortalError::EmailVerificationTokenExpired);
+            }
+        } else {
+            return Err(DeveloperPortalError::InvalidEmailVerificationToken);
+        }
+
+        // Verify email and grant sandbox access
+        let verified_account = self
+            .developer_account_repo
+            .verify_email(account.id)
+            .await?;
+
+        info!("Email verified for developer account: {}", verified_account.email);
+
+        Ok(verified_account)
+    }
+
+    pub async fn submit_identity_verification(
+        &self,
+        account_id: Uuid,
+        request: IdentityVerificationRequest,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        // Check if account exists and is verified
+        let account = self
+            .developer_account_repo
+            .find_by_id(account_id)
+            .await?
+            .ok_or(DeveloperPortalError::AccountNotFound)?;
+
+        if !account.email_verified {
+            return Err(DeveloperPortalError::AccountNotFound);
+        }
+
+        // Check if identity verification is already submitted
+        if account.identity_verification_status != "unverified" {
+            return Err(DeveloperPortalError::IdentityVerificationAlreadySubmitted);
+        }
+
+        // Submit identity verification
+        let updated_account = self
+            .developer_account_repo
+            .update_identity_verification(account_id, request)
+            .await?;
+
+        // TODO: Integrate with KYC provider
+        info!("Identity verification submitted for account: {}", account.email);
+
+        Ok(updated_account)
+    }
+
+    pub async fn approve_identity_verification(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .approve_identity_verification(account_id)
+            .await?;
+
+        info!("Identity verification approved for account: {}", account.email);
+
+        Ok(account)
+    }
+
+    pub async fn reject_identity_verification(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .reject_identity_verification(account_id)
+            .await?;
+
+        warn!("Identity verification rejected for account: {}", account.email);
+
+        Ok(account)
+    }
+
+    pub async fn create_application(
+        &self,
+        developer_account_id: Uuid,
+        request: CreateApplicationRequest,
+    ) -> Result<DeveloperApplication, DeveloperPortalError> {
+        // Check if developer account exists and is active
+        let account = self
+            .developer_account_repo
+            .find_by_id(developer_account_id)
+            .await?
+            .ok_or(DeveloperPortalError::AccountNotFound)?;
+
+        if account.status_code != "verified" && account.status_code != "active" {
+            return Err(DeveloperPortalError::AccountNotFound);
+        }
+
+        // Check application limit
+        let tier = self
+            .developer_account_repo
+            .get_access_tier(&account.access_tier_code)
+            .await?
+            .ok_or(DeveloperPortalError::AccessTierNotFound)?;
+
+        let current_app_count = self
+            .developer_account_repo
+            .get_application_count(developer_account_id)
+            .await?;
+
+        if current_app_count >= tier.max_applications as i64 {
+            return Err(DeveloperPortalError::MaximumApplicationsLimitReached);
+        }
+
+        // Create application
+        let application = self
+            .application_repo
+            .create(developer_account_id, request)
+            .await?;
+
+        info!(
+            "Application created: {} for developer: {}",
+            application.name, account.email
+        );
+
+        Ok(application)
+    }
+
+    pub async fn get_applications(
+        &self,
+        developer_account_id: Uuid,
+    ) -> Result<Vec<DeveloperApplication>, DeveloperPortalError> {
+        let applications = self
+            .application_repo
+            .find_by_developer_account(developer_account_id)
+            .await?;
+
+        Ok(applications)
+    }
+
+    pub async fn get_application(
+        &self,
+        application_id: Uuid,
+    ) -> Result<DeveloperApplication, DeveloperPortalError> {
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?
+            .ok_or(DeveloperPortalError::ApplicationNotFound)?;
+
+        Ok(application)
+    }
+
+    pub async fn update_application(
+        &self,
+        application_id: Uuid,
+        request: UpdateApplicationRequest,
+    ) -> Result<DeveloperApplication, DeveloperPortalError> {
+        let application = self
+            .application_repo
+            .update(application_id, request)
+            .await?;
+
+        info!("Application updated: {}", application.name);
+
+        Ok(application)
+    }
+
+    pub async fn delete_application(&self, application_id: Uuid) -> Result<(), DeveloperPortalError> {
+        // Revoke all API keys for this application
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?
+            .ok_or(DeveloperPortalError::ApplicationNotFound)?;
+
+        // Revoke sandbox credentials
+        self.api_key_repo
+            .revoke_by_application(application_id, "sandbox")
+            .await?;
+
+        // Revoke production credentials
+        self.api_key_repo
+            .revoke_by_application(application_id, "production")
+            .await?;
+
+        // Soft delete application
+        self.application_repo.soft_delete(application_id).await?;
+
+        info!("Application deleted: {}", application.name);
+
+        Ok(())
+    }
+
+    pub async fn create_api_key(
+        &self,
+        application_id: Uuid,
+        request: CreateApiKeyRequest,
+    ) -> Result<(ApiKey, String), DeveloperPortalError> {
+        // Validate environment
+        if request.environment != "sandbox" && request.environment != "production" {
+            return Err(DeveloperPortalError::InvalidEnvironment);
+        }
+
+        // Check if application exists
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?
+            .ok_or(DeveloperPortalError::ApplicationNotFound)?;
+
+        // Check if production access is allowed
+        if request.environment == "production" {
+            let account = self
+                .developer_account_repo
+                .find_by_id(application.developer_account_id)
+                .await?
+                .ok_or(DeveloperPortalError::AccountNotFound)?;
+
+            if account.access_tier_code == "sandbox" {
+                return Err(DeveloperPortalError::IdentityVerificationRequired);
+            }
+        }
+
+        // Generate API key
+        let raw_key = self.generate_api_key();
+        let key_prefix = &raw_key[..8];
+        let key_hash = self.hash_api_key(&raw_key)?;
+
+        // Create API key record
+        let api_key = self
+            .api_key_repo
+            .create(application_id, request, key_prefix, &key_hash)
+            .await?;
+
+        info!(
+            "API key created: {} for application: {}",
+            api_key.key_name, application.name
+        );
+
+        Ok((api_key, raw_key))
+    }
+
+    pub async fn get_api_keys(&self, application_id: Uuid) -> Result<Vec<ApiKey>, DeveloperPortalError> {
+        let api_keys = self.api_key_repo.find_by_application(application_id).await?;
+        Ok(api_keys)
+    }
+
+    pub async fn revoke_api_key(&self, api_key_id: Uuid) -> Result<(), DeveloperPortalError> {
+        self.api_key_repo.revoke(api_key_id).await?;
+        info!("API key revoked: {}", api_key_id);
+        Ok(())
+    }
+
+    pub async fn validate_api_key(&self, raw_key: &str) -> Result<Option<ApiKey>, DeveloperPortalError> {
+        let key_hash = self.hash_api_key(raw_key)?;
+        let api_key = self.api_key_repo.find_by_key_hash(&key_hash).await?;
+
+        if let Some(ref key) = api_key {
+            // Check if key has expired
+            if let Some(expires_at) = key.expires_at {
+                if expires_at < Utc::now() {
+                    return Ok(None);
+                }
+            }
+        }
+
+        Ok(api_key)
+    }
+
+    pub async fn update_api_key_usage(&self, api_key_id: Uuid) -> Result<(), DeveloperPortalError> {
+        self.api_key_repo.update_usage(api_key_id).await?;
+        Ok(())
+    }
+
+    pub async fn suspend_account(&self, account_id: Uuid, reason: &str) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .suspend(account_id, reason)
+            .await?;
+
+        // Revoke all API keys for this account's applications
+        let applications = self
+            .application_repo
+            .find_by_developer_account(account_id)
+            .await?;
+
+        for application in applications {
+            self.api_key_repo
+                .revoke_by_application(application.id, "sandbox")
+                .await?;
+            self.api_key_repo
+                .revoke_by_application(application.id, "production")
+                .await?;
+        }
+
+        warn!("Account suspended: {} - reason: {}", account.email, reason);
+
+        Ok(account)
+    }
+
+    pub async fn reinstate_account(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .reinstate(account_id)
+            .await?;
+
+        info!("Account reinstated: {}", account.email);
+
+        Ok(account)
+    }
+
+    pub async fn upgrade_to_standard_tier(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .upgrade_to_standard_tier(account_id)
+            .await?;
+
+        info!("Account upgraded to standard tier: {}", account.email);
+
+        Ok(account)
+    }
+
+    pub async fn upgrade_to_partner_tier(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .upgrade_to_partner_tier(account_id)
+            .await?;
+
+        info!("Account upgraded to partner tier: {}", account.email);
+
+        Ok(account)
+    }
+
+    pub async fn get_developer_account(&self, account_id: Uuid) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .find_by_id(account_id)
+            .await?
+            .ok_or(DeveloperPortalError::AccountNotFound)?;
+
+        Ok(account)
+    }
+
+    pub async fn update_developer_account(
+        &self,
+        account_id: Uuid,
+        request: UpdateDeveloperAccountRequest,
+    ) -> Result<DeveloperAccount, DeveloperPortalError> {
+        let account = self
+            .developer_account_repo
+            .update(account_id, request)
+            .await?;
+
+        info!("Developer account updated: {}", account.email);
+
+        Ok(account)
+    }
+
+    pub async fn list_developer_accounts_for_admin(
+        &self,
+        page: i64,
+        per_page: i64,
+    ) -> Result<AdminDeveloperAccountList, DeveloperPortalError> {
+        let accounts = self
+            .developer_account_repo
+            .list_for_admin(page, per_page)
+            .await?;
+
+        Ok(accounts)
+    }
+
+    /// Returns aggregated usage statistics for an application over a configurable time window.
+    pub async fn get_usage_statistics(
+        &self,
+        application_id: Uuid,
+        time_range: Option<&str>,
+        start_date: Option<DateTime<Utc>>,
+        end_date: Option<DateTime<Utc>>,
+        environment: Option<&str>,
+    ) -> Result<ApplicationUsageSummary, DeveloperPortalError> {
+        let application = self
+            .application_repo
+            .find_by_id(application_id)
+            .await?
+            .ok_or(DeveloperPortalError::ApplicationNotFound)?;
+
+        let (start, end) = self.resolve_time_range(time_range, start_date, end_date);
+
+        let metrics = self
+            .application_repo
+            .get_usage_metrics(application_id, start, end, environment)
+            .await?;
+
+        let endpoint_breakdown = self
+            .application_repo
+            .get_endpoint_breakdown(application_id, start, end, environment)
+            .await?;
+
+        let time_series_data = self
+            .application_repo
+            .get_time_series(application_id, start, end, environment, time_range)
+            .await?;
+
+        Ok(ApplicationUsageSummary {
+            application_id,
+            application_name: application.name,
+            environment: environment.unwrap_or("all").to_string(),
+            metrics,
+            endpoint_breakdown,
+            time_series_data,
+        })
+    }
+
+    fn resolve_time_range(
+        &self,
+        time_range: Option<&str>,
+        start_date: Option<DateTime<Utc>>,
+        end_date: Option<DateTime<Utc>>,
+    ) -> (DateTime<Utc>, DateTime<Utc>) {
+        let now = Utc::now();
+        match time_range {
+            Some("daily") => (now - Duration::days(1), now),
+            Some("weekly") => (now - Duration::days(7), now),
+            Some("monthly") => (now - Duration::days(30), now),
+            _ => (
+                start_date.unwrap_or(now - Duration::days(30)),
+                end_date.unwrap_or(now),
+            ),
+        }
+    }
+
+    fn generate_verification_token(&self) -> String {
+        let mut rng = rand::thread_rng();
+        (0..EMAIL_VERIFICATION_TOKEN_LENGTH)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect()
+    }
+
+    fn generate_api_key(&self) -> String {
+        let mut rng = rand::thread_rng();
+        let prefix = "ak_";
+        let key_part: String = (0..32)
+            .map(|_| {
+                let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+                chars[rng.gen_range(0..chars.len())] as char
+            })
+            .collect();
+
+        format!("{}{}", prefix, key_part)
+    }
+
+    fn hash_api_key(&self, api_key: &str) -> Result<String, DeveloperPortalError> {
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        
+        let password_hash = argon2
+            .hash_password(api_key.as_bytes(), &salt)
+            .map_err(|e| DeveloperPortalError::Crypto(e.to_string()))?;
+
+        Ok(password_hash.to_string())
+    }
+
+    pub fn verify_api_key_hash(&self, api_key: &str, hash: &str) -> Result<bool, DeveloperPortalError> {
+        let parsed_hash = PasswordHash::new(hash)
+            .map_err(|e| DeveloperPortalError::Crypto(e.to_string()))?;
+
+        let argon2 = Argon2::default();
+        
+        match argon2.verify_password(api_key.as_bytes(), &parsed_hash) {
+            Ok(()) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+}
+
+/// Converts developer portal errors into the global AppError type so `?` works in handlers.
+impl From<DeveloperPortalError> for AppError {
+    fn from(err: DeveloperPortalError) -> Self {
+        use crate::error::{AppErrorKind, DomainError, InfrastructureError, ValidationError};
+
+        let kind = match err {
+            DeveloperPortalError::EmailAlreadyRegistered => {
+                // Use generic message to prevent email enumeration
+                AppErrorKind::Domain(DomainError::DuplicateTransaction {
+                    transaction_id: "email_registration".to_string(),
+                })
+            }
+            DeveloperPortalError::AccountNotFound
+            | DeveloperPortalError::ApplicationNotFound
+            | DeveloperPortalError::ApiKeyNotFound
+            | DeveloperPortalError::OAuthClientNotFound
+            | DeveloperPortalError::WebhookConfigurationNotFound
+            | DeveloperPortalError::ProductionAccessRequestNotFound => {
+                AppErrorKind::Domain(DomainError::TransactionNotFound {
+                    transaction_id: err.to_string(),
+                })
+            }
+            DeveloperPortalError::InvalidEmailVerificationToken
+            | DeveloperPortalError::EmailVerificationTokenExpired => {
+                AppErrorKind::Validation(ValidationError::InvalidAmount {
+                    amount: "token".to_string(),
+                    reason: err.to_string(),
+                })
+            }
+            DeveloperPortalError::GeoRestrictedCountry => {
+                AppErrorKind::Validation(ValidationError::InvalidAmount {
+                    amount: "country".to_string(),
+                    reason: "Registration from this country is not supported".to_string(),
+                })
+            }
+            DeveloperPortalError::MaximumApplicationsLimitReached => {
+                AppErrorKind::Validation(ValidationError::OutOfRange {
+                    field: "applications".to_string(),
+                    min: None,
+                    max: Some("tier limit".to_string()),
+                })
+            }
+            DeveloperPortalError::IdentityVerificationRequired
+            | DeveloperPortalError::IdentityVerificationAlreadySubmitted => {
+                AppErrorKind::Validation(ValidationError::MissingField {
+                    field: "identity_verification".to_string(),
+                })
+            }
+            DeveloperPortalError::AccountSuspended => {
+                AppErrorKind::Validation(ValidationError::MissingField {
+                    field: "account_status".to_string(),
+                })
+            }
+            DeveloperPortalError::ProductionAccessRequestAlreadyPending => {
+                AppErrorKind::Domain(DomainError::DuplicateTransaction {
+                    transaction_id: "production_access_request".to_string(),
+                })
+            }
+            DeveloperPortalError::Database(e) => {
+                AppErrorKind::Infrastructure(InfrastructureError::Database {
+                    message: e.to_string(),
+                    is_retryable: true,
+                })
+            }
+            DeveloperPortalError::Serialization(e) => {
+                AppErrorKind::Infrastructure(InfrastructureError::Configuration {
+                    message: e.to_string(),
+                })
+            }
+            _ => AppErrorKind::Infrastructure(InfrastructureError::Configuration {
+                message: err.to_string(),
+            }),
+        };
+
+        AppError::new(kind)
+    }
+}

--- a/src/developer_portal/webhook_service.rs
+++ b/src/developer_portal/webhook_service.rs
@@ -1,0 +1,604 @@
+use super::models::*;
+use super::repositories::{WebhookConfigurationRepository, WebhookDeliveryLogRepository};
+use crate::database::error::DatabaseError;
+use chrono::Utc;
+use serde_json::json;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct WebhookService {
+    webhook_config_repo: WebhookConfigurationRepository,
+    delivery_log_repo: WebhookDeliveryLogRepository,
+}
+
+impl WebhookService {
+    pub fn new(
+        webhook_config_repo: WebhookConfigurationRepository,
+        delivery_log_repo: WebhookDeliveryLogRepository,
+    ) -> Self {
+        Self {
+            webhook_config_repo,
+            delivery_log_repo,
+        }
+    }
+
+    pub async fn create_webhook_configuration(
+        &self,
+        application_id: Uuid,
+        request: CreateWebhookConfigurationRequest,
+    ) -> Result<WebhookConfiguration, DeveloperPortalError> {
+        let webhook = self
+            .webhook_config_repo
+            .create(application_id, request)
+            .await?;
+
+        info!(
+            "Webhook configuration created: {} for application: {}",
+            webhook.id, application_id
+        );
+
+        Ok(webhook)
+    }
+
+    pub async fn get_webhook_configurations(
+        &self,
+        application_id: Uuid,
+    ) -> Result<Vec<WebhookConfiguration>, DeveloperPortalError> {
+        let webhooks = self
+            .webhook_config_repo
+            .find_by_application(application_id)
+            .await?;
+
+        Ok(webhooks)
+    }
+
+    pub async fn update_webhook_configuration(
+        &self,
+        webhook_id: Uuid,
+        request: UpdateWebhookConfigurationRequest,
+    ) -> Result<WebhookConfiguration, DeveloperPortalError> {
+        let webhook = self
+            .webhook_config_repo
+            .update(webhook_id, request)
+            .await?;
+
+        info!("Webhook configuration updated: {}", webhook_id);
+
+        Ok(webhook)
+    }
+
+    pub async fn delete_webhook_configuration(
+        &self,
+        webhook_id: Uuid,
+    ) -> Result<(), DeveloperPortalError> {
+        self.webhook_config_repo.soft_delete(webhook_id).await?;
+        info!("Webhook configuration deleted: {}", webhook_id);
+
+        Ok(())
+    }
+
+    pub async fn deliver_webhook(
+        &self,
+        webhook_id: Uuid,
+        event_type: &str,
+        payload: serde_json::Value,
+    ) -> Result<(), DeveloperPortalError> {
+        let webhook = self
+            .webhook_config_repo
+            .find_by_id(webhook_id)
+            .await?
+            .ok_or(DeveloperPortalError::WebhookConfigurationNotFound)?;
+
+        // Check if webhook is active and handles this event type
+        if webhook.status != "active" || !webhook.events.contains(&event_type.to_string()) {
+            return Ok(());
+        }
+
+        // Create delivery log entry
+        let delivery_log = self
+            .delivery_log_repo
+            .create(
+                webhook_id,
+                event_type,
+                payload.clone(),
+                webhook.webhook_url.clone(),
+            )
+            .await?;
+
+        // Attempt delivery
+        let delivery_result = self
+            .attempt_webhook_delivery(&webhook, event_type, &payload)
+            .await;
+
+        match delivery_result {
+            Ok(_) => {
+                self.delivery_log_repo
+                    .mark_delivered(delivery_log.id, None, None)
+                    .await?;
+                info!(
+                    "Webhook delivered successfully: {} to {}",
+                    event_type, webhook.webhook_url
+                );
+            }
+            Err(e) => {
+                self.delivery_log_repo
+                    .mark_failed(delivery_log.id, Some(&e.to_string()))
+                    .await?;
+                error!(
+                    "Webhook delivery failed: {} to {} - {}",
+                    event_type, webhook.webhook_url, e
+                );
+            }
+        }
+
+        // Update webhook statistics
+        self.update_webhook_statistics(webhook_id).await?;
+
+        Ok(())
+    }
+
+    pub async fn get_webhook_delivery_logs(
+        &self,
+        webhook_id: Uuid,
+        page: i64,
+        per_page: i64,
+    ) -> Result<Vec<WebhookDeliveryLog>, DeveloperPortalError> {
+        let logs = self
+            .delivery_log_repo
+            .find_by_webhook(webhook_id, page, per_page)
+            .await?;
+
+        Ok(logs)
+    }
+
+    pub async fn get_webhook_metrics(
+        &self,
+        webhook_id: Uuid,
+    ) -> Result<WebhookMetrics, DeveloperPortalError> {
+        let metrics = self
+            .delivery_log_repo
+            .get_metrics(webhook_id)
+            .await?;
+
+        Ok(metrics)
+    }
+
+    async fn attempt_webhook_delivery(
+        &self,
+        webhook: &WebhookConfiguration,
+        event_type: &str,
+        payload: &serde_json::Value,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let client = reqwest::Client::new();
+        
+        let mut request = client
+            .post(&webhook.webhook_url)
+            .header("Content-Type", "application/json")
+            .header("User-Agent", "Bitmesh-Webhook/1.0")
+            .header("X-Webhook-Event", event_type)
+            .json(payload);
+
+        // Add signature if secret token is configured
+        if let Some(ref secret) = webhook.secret_token {
+            let signature = self.generate_signature(payload, secret)?;
+            request = request.header("X-Webhook-Signature", signature);
+        }
+
+        let response = request.send().await?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            Err(format!("Webhook returned status {}: {}", status, body).into())
+        }
+    }
+
+    fn generate_signature(
+        &self,
+        payload: &serde_json::Value,
+        secret: &str,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let payload_str = serde_json::to_string(payload)?;
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())?;
+        mac.update(payload_str.as_bytes());
+        let signature = hex::encode(mac.finalize().into_bytes());
+        
+        Ok(format!("sha256={}", signature))
+    }
+
+    async fn update_webhook_statistics(&self, webhook_id: Uuid) -> Result<(), DeveloperPortalError> {
+        let metrics = self
+            .delivery_log_repo
+            .get_metrics(webhook_id)
+            .await?;
+
+        let success_rate = if metrics.total_deliveries > 0 {
+            (metrics.successful_deliveries as f64 / metrics.total_deliveries as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        let average_latency = if metrics.successful_deliveries > 0 {
+            // TODO: Calculate average latency from delivery logs
+            0.0
+        } else {
+            0.0
+        };
+
+        self.webhook_config_repo
+            .update_statistics(
+                webhook_id,
+                rust_decimal::Decimal::from_f64_retain(success_rate).unwrap_or_default(),
+                average_latency as i32,
+                metrics.failed_deliveries as i32,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn retry_failed_webhooks(&self) -> Result<(), DeveloperPortalError> {
+        let failed_logs = self
+            .delivery_log_repo
+            .find_failed_for_retry()
+            .await?;
+
+        for log in failed_logs {
+            if log.delivery_attempts >= 5 {
+                // Max retries reached, mark as permanently failed
+                self.delivery_log_repo
+                    .mark_failed(log.id, Some("Max retries exceeded"))
+                    .await?;
+                continue;
+            }
+
+            let webhook = self
+                .webhook_config_repo
+                .find_by_id(log.webhook_configuration_id)
+                .await?
+                .ok_or(DeveloperPortalError::WebhookConfigurationNotFound)?;
+
+            // Update attempt count and schedule next retry
+            self.delivery_log_repo
+                .increment_attempts(log.id)
+                .await?;
+
+            // TODO: Schedule retry using background job system
+            info!(
+                "Scheduling webhook retry: {} for webhook: {}",
+                log.id, log.webhook_configuration_id
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct WebhookConfigurationRepository {
+    pool: Arc<sqlx::PgPool>,
+}
+
+impl WebhookConfigurationRepository {
+    pub fn new(pool: Arc<sqlx::PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        application_id: Uuid,
+        request: CreateWebhookConfigurationRequest,
+    ) -> Result<WebhookConfiguration, DeveloperPortalError> {
+        let webhook = sqlx::query_as!(
+            WebhookConfiguration,
+            r#"
+            INSERT INTO webhook_configurations (
+                application_id, webhook_url, secret_token, events
+            ) VALUES ($1, $2, $3, $4)
+            RETURNING *
+            "#,
+            application_id,
+            request.webhook_url,
+            request.secret_token,
+            &request.events
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(webhook)
+    }
+
+    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<WebhookConfiguration>, DeveloperPortalError> {
+        let webhook = sqlx::query_as!(
+            WebhookConfiguration,
+            "SELECT * FROM webhook_configurations WHERE id = $1",
+            id
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await?;
+
+        Ok(webhook)
+    }
+
+    pub async fn find_by_application(
+        &self,
+        application_id: Uuid,
+    ) -> Result<Vec<WebhookConfiguration>, DeveloperPortalError> {
+        let webhooks = sqlx::query_as!(
+            WebhookConfiguration,
+            "SELECT * FROM webhook_configurations WHERE application_id = $1 AND status != 'deleted' ORDER BY created_at DESC",
+            application_id
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(webhooks)
+    }
+
+    pub async fn update(
+        &self,
+        webhook_id: Uuid,
+        request: UpdateWebhookConfigurationRequest,
+    ) -> Result<WebhookConfiguration, DeveloperPortalError> {
+        let webhook = sqlx::query_as!(
+            WebhookConfiguration,
+            r#"
+            UPDATE webhook_configurations 
+            SET webhook_url = COALESCE($1, webhook_url),
+                secret_token = COALESCE($2, secret_token),
+                events = COALESCE($3, events),
+                updated_at = now()
+            WHERE id = $4
+            RETURNING *
+            "#,
+            request.webhook_url,
+            request.secret_token,
+            request.events.as_ref(),
+            webhook_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(webhook)
+    }
+
+    pub async fn soft_delete(&self, webhook_id: Uuid) -> Result<WebhookConfiguration, DeveloperPortalError> {
+        let webhook = sqlx::query_as!(
+            WebhookConfiguration,
+            r#"
+            UPDATE webhook_configurations 
+            SET status = 'deleted',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            webhook_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(webhook)
+    }
+
+    pub async fn update_statistics(
+        &self,
+        webhook_id: Uuid,
+        success_rate: rust_decimal::Decimal,
+        average_latency: i32,
+        failed_count: i32,
+    ) -> Result<(), DeveloperPortalError> {
+        sqlx::query!(
+            r#"
+            UPDATE webhook_configurations 
+            SET delivery_success_rate = $1,
+                average_delivery_latency = $2,
+                failed_delivery_count = $3,
+                updated_at = now()
+            WHERE id = $4
+            "#,
+            success_rate,
+            average_latency,
+            failed_count,
+            webhook_id
+        )
+        .execute(self.pool.as_ref())
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct WebhookDeliveryLogRepository {
+    pool: Arc<sqlx::PgPool>,
+}
+
+impl WebhookDeliveryLogRepository {
+    pub fn new(pool: Arc<sqlx::PgPool>) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        webhook_configuration_id: Uuid,
+        event_type: &str,
+        payload: serde_json::Value,
+        delivery_url: String,
+    ) -> Result<WebhookDeliveryLog, DeveloperPortalError> {
+        let log = sqlx::query_as!(
+            WebhookDeliveryLog,
+            r#"
+            INSERT INTO webhook_delivery_logs (
+                webhook_configuration_id, event_type, payload, delivery_url
+            ) VALUES ($1, $2, $3, $4)
+            RETURNING *
+            "#,
+            webhook_configuration_id,
+            event_type,
+            payload,
+            delivery_url
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(log)
+    }
+
+    pub async fn find_by_webhook(
+        &self,
+        webhook_id: Uuid,
+        page: i64,
+        per_page: i64,
+    ) -> Result<Vec<WebhookDeliveryLog>, DeveloperPortalError> {
+        let offset = (page - 1) * per_page;
+
+        let logs = sqlx::query_as!(
+            WebhookDeliveryLog,
+            "SELECT * FROM webhook_delivery_logs WHERE webhook_configuration_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+            webhook_id,
+            per_page,
+            offset
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(logs)
+    }
+
+    pub async fn mark_delivered(
+        &self,
+        log_id: Uuid,
+        http_status_code: Option<i32>,
+        response_body: Option<String>,
+    ) -> Result<WebhookDeliveryLog, DeveloperPortalError> {
+        let log = sqlx::query_as!(
+            WebhookDeliveryLog,
+            r#"
+            UPDATE webhook_delivery_logs 
+            SET status = 'delivered',
+                http_status_code = $1,
+                response_body = $2,
+                delivered_at = now(),
+                updated_at = now()
+            WHERE id = $3
+            RETURNING *
+            "#,
+            http_status_code,
+            response_body,
+            log_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(log)
+    }
+
+    pub async fn mark_failed(
+        &self,
+        log_id: Uuid,
+        error_message: Option<String>,
+    ) -> Result<WebhookDeliveryLog, DeveloperPortalError> {
+        let log = sqlx::query_as!(
+            WebhookDeliveryLog,
+            r#"
+            UPDATE webhook_delivery_logs 
+            SET status = 'failed',
+                error_message = $1,
+                updated_at = now()
+            WHERE id = $2
+            RETURNING *
+            "#,
+            error_message,
+            log_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(log)
+    }
+
+    pub async fn increment_attempts(&self, log_id: Uuid) -> Result<WebhookDeliveryLog, DeveloperPortalError> {
+        let log = sqlx::query_as!(
+            WebhookDeliveryLog,
+            r#"
+            UPDATE webhook_delivery_logs 
+            SET delivery_attempts = delivery_attempts + 1,
+                status = 'retrying',
+                next_retry_at = now() + interval '5 minutes',
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+            log_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        Ok(log)
+    }
+
+    pub async fn find_failed_for_retry(&self) -> Result<Vec<WebhookDeliveryLog>, DeveloperPortalError> {
+        let logs = sqlx::query_as!(
+            WebhookDeliveryLog,
+            r#"
+            SELECT * FROM webhook_delivery_logs 
+            WHERE status = 'retrying' 
+            AND next_retry_at <= now()
+            AND delivery_attempts < 5
+            ORDER BY next_retry_at ASC
+            LIMIT 100
+            "#
+        )
+        .fetch_all(self.pool.as_ref())
+        .await?;
+
+        Ok(logs)
+    }
+
+    pub async fn get_metrics(&self, webhook_id: Uuid) -> Result<WebhookMetrics, DeveloperPortalError> {
+        let metrics = sqlx::query!(
+            r#"
+            SELECT 
+                COUNT(*) as total_count,
+                COUNT(CASE WHEN status = 'delivered' THEN 1 END) as successful_count,
+                COUNT(CASE WHEN status = 'failed' THEN 1 END) as failed_count,
+                COUNT(CASE WHEN status = 'pending' OR status = 'retrying' THEN 1 END) as pending_count
+            FROM webhook_delivery_logs 
+            WHERE webhook_configuration_id = $1
+            "#,
+            webhook_id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await?;
+
+        let total_count = metrics.total_count.unwrap_or(0) as i64;
+        let successful_count = metrics.successful_count.unwrap_or(0) as i64;
+        let failed_count = metrics.failed_count.unwrap_or(0) as i64;
+        let pending_count = metrics.pending_count.unwrap_or(0) as i64;
+
+        let success_rate = if total_count > 0 {
+            (successful_count as f64 / total_count as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        // TODO: Calculate average latency from delivered logs
+        let average_latency = 0.0;
+
+        Ok(WebhookMetrics {
+            total_deliveries: total_count,
+            successful_deliveries: successful_count,
+            failed_deliveries: failed_count,
+            success_rate,
+            average_latency,
+            pending_deliveries: pending_count,
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod chains;
 mod config;
 mod config_validation;
 mod database;
+mod developer_portal;
 mod error;
 mod health;
 mod logging;
@@ -15,6 +16,7 @@ mod oauth;
 mod payments;
 mod recurring;
 mod services;
+mod telemetry;
 mod workers;
 
 // Imports
@@ -49,9 +51,6 @@ use tower_http::request_id::{PropagateRequestIdLayer, SetRequestIdLayer};
 use tracing::{error, info};
 use uuid::Uuid;
 
-// Re-export the telemetry module so `init_tracer` / `shutdown_tracer` resolve.
-// In the real project this module lives at src/telemetry/mod.rs (Issue #104).
-mod telemetry;
 
 /// Graceful shutdown signal handler
 async fn shutdown_signal() {
@@ -1292,6 +1291,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(developer_routes)
         .merge(oauth_routes)
         .merge(history_routes)
+        .merge(developer_portal::routes::register_developer_portal_routes(Router::new(), db_pool.clone()))
         .with_state(AppState {
             db_pool,
             redis_cache,


### PR DESCRIPTION
closes #179
- Add developer account model with registration, email verification, and identity verification workflows
- Add application model with CRUD, API key management, and OAuth clients
- Implement sandbox tier provisioning with testnet wallet generation
- Implement production access request, review, and approval workflows
- Add production credential issuance (API keys + OAuth clients)
- Add usage statistics aggregation with time-range and env filters
- Add endpoint breakdown and time-series analytics queries
- Implement OAuthClientRepository with full CRUD
- Add sandbox environment reset endpoint
- Wire up admin queue for production access request review
- Implement upgrade_to_standard_tier and upgrade_to_partner_tier
- Add From<DeveloperPortalError> for AppError conversion
- Add structured tracing events throughout service layer
- Add structured notification logging for account lifecycle events
- Add admin handlers for account suspension, reinstatement, tier upgrade
- Add webhook delivery service with HMAC signing and retry logic
- Add database schema migration for all developer portal tables