### PR TITLE
feat: implement sensitive data classification framework

### DIFF
--- a/migrations/20260402100000_data_classification_audit.sql
+++ b/migrations/20260402100000_data_classification_audit.sql
@@ -1,0 +1,58 @@
+-- migrate:up
+-- Data Classification Framework — Audit Table
+-- Purpose: Persist policy violation events, field access audit trails, and
+--          retention purge records for compliance reporting.
+--
+-- This table is append-only.  Rows are never updated or deleted.
+-- Retention: 7 years (AML/KYC regulatory requirement).
+
+CREATE TABLE IF NOT EXISTS data_classification_audit (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- The kind of event: field_access | policy_violation | field_masked |
+    --                    transmission_denied | retention_purge
+    event_kind      TEXT        NOT NULL,
+    -- The DataField variant name (e.g. "WalletPrivateKey", "UserEmail")
+    field_name      TEXT        NOT NULL,
+    -- The classification tier label (CRITICAL / RESTRICTED / CONFIDENTIAL / INTERNAL / PUBLIC)
+    tier            TEXT        NOT NULL,
+    -- The TransmissionContext variant name (e.g. "LogLine", "ApiResponse")
+    context         TEXT        NOT NULL,
+    -- The actor that triggered the event (wallet address, admin UUID, service name)
+    actor           TEXT,
+    -- Correlation ID from the HTTP request
+    request_id      TEXT,
+    -- Additional human-readable detail (violation reason, purge count, etc.)
+    detail          TEXT,
+    occurred_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE data_classification_audit IS
+    'Append-only audit trail for data classification policy events. '
+    'Covers field access, policy violations, and retention purges.';
+
+COMMENT ON COLUMN data_classification_audit.event_kind IS
+    'Type of event: field_access, policy_violation, field_masked, transmission_denied, retention_purge.';
+COMMENT ON COLUMN data_classification_audit.field_name IS
+    'The DataField variant that was involved (matches registry::DataField enum name).';
+COMMENT ON COLUMN data_classification_audit.tier IS
+    'Classification tier label at the time of the event.';
+COMMENT ON COLUMN data_classification_audit.context IS
+    'Transmission context: LogLine, ApiResponse, WebhookDelivery, InternalRpc, Cache, Database.';
+COMMENT ON COLUMN data_classification_audit.actor IS
+    'Authenticated actor (wallet address, admin ID, or background service name).';
+COMMENT ON COLUMN data_classification_audit.request_id IS
+    'HTTP request correlation ID (X-Request-Id header value).';
+COMMENT ON COLUMN data_classification_audit.detail IS
+    'Free-text detail: violation reason, purge row count, etc.';
+
+-- Indexes for compliance queries
+CREATE INDEX idx_dca_event_kind       ON data_classification_audit (event_kind);
+CREATE INDEX idx_dca_tier             ON data_classification_audit (tier);
+CREATE INDEX idx_dca_field_name       ON data_classification_audit (field_name);
+CREATE INDEX idx_dca_occurred_at      ON data_classification_audit (occurred_at DESC);
+CREATE INDEX idx_dca_actor            ON data_classification_audit (actor) WHERE actor IS NOT NULL;
+CREATE INDEX idx_dca_violations       ON data_classification_audit (occurred_at DESC)
+    WHERE event_kind = 'policy_violation';
+
+-- migrate:down
+DROP TABLE IF EXISTS data_classification_audit;

--- a/src/data_classification/audit.rs
+++ b/src/data_classification/audit.rs
@@ -1,0 +1,283 @@
+//! Policy violation and data access audit trail.
+//!
+//! Every time a Restricted or Critical field is accessed, or a policy
+//! violation is detected, an entry is written here.  The repository
+//! persists these to the `data_classification_audit` table.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::data_classification::{policy::TransmissionContext, registry::DataField};
+
+// ---------------------------------------------------------------------------
+// Audit event types
+// ---------------------------------------------------------------------------
+
+/// The kind of audit event being recorded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditEventKind {
+    /// A Restricted or Critical field was accessed by an authorised actor.
+    FieldAccess,
+    /// A policy violation was detected (e.g., Critical field in a log line).
+    PolicyViolation,
+    /// A field was masked before transmission.
+    FieldMasked,
+    /// A field was denied transmission in a given context.
+    TransmissionDenied,
+    /// A retention purge was executed for a field category.
+    RetentionPurge,
+}
+
+impl AuditEventKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            AuditEventKind::FieldAccess => "field_access",
+            AuditEventKind::PolicyViolation => "policy_violation",
+            AuditEventKind::FieldMasked => "field_masked",
+            AuditEventKind::TransmissionDenied => "transmission_denied",
+            AuditEventKind::RetentionPurge => "retention_purge",
+        }
+    }
+}
+
+/// A single audit event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassificationAuditEvent {
+    pub id: Uuid,
+    pub event_kind: AuditEventKind,
+    /// The field that was accessed or violated.
+    pub field_name: String,
+    /// The classification tier of the field.
+    pub tier: String,
+    /// The transmission context (log, api_response, etc.).
+    pub context: String,
+    /// The actor that triggered the event (wallet address, admin ID, service name).
+    pub actor: Option<String>,
+    /// The request ID for correlation.
+    pub request_id: Option<String>,
+    /// Additional detail (e.g., violation reason).
+    pub detail: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+}
+
+impl ClassificationAuditEvent {
+    pub fn field_access(
+        field: DataField,
+        context: TransmissionContext,
+        actor: Option<String>,
+        request_id: Option<String>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            event_kind: AuditEventKind::FieldAccess,
+            field_name: format!("{:?}", field),
+            tier: field.tier().label().to_string(),
+            context: format!("{:?}", context),
+            actor,
+            request_id,
+            detail: None,
+            occurred_at: Utc::now(),
+        }
+    }
+
+    pub fn policy_violation(
+        field: DataField,
+        context: TransmissionContext,
+        reason: &str,
+        actor: Option<String>,
+        request_id: Option<String>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            event_kind: AuditEventKind::PolicyViolation,
+            field_name: format!("{:?}", field),
+            tier: field.tier().label().to_string(),
+            context: format!("{:?}", context),
+            actor,
+            request_id,
+            detail: Some(reason.to_string()),
+            occurred_at: Utc::now(),
+        }
+    }
+
+    pub fn transmission_denied(
+        field: DataField,
+        context: TransmissionContext,
+        reason: &str,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            event_kind: AuditEventKind::TransmissionDenied,
+            field_name: format!("{:?}", field),
+            tier: field.tier().label().to_string(),
+            context: format!("{:?}", context),
+            actor: None,
+            request_id: None,
+            detail: Some(reason.to_string()),
+            occurred_at: Utc::now(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+/// Persists classification audit events to the database.
+#[derive(Clone)]
+pub struct ClassificationAuditRepository {
+    pool: PgPool,
+}
+
+impl ClassificationAuditRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert an audit event.  Errors are logged but never propagated —
+    /// audit failures must not break the primary request path.
+    pub async fn record(&self, event: ClassificationAuditEvent) {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO data_classification_audit (
+                id, event_kind, field_name, tier, context,
+                actor, request_id, detail, occurred_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            "#,
+        )
+        .bind(event.id)
+        .bind(event.event_kind.as_str())
+        .bind(event.field_name)
+        .bind(event.tier)
+        .bind(event.context)
+        .bind(event.actor)
+        .bind(event.request_id)
+        .bind(event.detail)
+        .bind(event.occurred_at)
+        .execute(&self.pool)
+        .await;
+
+        if let Err(e) = result {
+            tracing::error!(
+                error = %e,
+                event_id = %event.id,
+                "Failed to persist classification audit event"
+            );
+        }
+    }
+
+    /// Retrieve recent policy violations for compliance review.
+    pub async fn get_violations(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<ClassificationAuditEvent>, sqlx::Error> {
+        type Row = (
+            Uuid,
+            String,
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            DateTime<Utc>,
+        );
+        let rows: Vec<Row> = sqlx::query_as(
+                r#"
+                SELECT id, event_kind, field_name, tier, context,
+                       actor, request_id, detail, occurred_at
+                FROM data_classification_audit
+                WHERE event_kind = 'policy_violation'
+                ORDER BY occurred_at DESC
+                LIMIT $1
+                "#,
+            )
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, _kind, field_name, tier, context, actor, request_id, detail, occurred_at)| {
+                ClassificationAuditEvent {
+                    id,
+                    event_kind: AuditEventKind::PolicyViolation,
+                    field_name,
+                    tier,
+                    context,
+                    actor,
+                    request_id,
+                    detail,
+                    occurred_at,
+                }
+            })
+            .collect())
+    }
+
+    /// Count violations in the last N hours — used by compliance dashboards.
+    pub async fn violation_count_last_hours(&self, hours: i64) -> Result<i64, sqlx::Error> {
+        let interval = format!("{} hours", hours);
+        let row: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM data_classification_audit
+            WHERE event_kind = 'policy_violation'
+              AND occurred_at >= now() - $1::interval
+            "#,
+        )
+        .bind(interval)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// In-process violation reporter (no DB dependency)
+// ---------------------------------------------------------------------------
+
+/// Report a policy violation to the structured log.
+///
+/// This is the lightweight path used in hot code paths where a DB write
+/// would add unacceptable latency.  The DB-backed repository should be
+/// used for compliance-critical events.
+pub fn report_violation(
+    field: DataField,
+    context: TransmissionContext,
+    reason: &str,
+    request_id: Option<&str>,
+) {
+    tracing::error!(
+        classification_event = "policy_violation",
+        field = ?field,
+        tier = field.tier().label(),
+        context = ?context,
+        reason = reason,
+        request_id = request_id,
+        "DATA_CLASSIFICATION_POLICY_VIOLATION"
+    );
+}
+
+/// Report a field access audit event to the structured log.
+pub fn report_access(
+    field: DataField,
+    context: TransmissionContext,
+    actor: Option<&str>,
+    request_id: Option<&str>,
+) {
+    if field.tier().requires_access_audit() {
+        tracing::info!(
+            classification_event = "field_access",
+            field = ?field,
+            tier = field.tier().label(),
+            context = ?context,
+            actor = actor,
+            request_id = request_id,
+            "DATA_CLASSIFICATION_FIELD_ACCESS"
+        );
+    }
+}

--- a/src/data_classification/enforcer.rs
+++ b/src/data_classification/enforcer.rs
@@ -1,0 +1,437 @@
+//! Enforcement utilities — the runtime layer that applies policy decisions.
+//!
+//! This module provides:
+//! - [`LogSanitizer`] — scrubs sensitive fields from structured log events.
+//! - [`mask_field`] — apply the correct masking strategy for a known field.
+//! - [`sanitize_json`] — walk a `serde_json::Value` and redact classified fields.
+//! - [`ClassifiedString`] — a newtype that enforces masking on `Display`/`Debug`.
+//! - [`guard_transmission`] — assert a field is allowed in a context or panic in debug.
+
+use serde_json::{Map, Value as JsonValue};
+use std::fmt;
+
+use crate::data_classification::{
+    policy::{transmission_decision, TransmissionContext, TransmissionDecision},
+    registry::DataField,
+    types::ClassificationTier,
+};
+
+// ---------------------------------------------------------------------------
+// Field masking
+// ---------------------------------------------------------------------------
+
+/// Apply the registered masking strategy for `field` to `value`.
+///
+/// Returns the masked string.  If the field's tier is `Critical` this always
+/// returns `"[REDACTED]"` regardless of the masking strategy.
+pub fn mask_field(field: DataField, value: &str) -> String {
+    if field.tier().must_never_log() {
+        return "[REDACTED]".to_string();
+    }
+    field.masking_strategy().apply(value)
+}
+
+// ---------------------------------------------------------------------------
+// ClassifiedString — safe wrapper for sensitive values
+// ---------------------------------------------------------------------------
+
+/// A string value tagged with its classification tier.
+///
+/// `Display` and `Debug` implementations automatically apply the masking
+/// strategy so the raw value is never accidentally emitted to logs.
+///
+/// ```rust,no_run
+/// use Bitmesh_backend::data_classification::enforcer::ClassifiedString;
+/// use Bitmesh_backend::data_classification::registry::DataField;
+///
+/// let email = ClassifiedString::new("user@example.com", DataField::UserEmail);
+/// // Logs will show the masked form, not the raw email.
+/// println!("{}", email); // → "us*****.com" (masked)
+/// ```
+#[derive(Clone)]
+pub struct ClassifiedString {
+    raw: String,
+    field: DataField,
+}
+
+impl ClassifiedString {
+    /// Wrap a raw value with its field classification.
+    pub fn new(raw: impl Into<String>, field: DataField) -> Self {
+        Self {
+            raw: raw.into(),
+            field,
+        }
+    }
+
+    /// Access the raw value.
+    ///
+    /// Only call this when you have verified the transmission context is
+    /// appropriate (e.g., writing to the database, passing to a payment
+    /// provider over TLS).  Never pass the raw value to a log macro.
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    /// Return the masked representation.
+    pub fn masked(&self) -> String {
+        mask_field(self.field, &self.raw)
+    }
+
+    /// The classification tier of this value.
+    pub fn tier(&self) -> ClassificationTier {
+        self.field.tier()
+    }
+}
+
+/// `Display` always shows the masked form.
+impl fmt::Display for ClassifiedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.masked())
+    }
+}
+
+/// `Debug` always shows the masked form.
+impl fmt::Debug for ClassifiedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ClassifiedString({:?})", self.masked())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON sanitizer
+// ---------------------------------------------------------------------------
+
+/// Well-known JSON key names that map to classified fields.
+///
+/// The sanitizer walks a `serde_json::Value` and redacts any key whose name
+/// appears in this list.  Keys are matched case-insensitively.
+const SENSITIVE_JSON_KEYS: &[(&str, DataField)] = &[
+    // Critical
+    ("private_key", DataField::WalletPrivateKey),
+    ("privatekey", DataField::WalletPrivateKey),
+    ("secret_seed", DataField::WalletSecretSeed),
+    ("secretseed", DataField::WalletSecretSeed),
+    ("secret_key", DataField::PaystackSecretKey),
+    ("secretkey", DataField::PaystackSecretKey),
+    ("api_key", DataField::ApiKeyPlaintext),
+    ("apikey", DataField::ApiKeyPlaintext),
+    ("consumer_secret", DataField::MpesaConsumerSecret),
+    ("consumersecret", DataField::MpesaConsumerSecret),
+    ("passkey", DataField::MpesaPasskey),
+    ("webhook_secret", DataField::WebhookSignatureSecret),
+    ("webhooksecret", DataField::WebhookSignatureSecret),
+    ("card_number", DataField::CardPan),
+    ("cardnumber", DataField::CardPan),
+    ("pan", DataField::CardPan),
+    ("totp_secret", DataField::TotpSecretSeed),
+    ("totpsecret", DataField::TotpSecretSeed),
+    // Restricted
+    ("access_token", DataField::JwtAccessToken),
+    ("accesstoken", DataField::JwtAccessToken),
+    ("refresh_token", DataField::JwtRefreshToken),
+    ("refreshtoken", DataField::JwtRefreshToken),
+    ("document_number", DataField::KycDocumentNumber),
+    ("documentnumber", DataField::KycDocumentNumber),
+    ("selfie_image", DataField::KycSelfieImageRef),
+    ("selfieimage", DataField::KycSelfieImageRef),
+    ("document_image", DataField::KycDocumentImageRef),
+    ("documentimage", DataField::KycDocumentImageRef),
+    ("full_name", DataField::UserFullName),
+    ("fullname", DataField::UserFullName),
+    ("date_of_birth", DataField::UserDateOfBirth),
+    ("dateofbirth", DataField::UserDateOfBirth),
+    ("dob", DataField::UserDateOfBirth),
+    ("bank_account_number", DataField::BankAccountNumber),
+    ("bankaccountnumber", DataField::BankAccountNumber),
+    ("account_number", DataField::BankAccountNumber),
+    // Confidential
+    ("email", DataField::UserEmail),
+    ("phone", DataField::UserPhone),
+    ("phone_number", DataField::UserPhone),
+    ("phonenumber", DataField::UserPhone),
+    ("wallet_address", DataField::WalletAddress),
+    ("walletaddress", DataField::WalletAddress),
+    ("ip_address", DataField::IpAddress),
+    ("ipaddress", DataField::IpAddress),
+    ("ip", DataField::IpAddress),
+    ("amount", DataField::TransactionAmount),
+    ("from_amount", DataField::TransactionFromAmount),
+    ("to_amount", DataField::TransactionToAmount),
+    ("balance", DataField::CryptoBalance),
+    ("afri_balance", DataField::CngnBalance),
+    ("cngn_balance", DataField::CngnBalance),
+    ("payment_reference", DataField::TransactionPaymentReference),
+    ("paymentreference", DataField::TransactionPaymentReference),
+    ("signature", DataField::WebhookSignature),
+];
+
+/// Sanitize a `serde_json::Value` for use in a log line or API response.
+///
+/// Walks the JSON tree recursively.  For each object key that matches a
+/// known sensitive field, the value is replaced with the masked form.
+///
+/// `context` controls how aggressively fields are masked:
+/// - [`TransmissionContext::LogLine`] — masks all Confidential+ fields.
+/// - [`TransmissionContext::ApiResponse`] — masks Restricted+ fields.
+/// - Other contexts — passes through (caller is responsible).
+pub fn sanitize_json(value: JsonValue, context: TransmissionContext) -> JsonValue {
+    match value {
+        JsonValue::Object(map) => {
+            let sanitized: Map<String, JsonValue> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let sanitized_v = sanitize_json_value_for_key(&k, v, context);
+                    (k, sanitized_v)
+                })
+                .collect();
+            JsonValue::Object(sanitized)
+        }
+        JsonValue::Array(arr) => {
+            JsonValue::Array(arr.into_iter().map(|v| sanitize_json(v, context)).collect())
+        }
+        other => other,
+    }
+}
+
+fn sanitize_json_value_for_key(
+    key: &str,
+    value: JsonValue,
+    context: TransmissionContext,
+) -> JsonValue {
+    let key_lower = key.to_lowercase();
+
+    // Look up the field in the sensitive key registry
+    if let Some((_, field)) = SENSITIVE_JSON_KEYS
+        .iter()
+        .find(|(k, _)| *k == key_lower.as_str())
+    {
+        let decision = transmission_decision(*field, context);
+        match decision {
+            TransmissionDecision::Deny { .. } => {
+                return JsonValue::String("[REDACTED]".to_string());
+            }
+            TransmissionDecision::AllowMasked(strategy) => {
+                if let JsonValue::String(s) = &value {
+                    return JsonValue::String(strategy.apply(s));
+                }
+                return JsonValue::String("[REDACTED]".to_string());
+            }
+            TransmissionDecision::Allow => {}
+        }
+    }
+
+    // Recurse into nested objects/arrays
+    match value {
+        JsonValue::Object(_) | JsonValue::Array(_) => sanitize_json(value, context),
+        other => other,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Log sanitizer
+// ---------------------------------------------------------------------------
+
+/// Sanitizes a free-form string (e.g., a log message or error string) by
+/// applying regex-based redaction for known sensitive patterns.
+///
+/// This is a defence-in-depth measure for cases where structured field
+/// masking was not applied upstream.
+pub struct LogSanitizer;
+
+impl LogSanitizer {
+    /// Redact known sensitive patterns from a log string.
+    pub fn sanitize(input: &str) -> String {
+        let mut result = input.to_string();
+
+        // JWT tokens (three base64url segments separated by dots)
+        result = redact_pattern(
+            &result,
+            r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
+            "[JWT_REDACTED]",
+        );
+
+        // Stellar secret seeds (S + 55 base32 chars)
+        result = redact_pattern(&result, r"\bS[A-Z2-7]{55}\b", "[STELLAR_SECRET_REDACTED]");
+
+        // Credentials adjacent to secret-like key names
+        result = redact_pattern(
+            &result,
+            r#"(?i)(secret|private_key|seed)["\s:=]+[A-Za-z0-9+/=]{20,}"#,
+            "[SECRET_REDACTED]",
+        );
+
+        // API keys with known prefixes
+        result = redact_pattern(
+            &result,
+            r"aframp_(live|test)_[A-Za-z0-9]{32}",
+            "[API_KEY_REDACTED]",
+        );
+
+        // Paystack secret keys
+        result = redact_pattern(
+            &result,
+            r"sk_(live|test)_[A-Za-z0-9]{40,}",
+            "[PSK_REDACTED]",
+        );
+
+        // Flutterwave secret keys
+        result = redact_pattern(
+            &result,
+            r"FLWSECK[_-][A-Za-z0-9]{20,}",
+            "[FLW_SECRET_REDACTED]",
+        );
+
+        // Card PANs (13-19 digit sequences, optionally space/dash separated)
+        result = redact_pattern(
+            &result,
+            r"\b(?:\d[ -]?){13,19}\b",
+            "[CARD_PAN_REDACTED]",
+        );
+
+        result
+    }
+}
+
+fn redact_pattern(input: &str, pattern: &str, replacement: &str) -> String {
+    match regex::Regex::new(pattern) {
+        Ok(re) => re.replace_all(input, replacement).to_string(),
+        Err(_) => input.to_string(), // never panic on bad pattern
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transmission guard
+// ---------------------------------------------------------------------------
+
+/// Assert that `field` is allowed in `context`.
+///
+/// In debug builds this panics with a descriptive message if the policy
+/// denies the transmission.  In release builds it logs an error and
+/// returns `false` so callers can handle the denial gracefully.
+///
+/// Returns `true` if the transmission is allowed (possibly with masking).
+pub fn guard_transmission(field: DataField, context: TransmissionContext) -> bool {
+    let decision = transmission_decision(field, context);
+    match decision {
+        TransmissionDecision::Deny { reason } => {
+            #[cfg(debug_assertions)]
+            panic!(
+                "Data classification policy violation: field {:?} denied in context {:?}: {}",
+                field, context, reason
+            );
+            #[cfg(not(debug_assertions))]
+            {
+                tracing::error!(
+                    field = ?field,
+                    context = ?context,
+                    reason = reason,
+                    "DATA_CLASSIFICATION_VIOLATION: field denied in context"
+                );
+                false
+            }
+        }
+        _ => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Retention enforcement helper
+// ---------------------------------------------------------------------------
+
+/// Returns the maximum retention period in days for a field.
+///
+/// Callers (e.g., the DB maintenance worker) use this to schedule purge jobs.
+pub fn retention_days_for_field(field: DataField) -> Option<u32> {
+    field.tier().default_retention_days()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn mask_field_critical_always_redacts() {
+        let result = mask_field(
+            DataField::WalletPrivateKey,
+            "SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        );
+        assert_eq!(result, "[REDACTED]");
+    }
+
+    #[test]
+    fn mask_field_email_partial() {
+        let result = mask_field(DataField::UserEmail, "user@example.com");
+        assert!(!result.contains("user@example.com"));
+        assert!(result.starts_with("us"));
+    }
+
+    #[test]
+    fn classified_string_display_is_masked() {
+        let cs = ClassifiedString::new(
+            "SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            DataField::WalletPrivateKey,
+        );
+        let displayed = format!("{}", cs);
+        assert_eq!(displayed, "[REDACTED]");
+    }
+
+    #[test]
+    fn classified_string_raw_accessible() {
+        let raw = "user@example.com";
+        let cs = ClassifiedString::new(raw, DataField::UserEmail);
+        assert_eq!(cs.raw(), raw);
+    }
+
+    #[test]
+    fn sanitize_json_redacts_private_key() {
+        let input = json!({
+            "private_key": "SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            "amount": "1000"
+        });
+        let sanitized = sanitize_json(input, TransmissionContext::LogLine);
+        assert_eq!(sanitized["private_key"], "[REDACTED]");
+    }
+
+    #[test]
+    fn sanitize_json_masks_email_in_log() {
+        let input = json!({ "email": "user@example.com" });
+        let sanitized = sanitize_json(input, TransmissionContext::LogLine);
+        let email_val = sanitized["email"].as_str().unwrap();
+        assert_ne!(email_val, "user@example.com");
+    }
+
+    #[test]
+    fn sanitize_json_allows_currency_code() {
+        let input = json!({ "currency": "NGN" });
+        let sanitized = sanitize_json(input, TransmissionContext::LogLine);
+        assert_eq!(sanitized["currency"], "NGN");
+    }
+
+    #[test]
+    fn log_sanitizer_redacts_jwt() {
+        // A real JWT token split across a concat to stay within line length
+        let header = "eyJhbGciOiJIUzI1NiJ9";
+        let log = format!(
+            "token={}.eyJzdWIiOiJ1c2VyIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            header
+        );
+        let sanitized = LogSanitizer::sanitize(&log);
+        assert!(!sanitized.contains(header));
+        assert!(sanitized.contains("[JWT_REDACTED]"));
+    }
+
+    #[test]
+    fn log_sanitizer_redacts_stellar_secret() {
+        let log = "seed=SCZANGBA5XTONSOWMNZOVLY4SWDTCMFKOOIIUZNSP5ZH5TZJNHQOWOBQ";
+        let sanitized = LogSanitizer::sanitize(log);
+        assert!(sanitized.contains("[STELLAR_SECRET_REDACTED]"));
+    }
+
+    #[test]
+    fn log_sanitizer_redacts_api_key() {
+        let log = "key=aframp_live_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456";
+        let sanitized = LogSanitizer::sanitize(log);
+        assert!(sanitized.contains("[API_KEY_REDACTED]"));
+    }
+}

--- a/src/data_classification/mod.rs
+++ b/src/data_classification/mod.rs
@@ -1,0 +1,104 @@
+//! # Data Classification Framework
+//!
+//! This module is the single authoritative source for how every category of
+//! sensitive data is classified and handled across the Aframp platform.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                   Data Classification Framework                  │
+//! │                                                                   │
+//! │  ┌──────────────┐   ┌──────────────┐   ┌──────────────────────┐ │
+//! │  │   registry   │   │    types     │   │       policy         │ │
+//! │  │              │   │              │   │                      │ │
+//! │  │  DataField   │──▶│ ClassTier    │──▶│  PolicyEngine        │ │
+//! │  │  (every      │   │ DataCategory │   │  HandlingRequirements│ │
+//! │  │   field)     │   │ MaskStrategy │   │  TransmissionDecision│ │
+//! │  └──────────────┘   └──────────────┘   └──────────────────────┘ │
+//! │                                                  │               │
+//! │                              ┌───────────────────┘               │
+//! │                              ▼                                    │
+//! │  ┌──────────────────────────────────────────────────────────┐    │
+//! │  │                      enforcer                             │    │
+//! │  │  mask_field · sanitize_json · ClassifiedString           │    │
+//! │  │  LogSanitizer · guard_transmission                       │    │
+//! │  └──────────────────────────────────────────────────────────┘    │
+//! │                              │                                    │
+//! │                              ▼                                    │
+//! │  ┌──────────────────────────────────────────────────────────┐    │
+//! │  │                       audit                               │    │
+//! │  │  ClassificationAuditRepository · report_violation        │    │
+//! │  └──────────────────────────────────────────────────────────┘    │
+//! └─────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Quick-start
+//!
+//! ### Check if a field may appear in a log line
+//! ```rust,no_run
+//! use Bitmesh_backend::data_classification::policy::{
+//!     transmission_decision, TransmissionContext, TransmissionDecision,
+//! };
+//! use Bitmesh_backend::data_classification::registry::DataField;
+//!
+//! let decision = transmission_decision(DataField::UserEmail, TransmissionContext::LogLine);
+//! // → AllowMasked(PartialMask { show_first: 2, show_last: 4 })
+//! ```
+//!
+//! ### Mask a field value for logging
+//! ```rust,no_run
+//! use Bitmesh_backend::data_classification::enforcer::mask_field;
+//! use Bitmesh_backend::data_classification::registry::DataField;
+//!
+//! let masked = mask_field(
+//!     DataField::WalletAddress,
+//!     "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRS",
+//! );
+//! // → "GABC****...****PQRS"
+//! ```
+//!
+//! ### Sanitize a JSON payload before logging
+//! ```rust,no_run
+//! use Bitmesh_backend::data_classification::enforcer::sanitize_json;
+//! use Bitmesh_backend::data_classification::policy::TransmissionContext;
+//! use serde_json::json;
+//!
+//! let payload = json!({ "email": "user@example.com", "private_key": "SECRET" });
+//! let safe = sanitize_json(payload, TransmissionContext::LogLine);
+//! // email → masked, private_key → "[REDACTED]"
+//! ```
+//!
+//! ### Wrap a sensitive value so it can never be accidentally logged
+//! ```rust,no_run
+//! use Bitmesh_backend::data_classification::enforcer::ClassifiedString;
+//! use Bitmesh_backend::data_classification::registry::DataField;
+//!
+//! let email = ClassifiedString::new("user@example.com", DataField::UserEmail);
+//! tracing::info!(email = %email); // logs the masked form automatically
+//! ```
+//!
+//! ## Classification Tiers
+//!
+//! | Tier | Encrypt at rest | Mask in logs | Audit on access | Never log |
+//! |------|----------------|--------------|-----------------|-----------|
+//! | Critical | ✓ | ✓ | ✓ | ✓ |
+//! | Restricted | ✓ | ✓ | ✓ | ✗ |
+//! | Confidential | ✓ | ✓ | ✗ | ✗ |
+//! | Internal | ✗ | ✗ | ✗ | ✗ |
+//! | Public | ✗ | ✗ | ✗ | ✗ |
+
+pub mod audit;
+pub mod enforcer;
+pub mod policy;
+pub mod registry;
+pub mod types;
+
+// Re-export the most commonly used items at the module root for ergonomics.
+pub use enforcer::{mask_field, sanitize_json, ClassifiedString, LogSanitizer};
+pub use policy::{
+    requirements_for_field, transmission_decision, PolicyEngine, TransmissionContext,
+    TransmissionDecision,
+};
+pub use registry::DataField;
+pub use types::{ClassificationTier, DataCategory, HandlingRequirements, MaskingStrategy};

--- a/src/data_classification/policy.rs
+++ b/src/data_classification/policy.rs
@@ -1,0 +1,330 @@
+//! Policy engine — derives and enforces handling requirements for every
+//! data field based on its classification tier and category.
+//!
+//! The engine is the single place where "what tier does this field have?"
+//! translates into "what must we do with it?".  All enforcement utilities
+//! call through here rather than hard-coding tier logic themselves.
+
+use crate::data_classification::{
+    registry::DataField,
+    types::{ClassificationTier, DataCategory, HandlingRequirements, MaskingStrategy},
+};
+
+// ---------------------------------------------------------------------------
+// Policy engine
+// ---------------------------------------------------------------------------
+
+/// Stateless policy engine.
+///
+/// All methods are pure functions — no state, no I/O.  Instantiate once and
+/// share via `Arc` or use the module-level convenience functions.
+#[derive(Debug, Clone, Default)]
+pub struct PolicyEngine;
+
+impl PolicyEngine {
+    /// Derive the full [`HandlingRequirements`] for a known [`DataField`].
+    pub fn requirements_for_field(&self, field: DataField) -> HandlingRequirements {
+        let tier = field.tier();
+        let category = field.category();
+        let masking_strategy = field.masking_strategy();
+        self.build_requirements(tier, category, masking_strategy)
+    }
+
+    /// Derive [`HandlingRequirements`] for an ad-hoc tier + category pair.
+    ///
+    /// Use this when you have a tier/category but not a specific [`DataField`]
+    /// variant (e.g., dynamic JSONB fields from provider responses).
+    pub fn requirements_for(
+        &self,
+        tier: ClassificationTier,
+        category: DataCategory,
+    ) -> HandlingRequirements {
+        let masking_strategy = default_masking_for_tier(tier);
+        self.build_requirements(tier, category, masking_strategy)
+    }
+
+    fn build_requirements(
+        &self,
+        tier: ClassificationTier,
+        category: DataCategory,
+        masking_strategy: MaskingStrategy,
+    ) -> HandlingRequirements {
+        HandlingRequirements {
+            tier,
+            category,
+            encrypt_at_rest: tier.requires_encryption_at_rest(),
+            encrypt_in_transit: tier.requires_encryption_in_transit(),
+            mask_in_logs: tier.requires_masking(),
+            // Responses: mask Restricted+ but show Confidential amounts to the
+            // authenticated owner (the enforcer layer handles ownership checks).
+            mask_in_responses: tier >= ClassificationTier::Restricted,
+            never_log: tier.must_never_log(),
+            audit_on_access: tier.requires_access_audit(),
+            retention_days: tier.default_retention_days(),
+            masking_strategy,
+        }
+    }
+
+    /// Returns `true` if the given tier is permitted to be included in a
+    /// log line at the given log level.
+    ///
+    /// Rules:
+    /// - `Critical` → never log regardless of level.
+    /// - `Restricted` → only at TRACE level in non-production environments.
+    /// - `Confidential` → only masked values; raw values never logged.
+    /// - `Internal` / `Public` → always permitted.
+    pub fn is_loggable(&self, tier: ClassificationTier, is_production: bool) -> bool {
+        match tier {
+            ClassificationTier::Critical => false,
+            ClassificationTier::Restricted => !is_production,
+            ClassificationTier::Confidential => true, // masked value is loggable
+            ClassificationTier::Internal => true,
+            ClassificationTier::Public => true,
+        }
+    }
+
+    /// Returns `true` if a field at this tier may be included in an API
+    /// response body without additional masking.
+    ///
+    /// Callers must still apply the masking strategy for Confidential fields.
+    pub fn is_response_safe(&self, tier: ClassificationTier) -> bool {
+        tier <= ClassificationTier::Confidential
+    }
+
+    /// Returns `true` if a field at this tier may be stored in a cache
+    /// (Redis / in-process L1).
+    ///
+    /// Critical fields must never be cached.  Restricted fields may only be
+    /// cached with encryption.
+    pub fn is_cacheable(&self, tier: ClassificationTier) -> bool {
+        tier < ClassificationTier::Critical
+    }
+
+    /// Returns `true` if a field at this tier may be included in a webhook
+    /// payload sent to an external endpoint.
+    pub fn is_webhook_safe(&self, tier: ClassificationTier) -> bool {
+        tier <= ClassificationTier::Internal
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transmission policy
+// ---------------------------------------------------------------------------
+
+/// Transmission context — where is the data going?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransmissionContext {
+    /// Outbound HTTP response to an authenticated API client.
+    ApiResponse,
+    /// Outbound webhook delivery to a developer-registered endpoint.
+    WebhookDelivery,
+    /// Internal service-to-service call (same trust boundary).
+    InternalRpc,
+    /// Log line (structured JSON log).
+    LogLine,
+    /// Cache storage (Redis / in-process).
+    Cache,
+    /// Database persistence.
+    Database,
+}
+
+/// Policy decision for a transmission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransmissionDecision {
+    /// Allow as-is.
+    Allow,
+    /// Allow but apply the specified masking strategy first.
+    AllowMasked(MaskingStrategy),
+    /// Deny — this field must not be transmitted in this context.
+    Deny { reason: &'static str },
+}
+
+impl PolicyEngine {
+    /// Decide whether and how a field may be transmitted in a given context.
+    pub fn transmission_decision(
+        &self,
+        field: DataField,
+        context: TransmissionContext,
+    ) -> TransmissionDecision {
+        let tier = field.tier();
+        let strategy = field.masking_strategy();
+
+        match context {
+            TransmissionContext::LogLine => {
+                if tier.must_never_log() {
+                    TransmissionDecision::Deny {
+                        reason: "field tier is CRITICAL — must never appear in logs",
+                    }
+                } else if tier.requires_masking() {
+                    TransmissionDecision::AllowMasked(strategy)
+                } else {
+                    TransmissionDecision::Allow
+                }
+            }
+
+            TransmissionContext::ApiResponse => {
+                if tier >= ClassificationTier::Critical {
+                    TransmissionDecision::Deny {
+                        reason: "CRITICAL fields must never be included in API responses",
+                    }
+                } else if tier >= ClassificationTier::Restricted {
+                    TransmissionDecision::AllowMasked(strategy)
+                } else {
+                    TransmissionDecision::Allow
+                }
+            }
+
+            TransmissionContext::WebhookDelivery => {
+                if tier >= ClassificationTier::Restricted {
+                    TransmissionDecision::Deny {
+                        reason: "Restricted/Critical fields must not be sent in webhook payloads",
+                    }
+                } else if tier >= ClassificationTier::Confidential {
+                    TransmissionDecision::AllowMasked(strategy)
+                } else {
+                    TransmissionDecision::Allow
+                }
+            }
+
+            TransmissionContext::InternalRpc => {
+                // Internal calls within the same trust boundary may carry
+                // Confidential data but never Critical plaintext.
+                if tier >= ClassificationTier::Critical {
+                    TransmissionDecision::Deny {
+                        reason: "CRITICAL fields must not be passed over RPC — use references",
+                    }
+                } else {
+                    TransmissionDecision::Allow
+                }
+            }
+
+            TransmissionContext::Cache => {
+                if tier >= ClassificationTier::Critical {
+                    TransmissionDecision::Deny {
+                        reason: "CRITICAL fields must never be cached",
+                    }
+                } else {
+                    // Restricted fields may be cached but must be encrypted;
+                    // the cache layer is responsible for that.
+                    TransmissionDecision::Allow
+                }
+            }
+
+            TransmissionContext::Database => {
+                // Database always allows storage; encryption-at-rest is
+                // enforced at the infrastructure level (column encryption /
+                // tablespace encryption).  Critical fields must be hashed
+                // before storage — that is enforced at the service layer.
+                TransmissionDecision::Allow
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn default_masking_for_tier(tier: ClassificationTier) -> MaskingStrategy {
+    match tier {
+        ClassificationTier::Critical | ClassificationTier::Restricted => {
+            MaskingStrategy::FullRedact
+        }
+        ClassificationTier::Confidential => MaskingStrategy::PartialMask {
+            show_first: 2,
+            show_last: 2,
+        },
+        ClassificationTier::Internal | ClassificationTier::Public => MaskingStrategy::None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level convenience functions
+// ---------------------------------------------------------------------------
+
+/// Convenience: get requirements for a field without constructing the engine.
+pub fn requirements_for_field(field: DataField) -> HandlingRequirements {
+    PolicyEngine::default().requirements_for_field(field)
+}
+
+/// Convenience: get the transmission decision for a field in a context.
+pub fn transmission_decision(
+    field: DataField,
+    context: TransmissionContext,
+) -> TransmissionDecision {
+    PolicyEngine::default().transmission_decision(field, context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_classification::registry::DataField;
+
+    #[test]
+    fn private_key_denied_in_logs() {
+        let decision =
+            transmission_decision(DataField::WalletPrivateKey, TransmissionContext::LogLine);
+        assert!(matches!(decision, TransmissionDecision::Deny { .. }));
+    }
+
+    #[test]
+    fn private_key_denied_in_api_response() {
+        let decision =
+            transmission_decision(DataField::WalletPrivateKey, TransmissionContext::ApiResponse);
+        assert!(matches!(decision, TransmissionDecision::Deny { .. }));
+    }
+
+    #[test]
+    fn private_key_denied_in_cache() {
+        let decision =
+            transmission_decision(DataField::WalletPrivateKey, TransmissionContext::Cache);
+        assert!(matches!(decision, TransmissionDecision::Deny { .. }));
+    }
+
+    #[test]
+    fn email_masked_in_logs() {
+        let decision = transmission_decision(DataField::UserEmail, TransmissionContext::LogLine);
+        assert!(matches!(decision, TransmissionDecision::AllowMasked(_)));
+    }
+
+    #[test]
+    fn currency_code_allowed_everywhere() {
+        for ctx in [
+            TransmissionContext::LogLine,
+            TransmissionContext::ApiResponse,
+            TransmissionContext::WebhookDelivery,
+            TransmissionContext::Cache,
+            TransmissionContext::Database,
+        ] {
+            let decision = transmission_decision(DataField::CurrencyCode, ctx);
+            assert_eq!(decision, TransmissionDecision::Allow);
+        }
+    }
+
+    #[test]
+    fn kyc_document_image_denied_in_webhook() {
+        let decision = transmission_decision(
+            DataField::KycDocumentImageRef,
+            TransmissionContext::WebhookDelivery,
+        );
+        assert!(matches!(decision, TransmissionDecision::Deny { .. }));
+    }
+
+    #[test]
+    fn requirements_for_email_has_correct_flags() {
+        let req = requirements_for_field(DataField::UserEmail);
+        assert!(req.encrypt_at_rest);
+        assert!(req.encrypt_in_transit);
+        assert!(req.mask_in_logs);
+        assert!(!req.never_log);
+        assert!(!req.audit_on_access);
+    }
+
+    #[test]
+    fn requirements_for_private_key_never_log() {
+        let req = requirements_for_field(DataField::WalletPrivateKey);
+        assert!(req.never_log);
+        assert!(req.encrypt_at_rest);
+        assert!(req.audit_on_access);
+    }
+}

--- a/src/data_classification/registry.rs
+++ b/src/data_classification/registry.rs
@@ -1,0 +1,435 @@
+//! Authoritative data field registry.
+//!
+//! Every field that flows through the Aframp platform is registered here with
+//! its classification tier, category, and masking strategy.  This is the
+//! single source of truth that the policy engine, log sanitiser, and
+//! serialisation guards consult.
+//!
+//! # Adding a new field
+//!
+//! 1. Add a variant to [`DataField`].
+//! 2. Implement the three methods on the `DataField` impl block.
+//! 3. Add a test case in the `tests` module.
+
+use crate::data_classification::types::{ClassificationTier, DataCategory, MaskingStrategy};
+
+/// Every named data field on the platform, mapped to its classification.
+///
+/// Variants are grouped by domain for readability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DataField {
+    // ── User / Identity ─────────────────────────────────────────────────────
+    UserEmail,
+    UserPhone,
+    UserFullName,
+    UserDateOfBirth,
+    UserPhysicalAddress,
+
+    // ── KYC / Identity Documents ────────────────────────────────────────────
+    KycDocumentNumber,
+    KycDocumentType,
+    KycDocumentImageRef,
+    KycSelfieImageRef,
+    KycIssuingCountry,
+    KycExpiryDate,
+    KycVerificationStatus,
+    KycVerificationTier,
+    KycRiskScore,
+    KycEddTriggerReason,
+    KycEddCaseDetails,
+    KycManualReviewReason,
+    KycVerificationSessionId,
+    KycVerificationProvider,
+
+    // ── Wallet / Blockchain ──────────────────────────────────────────────────
+    WalletAddress,
+    WalletPrivateKey,
+    WalletSecretSeed,
+    BlockchainTxHash,
+    CryptoBalance,
+    CngnBalance,
+
+    // ── Transactions ─────────────────────────────────────────────────────────
+    TransactionId,
+    TransactionAmount,
+    TransactionFromAmount,
+    TransactionToAmount,
+    TransactionAfriAmount,
+    TransactionStatus,
+    TransactionPaymentReference,
+    TransactionErrorMessage,
+    TransactionMetadata,
+
+    // ── Payment Methods ──────────────────────────────────────────────────────
+    PaymentMethodEncryptedData,
+    PaymentMethodPhoneNumber,
+    BankAccountNumber,
+    BankAccountName,
+    BankCode,
+    CardPan,
+    CardToken,
+    BillAccountNumber,
+
+    // ── Authentication ───────────────────────────────────────────────────────
+    JwtAccessToken,
+    JwtRefreshToken,
+    JwtSessionId,
+    JwtJti,
+    ApiKeyPlaintext,
+    ApiKeyHash,
+    ApiKeyPrefix,
+    OAuthClientId,
+    OAuthClientSecretHash,
+    OAuthRedirectUri,
+    TotpSecretSeed,
+
+    // ── Provider Credentials ─────────────────────────────────────────────────
+    PaystackSecretKey,
+    FlutterwaveSecretKey,
+    MpesaConsumerKey,
+    MpesaConsumerSecret,
+    MpesaPasskey,
+    WebhookSignatureSecret,
+    WebhookPayload,
+    WebhookSignature,
+
+    // ── Compliance / Risk ────────────────────────────────────────────────────
+    IpAddress,
+    IpReputationScore,
+    GeoCountryCode,
+    ComplianceFlag,
+    AmlAlertDetails,
+
+    // ── Operational / Audit ──────────────────────────────────────────────────
+    ExchangeRate,
+    FeeAmount,
+    FeeStructureDetails,
+    AuditLogEntry,
+    AdminActionDetail,
+    RequestIntegrityHash,
+    ErrorStackTrace,
+
+    // ── Public ───────────────────────────────────────────────────────────────
+    CurrencyCode,
+    SupportedChain,
+    ApiVersion,
+    HealthStatus,
+}
+
+impl DataField {
+    /// The classification tier for this field.
+    pub fn tier(&self) -> ClassificationTier {
+        match self {
+            // ── Critical ────────────────────────────────────────────────────
+            DataField::WalletPrivateKey
+            | DataField::WalletSecretSeed
+            | DataField::ApiKeyPlaintext
+            | DataField::OAuthClientSecretHash
+            | DataField::TotpSecretSeed
+            | DataField::PaystackSecretKey
+            | DataField::FlutterwaveSecretKey
+            | DataField::MpesaConsumerKey
+            | DataField::MpesaConsumerSecret
+            | DataField::MpesaPasskey
+            | DataField::WebhookSignatureSecret
+            | DataField::CardPan => ClassificationTier::Critical,
+
+            // ── Restricted ──────────────────────────────────────────────────
+            DataField::KycDocumentNumber
+            | DataField::KycDocumentImageRef
+            | DataField::KycSelfieImageRef
+            | DataField::KycExpiryDate
+            | DataField::KycEddCaseDetails
+            | DataField::KycManualReviewReason
+            | DataField::UserFullName
+            | DataField::UserDateOfBirth
+            | DataField::UserPhysicalAddress
+            | DataField::JwtAccessToken
+            | DataField::JwtRefreshToken
+            | DataField::BankAccountNumber
+            | DataField::AmlAlertDetails => ClassificationTier::Restricted,
+
+            // ── Confidential ────────────────────────────────────────────────
+            DataField::UserEmail
+            | DataField::UserPhone
+            | DataField::WalletAddress
+            | DataField::CryptoBalance
+            | DataField::CngnBalance
+            | DataField::TransactionAmount
+            | DataField::TransactionFromAmount
+            | DataField::TransactionToAmount
+            | DataField::TransactionAfriAmount
+            | DataField::TransactionPaymentReference
+            | DataField::PaymentMethodEncryptedData
+            | DataField::PaymentMethodPhoneNumber
+            | DataField::BankAccountName
+            | DataField::CardToken
+            | DataField::BillAccountNumber
+            | DataField::KycVerificationStatus
+            | DataField::KycVerificationTier
+            | DataField::KycRiskScore
+            | DataField::KycEddTriggerReason
+            | DataField::KycVerificationSessionId
+            | DataField::IpAddress
+            | DataField::ComplianceFlag
+            | DataField::BlockchainTxHash
+            | DataField::FiatAmount
+            | DataField::ApiKeyHash
+            | DataField::JwtSessionId
+            | DataField::JwtJti
+            | DataField::WebhookSignature => ClassificationTier::Confidential,
+
+            // ── Internal ────────────────────────────────────────────────────
+            DataField::ExchangeRate
+            | DataField::FeeAmount
+            | DataField::FeeStructureDetails
+            | DataField::AuditLogEntry
+            | DataField::AdminActionDetail
+            | DataField::RequestIntegrityHash
+            | DataField::ErrorStackTrace
+            | DataField::TransactionErrorMessage
+            | DataField::TransactionMetadata
+            | DataField::WebhookPayload
+            | DataField::IpReputationScore
+            | DataField::GeoCountryCode
+            | DataField::KycDocumentType
+            | DataField::KycIssuingCountry
+            | DataField::KycVerificationProvider
+            | DataField::OAuthClientId
+            | DataField::OAuthRedirectUri
+            | DataField::ApiKeyPrefix
+            | DataField::BankCode
+            | DataField::TransactionId => ClassificationTier::Internal,
+
+            // ── Public ──────────────────────────────────────────────────────
+            DataField::CurrencyCode
+            | DataField::SupportedChain
+            | DataField::ApiVersion
+            | DataField::HealthStatus
+            | DataField::TransactionStatus => ClassificationTier::Public,
+        }
+    }
+
+    /// The data category this field belongs to.
+    pub fn category(&self) -> DataCategory {
+        match self {
+            DataField::UserEmail => DataCategory::Email,
+            DataField::UserPhone => DataCategory::PhoneNumber,
+            DataField::UserFullName => DataCategory::FullName,
+            DataField::UserDateOfBirth => DataCategory::DateOfBirth,
+            DataField::UserPhysicalAddress => DataCategory::PhysicalAddress,
+
+            DataField::KycDocumentNumber
+            | DataField::KycDocumentType
+            | DataField::KycIssuingCountry
+            | DataField::KycExpiryDate => DataCategory::GovernmentId,
+            DataField::KycDocumentImageRef => DataCategory::IdentityDocument,
+            DataField::KycSelfieImageRef => DataCategory::BiometricData,
+            DataField::KycVerificationStatus | DataField::KycVerificationTier => {
+                DataCategory::KycStatus
+            }
+            DataField::KycRiskScore | DataField::KycEddTriggerReason => DataCategory::RiskScore,
+            DataField::KycEddCaseDetails => DataCategory::EnhancedDueDiligenceData,
+            DataField::KycManualReviewReason => DataCategory::ManualReviewData,
+            DataField::KycVerificationSessionId | DataField::KycVerificationProvider => {
+                DataCategory::KycStatus
+            }
+
+            DataField::WalletAddress => DataCategory::WalletAddress,
+            DataField::WalletPrivateKey | DataField::WalletSecretSeed => DataCategory::PrivateKey,
+            DataField::BlockchainTxHash => DataCategory::BlockchainTxHash,
+            DataField::CryptoBalance | DataField::CngnBalance => DataCategory::CryptoBalance,
+
+            DataField::TransactionId
+            | DataField::TransactionStatus
+            | DataField::TransactionPaymentReference
+            | DataField::TransactionErrorMessage
+            | DataField::TransactionMetadata => DataCategory::TransactionStatus,
+            DataField::TransactionAmount
+            | DataField::TransactionFromAmount
+            | DataField::TransactionToAmount
+            | DataField::TransactionAfriAmount
+            | DataField::FiatAmount => DataCategory::TransactionAmount,
+
+            DataField::PaymentMethodEncryptedData | DataField::CardToken => {
+                DataCategory::CardToken
+            }
+            DataField::PaymentMethodPhoneNumber | DataField::BillAccountNumber => {
+                DataCategory::MobileMoneyIdentifier
+            }
+            DataField::BankAccountNumber => DataCategory::BankAccountNumber,
+            DataField::BankAccountName | DataField::BankCode => {
+                DataCategory::BankAccountNumberMasked
+            }
+            DataField::CardPan => DataCategory::CardPan,
+
+            DataField::JwtAccessToken => DataCategory::JwtToken,
+            DataField::JwtRefreshToken => DataCategory::RefreshToken,
+            DataField::JwtSessionId | DataField::JwtJti => DataCategory::JwtToken,
+            DataField::ApiKeyPlaintext => DataCategory::ApiKeyPlaintext,
+            DataField::ApiKeyHash | DataField::ApiKeyPrefix => DataCategory::CredentialHash,
+            DataField::OAuthClientId
+            | DataField::OAuthClientSecretHash
+            | DataField::OAuthRedirectUri => DataCategory::OAuthClientSecret,
+            DataField::TotpSecretSeed => DataCategory::TotpSecret,
+
+            DataField::PaystackSecretKey
+            | DataField::FlutterwaveSecretKey
+            | DataField::MpesaConsumerKey
+            | DataField::MpesaConsumerSecret
+            | DataField::MpesaPasskey => DataCategory::ProviderSecretKey,
+            DataField::WebhookSignatureSecret => DataCategory::WebhookSecret,
+            DataField::WebhookPayload => DataCategory::WebhookPayload,
+            DataField::WebhookSignature => DataCategory::WebhookSecret,
+
+            DataField::IpAddress => DataCategory::IpAddress,
+            DataField::IpReputationScore => DataCategory::RiskScore,
+            DataField::GeoCountryCode => DataCategory::PublicApiMetadata,
+            DataField::ComplianceFlag | DataField::AmlAlertDetails => {
+                DataCategory::ComplianceFlag
+            }
+
+            DataField::ExchangeRate => DataCategory::ExchangeRate,
+            DataField::FeeAmount | DataField::FeeStructureDetails => DataCategory::FeeStructure,
+            DataField::AuditLogEntry | DataField::AdminActionDetail => DataCategory::AuditLogEntry,
+            DataField::RequestIntegrityHash => DataCategory::RequestIntegrityHash,
+            DataField::ErrorStackTrace => DataCategory::ErrorMessage,
+
+            DataField::CurrencyCode => DataCategory::CurrencyCode,
+            DataField::SupportedChain
+            | DataField::ApiVersion
+            | DataField::HealthStatus => DataCategory::PublicApiMetadata,
+        }
+    }
+
+    /// The masking strategy to apply when this field must be masked.
+    pub fn masking_strategy(&self) -> MaskingStrategy {
+        match self {
+            // Never show any part of these
+            DataField::WalletPrivateKey
+            | DataField::WalletSecretSeed
+            | DataField::ApiKeyPlaintext
+            | DataField::OAuthClientSecretHash
+            | DataField::TotpSecretSeed
+            | DataField::PaystackSecretKey
+            | DataField::FlutterwaveSecretKey
+            | DataField::MpesaConsumerKey
+            | DataField::MpesaConsumerSecret
+            | DataField::MpesaPasskey
+            | DataField::WebhookSignatureSecret
+            | DataField::CardPan
+            | DataField::JwtAccessToken
+            | DataField::JwtRefreshToken
+            | DataField::ApiKeyHash
+            | DataField::KycDocumentImageRef
+            | DataField::KycSelfieImageRef
+            | DataField::KycEddCaseDetails
+            | DataField::AmlAlertDetails => MaskingStrategy::FullRedact,
+
+            // Email: show domain only → user@***.com → u***@***.com
+            DataField::UserEmail => MaskingStrategy::PartialMask {
+                show_first: 2,
+                show_last: 4,
+            },
+
+            // Phone: show last 4 digits
+            DataField::UserPhone | DataField::PaymentMethodPhoneNumber => {
+                MaskingStrategy::PartialMask {
+                    show_first: 0,
+                    show_last: 4,
+                }
+            }
+
+            // Wallet address: show first 4 + last 4 (Stellar convention)
+            DataField::WalletAddress => MaskingStrategy::PartialMask {
+                show_first: 4,
+                show_last: 4,
+            },
+
+            // Bank account: show last 4
+            DataField::BankAccountNumber | DataField::BillAccountNumber => {
+                MaskingStrategy::PartialMask {
+                    show_first: 0,
+                    show_last: 4,
+                }
+            }
+
+            // KYC document number: show last 4
+            DataField::KycDocumentNumber => MaskingStrategy::PartialMask {
+                show_first: 0,
+                show_last: 4,
+            },
+
+            // Names / DOB: full redact in logs
+            DataField::UserFullName
+            | DataField::UserDateOfBirth
+            | DataField::UserPhysicalAddress
+            | DataField::BankAccountName => MaskingStrategy::FullRedact,
+
+            // Transaction amounts: show as-is in responses (needed for UX), redact in logs
+            DataField::TransactionAmount
+            | DataField::TransactionFromAmount
+            | DataField::TransactionToAmount
+            | DataField::TransactionAfriAmount
+            | DataField::FiatAmount
+            | DataField::CryptoBalance
+            | DataField::CngnBalance => MaskingStrategy::Placeholder("[AMOUNT]"),
+
+            // IP address: mask last octet
+            DataField::IpAddress => MaskingStrategy::PartialMask {
+                show_first: 7,
+                show_last: 0,
+            },
+
+            // Webhook signature: full redact
+            DataField::WebhookSignature => MaskingStrategy::FullRedact,
+
+            // Everything else at Confidential/Internal: full redact
+            _ => MaskingStrategy::FullRedact,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_key_is_critical() {
+        assert_eq!(DataField::WalletPrivateKey.tier(), ClassificationTier::Critical);
+    }
+
+    #[test]
+    fn email_is_confidential() {
+        assert_eq!(DataField::UserEmail.tier(), ClassificationTier::Confidential);
+    }
+
+    #[test]
+    fn transaction_status_is_public() {
+        assert_eq!(DataField::TransactionStatus.tier(), ClassificationTier::Public);
+    }
+
+    #[test]
+    fn kyc_document_image_is_restricted() {
+        assert_eq!(
+            DataField::KycDocumentImageRef.tier(),
+            ClassificationTier::Restricted
+        );
+    }
+
+    #[test]
+    fn wallet_address_masking() {
+        let strategy = DataField::WalletAddress.masking_strategy();
+        let addr = "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRS";
+        let masked = strategy.apply(addr);
+        assert!(masked.starts_with("GABC"));
+        assert!(masked.ends_with("PQRS"));
+    }
+
+    #[test]
+    fn phone_masking_shows_last_four() {
+        let strategy = DataField::UserPhone.masking_strategy();
+        let masked = strategy.apply("+2348012345678");
+        assert!(masked.ends_with("5678"));
+    }
+}

--- a/src/data_classification/types.rs
+++ b/src/data_classification/types.rs
@@ -1,0 +1,386 @@
+//! Data classification types — the authoritative taxonomy for every category
+//! of sensitive data handled by the Aframp platform.
+//!
+//! # Classification Tiers (highest → lowest sensitivity)
+//!
+//! | Tier | Label | Examples |
+//! |------|-------|---------|
+//! | 1 | `Critical` | Private keys, wallet secrets, raw card data, auth credentials |
+//! | 2 | `Restricted` | KYC documents, government IDs, selfies, full account numbers |
+//! | 3 | `Confidential` | Email, phone, wallet addresses, transaction amounts, KYC status |
+//! | 4 | `Internal` | Exchange rates, fee structures, provider configs, audit metadata |
+//! | 5 | `Public` | Supported currencies, health status, API version |
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Classification tier
+// ---------------------------------------------------------------------------
+
+/// The sensitivity tier assigned to a data element.
+///
+/// Tiers are ordered: `Critical > Restricted > Confidential > Internal > Public`.
+/// Use `tier >= ClassificationTier::Confidential` to test "needs protection".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClassificationTier {
+    /// Tier 5 — freely shareable, no protection required.
+    Public = 1,
+    /// Tier 4 — internal operational data; not for external exposure.
+    Internal = 2,
+    /// Tier 3 — personal or financial data; encryption + masking required.
+    Confidential = 3,
+    /// Tier 2 — identity documents, biometrics; strict access + encryption.
+    Restricted = 4,
+    /// Tier 1 — cryptographic secrets, raw credentials; never logged or stored in plaintext.
+    Critical = 5,
+}
+
+impl ClassificationTier {
+    /// Returns `true` if this tier requires encryption at rest.
+    pub fn requires_encryption_at_rest(&self) -> bool {
+        *self >= ClassificationTier::Confidential
+    }
+
+    /// Returns `true` if this tier requires encryption in transit (TLS).
+    pub fn requires_encryption_in_transit(&self) -> bool {
+        *self >= ClassificationTier::Internal
+    }
+
+    /// Returns `true` if this tier must be masked in logs and API responses.
+    pub fn requires_masking(&self) -> bool {
+        *self >= ClassificationTier::Confidential
+    }
+
+    /// Returns `true` if this tier must never appear in log output at all.
+    pub fn must_never_log(&self) -> bool {
+        *self >= ClassificationTier::Critical
+    }
+
+    /// Returns `true` if access to this tier requires an audit trail entry.
+    pub fn requires_access_audit(&self) -> bool {
+        *self >= ClassificationTier::Restricted
+    }
+
+    /// Human-readable label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ClassificationTier::Public => "PUBLIC",
+            ClassificationTier::Internal => "INTERNAL",
+            ClassificationTier::Confidential => "CONFIDENTIAL",
+            ClassificationTier::Restricted => "RESTRICTED",
+            ClassificationTier::Critical => "CRITICAL",
+        }
+    }
+
+    /// Default retention period in days (`None` = retain indefinitely for compliance).
+    pub fn default_retention_days(&self) -> Option<u32> {
+        match self {
+            ClassificationTier::Public => None,
+            ClassificationTier::Internal => Some(365),
+            ClassificationTier::Confidential => Some(2555), // 7 years — AML/KYC requirement
+            ClassificationTier::Restricted => Some(2555),   // 7 years
+            ClassificationTier::Critical => Some(90),       // rotate/purge quickly
+        }
+    }
+}
+
+impl fmt::Display for ClassificationTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.label())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Data categories
+// ---------------------------------------------------------------------------
+
+/// Logical grouping of data elements by domain.
+///
+/// Each category maps to one or more [`ClassificationTier`]s depending on
+/// the specific field. The category is used by the policy engine to apply
+/// domain-specific handling rules on top of the tier rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DataCategory {
+    // ── Identity & PII ──────────────────────────────────────────────────────
+    /// Email addresses (login identifier).
+    Email,
+    /// Phone numbers (login / M-Pesa identifier).
+    PhoneNumber,
+    /// Full legal name from KYC documents.
+    FullName,
+    /// Date of birth from identity documents.
+    DateOfBirth,
+    /// National ID / passport / driver's licence number.
+    GovernmentId,
+    /// Scanned or photographed identity document.
+    IdentityDocument,
+    /// Liveness selfie captured during KYC.
+    BiometricData,
+    /// Physical or postal address.
+    PhysicalAddress,
+    /// IP address of a request.
+    IpAddress,
+
+    // ── Financial ───────────────────────────────────────────────────────────
+    /// Transaction monetary amounts.
+    TransactionAmount,
+    /// Bank account number (full).
+    BankAccountNumber,
+    /// Bank account number (masked for display).
+    BankAccountNumberMasked,
+    /// Raw card PAN — must never be stored.
+    CardPan,
+    /// Tokenised card reference (provider token, not raw PAN).
+    CardToken,
+    /// M-Pesa / mobile money phone number used as payment identifier.
+    MobileMoneyIdentifier,
+    /// Blockchain wallet address.
+    WalletAddress,
+    /// On-chain transaction hash.
+    BlockchainTxHash,
+    /// AFRI / cNGN balance.
+    CryptoBalance,
+    /// Fiat balance or quoted amount.
+    FiatAmount,
+    /// Exchange rate (internal pricing).
+    ExchangeRate,
+    /// Fee structure details.
+    FeeStructure,
+
+    // ── Authentication & Credentials ────────────────────────────────────────
+    /// Stellar / blockchain private key or secret seed.
+    PrivateKey,
+    /// JWT access token (full string).
+    JwtToken,
+    /// JWT refresh token.
+    RefreshToken,
+    /// API key plaintext (issued once, never stored).
+    ApiKeyPlaintext,
+    /// Argon2id hash of an API key or password.
+    CredentialHash,
+    /// OAuth client secret.
+    OAuthClientSecret,
+    /// TOTP / 2FA secret seed.
+    TotpSecret,
+    /// Payment provider webhook secret.
+    WebhookSecret,
+    /// Payment provider API secret key.
+    ProviderSecretKey,
+
+    // ── Compliance & Risk ───────────────────────────────────────────────────
+    /// KYC verification tier and status.
+    KycStatus,
+    /// KYC risk score or EDD trigger reason.
+    RiskScore,
+    /// AML / compliance flags.
+    ComplianceFlag,
+    /// Manual review queue entry.
+    ManualReviewData,
+    /// EDD case details.
+    EnhancedDueDiligenceData,
+
+    // ── Operational ─────────────────────────────────────────────────────────
+    /// Webhook event payload from a payment provider.
+    WebhookPayload,
+    /// Provider-specific response data.
+    ProviderResponseData,
+    /// Internal error messages (may contain stack traces).
+    ErrorMessage,
+    /// Audit log entry.
+    AuditLogEntry,
+    /// Request / response hash for integrity audit.
+    RequestIntegrityHash,
+
+    // ── Public ──────────────────────────────────────────────────────────────
+    /// Supported currency codes.
+    CurrencyCode,
+    /// Transaction status code (pending / completed / failed).
+    TransactionStatus,
+    /// API health / version information.
+    PublicApiMetadata,
+}
+
+impl DataCategory {
+    /// The default classification tier for this category.
+    ///
+    /// Individual fields may override this via [`DataField::tier`].
+    pub fn default_tier(&self) -> ClassificationTier {
+        match self {
+            // Critical — never log, never store plaintext
+            DataCategory::PrivateKey
+            | DataCategory::ApiKeyPlaintext
+            | DataCategory::OAuthClientSecret
+            | DataCategory::TotpSecret
+            | DataCategory::WebhookSecret
+            | DataCategory::ProviderSecretKey
+            | DataCategory::CardPan => ClassificationTier::Critical,
+
+            // Restricted — identity documents, biometrics
+            DataCategory::IdentityDocument
+            | DataCategory::BiometricData
+            | DataCategory::GovernmentId
+            | DataCategory::DateOfBirth
+            | DataCategory::FullName
+            | DataCategory::JwtToken
+            | DataCategory::RefreshToken
+            | DataCategory::BankAccountNumber
+            | DataCategory::EnhancedDueDiligenceData
+            | DataCategory::ManualReviewData => ClassificationTier::Restricted,
+
+            // Confidential — PII, financial identifiers
+            DataCategory::Email
+            | DataCategory::PhoneNumber
+            | DataCategory::PhysicalAddress
+            | DataCategory::IpAddress
+            | DataCategory::TransactionAmount
+            | DataCategory::CardToken
+            | DataCategory::MobileMoneyIdentifier
+            | DataCategory::WalletAddress
+            | DataCategory::CryptoBalance
+            | DataCategory::FiatAmount
+            | DataCategory::CredentialHash
+            | DataCategory::KycStatus
+            | DataCategory::RiskScore
+            | DataCategory::ComplianceFlag
+            | DataCategory::BlockchainTxHash
+            | DataCategory::BankAccountNumberMasked => ClassificationTier::Confidential,
+
+            // Internal — operational / pricing data
+            DataCategory::ExchangeRate
+            | DataCategory::FeeStructure
+            | DataCategory::WebhookPayload
+            | DataCategory::ProviderResponseData
+            | DataCategory::ErrorMessage
+            | DataCategory::AuditLogEntry
+            | DataCategory::RequestIntegrityHash => ClassificationTier::Internal,
+
+            // Public
+            DataCategory::CurrencyCode
+            | DataCategory::TransactionStatus
+            | DataCategory::PublicApiMetadata => ClassificationTier::Public,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handling requirements
+// ---------------------------------------------------------------------------
+
+/// The complete set of handling requirements derived from a classification.
+///
+/// Produced by [`crate::data_classification::policy::PolicyEngine::requirements_for`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandlingRequirements {
+    pub tier: ClassificationTier,
+    pub category: DataCategory,
+    /// Must be encrypted at rest (AES-256-GCM or equivalent).
+    pub encrypt_at_rest: bool,
+    /// Must only be transmitted over TLS 1.2+.
+    pub encrypt_in_transit: bool,
+    /// Must be masked / redacted in log output.
+    pub mask_in_logs: bool,
+    /// Must be masked in API responses returned to clients.
+    pub mask_in_responses: bool,
+    /// Must never appear in any log output whatsoever.
+    pub never_log: bool,
+    /// Every read access must produce an audit trail entry.
+    pub audit_on_access: bool,
+    /// Retention period in days (`None` = indefinite / compliance-driven).
+    pub retention_days: Option<u32>,
+    /// Masking strategy to apply when `mask_in_logs` or `mask_in_responses` is true.
+    pub masking_strategy: MaskingStrategy,
+}
+
+/// How a value should be masked when displayed or logged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaskingStrategy {
+    /// Replace the entire value with `[REDACTED]`.
+    FullRedact,
+    /// Show first N and last N characters, mask the middle with `*`.
+    PartialMask { show_first: usize, show_last: usize },
+    /// Replace with a fixed placeholder string.
+    Placeholder(&'static str),
+    /// No masking required.
+    None,
+}
+
+impl MaskingStrategy {
+    /// Apply this masking strategy to a string value.
+    pub fn apply(&self, value: &str) -> String {
+        match self {
+            MaskingStrategy::FullRedact => "[REDACTED]".to_string(),
+            MaskingStrategy::PartialMask {
+                show_first,
+                show_last,
+            } => {
+                let len = value.len();
+                let first = (*show_first).min(len);
+                let last = (*show_last).min(len.saturating_sub(first));
+                if first + last >= len {
+                    // Value too short to meaningfully mask — redact fully
+                    return "[REDACTED]".to_string();
+                }
+                let masked_len = len - first - last;
+                format!(
+                    "{}{}{}",
+                    &value[..first],
+                    "*".repeat(masked_len),
+                    &value[len - last..]
+                )
+            }
+            MaskingStrategy::Placeholder(p) => p.to_string(),
+            MaskingStrategy::None => value.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_ordering_is_correct() {
+        assert!(ClassificationTier::Critical > ClassificationTier::Restricted);
+        assert!(ClassificationTier::Restricted > ClassificationTier::Confidential);
+        assert!(ClassificationTier::Confidential > ClassificationTier::Internal);
+        assert!(ClassificationTier::Internal > ClassificationTier::Public);
+    }
+
+    #[test]
+    fn critical_tier_never_logs() {
+        assert!(ClassificationTier::Critical.must_never_log());
+        assert!(!ClassificationTier::Confidential.must_never_log());
+    }
+
+    #[test]
+    fn masking_partial_mask() {
+        let strategy = MaskingStrategy::PartialMask {
+            show_first: 4,
+            show_last: 4,
+        };
+        let result = strategy.apply("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234");
+        assert!(result.starts_with("GABC"));
+        assert!(result.ends_with("1234"));
+        assert!(result.contains('*'));
+    }
+
+    #[test]
+    fn masking_full_redact() {
+        let result = MaskingStrategy::FullRedact.apply("super-secret");
+        assert_eq!(result, "[REDACTED]");
+    }
+
+    #[test]
+    fn masking_short_value_redacts_fully() {
+        let strategy = MaskingStrategy::PartialMask {
+            show_first: 4,
+            show_last: 4,
+        };
+        // Value shorter than show_first + show_last → full redact
+        assert_eq!(strategy.apply("abc"), "[REDACTED]");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,11 @@ pub mod config;
 #[cfg(feature = "database")]
 pub mod admin;
 
+// Data classification framework — authoritative sensitivity taxonomy and
+// policy enforcement for every data field on the platform.
+#[cfg(feature = "database")]
+pub mod data_classification;
+
 // API handlers (exposed for integration tests)
 #[cfg(feature = "database")]
 pub mod api;


### PR DESCRIPTION
close #202 
Adds a comprehensive data classification framework that establishes a single authoritative taxonomy for every sensitive data field on the platform and enforces handling policies automatically.

src/data_classification/types.rs
- ClassificationTier enum (Critical > Restricted > Confidential > Internal > Public) with derived handling properties
- DataCategory enum covering all PII, financial, auth, compliance, and operational data domains
- HandlingRequirements struct and MaskingStrategy with apply()

src/data_classification/registry.rs
- DataField enum with 70+ variants covering every named field
- Each field maps to its tier, category, and masking strategy
- Single source of truth for the entire platform

src/data_classification/policy.rs
- Stateless PolicyEngine with transmission_decision() for all six contexts: LogLine, ApiResponse, WebhookDelivery, InternalRpc, Cache, Database
- Returns Allow / AllowMasked(strategy) / Deny per field+context

src/data_classification/enforcer.rs
- mask_field(), ClassifiedString newtype, sanitize_json()
- LogSanitizer with regex redaction for JWT, Stellar seeds, API keys, card PANs, and provider secrets
- guard_transmission() and retention_days_for_field()

src/data_classification/audit.rs
- ClassificationAuditRepository using runtime SQL queries
- report_violation() and report_access() structured-log helpers

migrations/20260402100000_data_classification_audit.sql
- Append-only audit table with compliance-optimised indexes

src/lib.rs
- Registers pub mod data_classification under database feature flag