### PR TITLE
feat: implement end-to-end payload encryption (field-level)

### DIFF
--- a/migrations/20260328200000_payload_encryption_keys.sql
+++ b/migrations/20260328200000_payload_encryption_keys.sql
@@ -1,0 +1,21 @@
+-- Migration: Payload encryption key versions
+-- Tracks key version metadata for audit and rotation management.
+-- Private keys are NEVER stored here — they live in the secrets manager.
+
+CREATE TABLE IF NOT EXISTS payload_encryption_keys (
+    kid                 TEXT        PRIMARY KEY,
+    status              TEXT        NOT NULL CHECK (status IN ('active', 'transitional', 'retired')),
+    alg                 TEXT        NOT NULL DEFAULT 'ECDH-ES+A256KW',
+    enc                 TEXT        NOT NULL DEFAULT 'A256GCM',
+    -- Public key PEM stored for audit; private key is in secrets manager only.
+    public_key_pem      TEXT        NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    activated_at        TIMESTAMPTZ,
+    retired_at          TIMESTAMPTZ,
+    rotation_window_end TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_payload_enc_keys_status ON payload_encryption_keys (status);
+
+COMMENT ON TABLE payload_encryption_keys IS
+    'Payload encryption key version registry. Private keys are stored exclusively in the secrets manager.';

--- a/src/api/crypto.rs
+++ b/src/api/crypto.rs
@@ -1,0 +1,164 @@
+//! Payload encryption API endpoints.
+//!
+//! GET  /api/crypto/public-key   — returns current and transitional public keys
+//! POST /api/crypto/test-decrypt — non-production test endpoint for consumer integration testing
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::crypto::{
+    envelope::EncryptedEnvelope,
+    keys::{KeyStore, PublicKeyInfo},
+    middleware::DecryptionState,
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/crypto/public-key
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct PublicKeyResponse {
+    pub keys: Vec<PublicKeyInfo>,
+    pub active_kid: String,
+}
+
+pub async fn get_public_key(State(key_store): State<Arc<KeyStore>>) -> impl IntoResponse {
+    Json(PublicKeyResponse {
+        active_kid: key_store.active_kid.clone(),
+        keys: key_store.public_versions(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/crypto/test-decrypt  (non-production only)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct TestDecryptRequest {
+    /// A single encrypted field envelope to test decryption.
+    pub field: serde_json::Value,
+}
+
+#[derive(Serialize)]
+pub struct TestDecryptResponse {
+    pub success: bool,
+    pub field_length: usize,
+    pub message: &'static str,
+}
+
+/// Test endpoint — confirms successful decryption without revealing the plaintext.
+/// Only available in non-production environments.
+pub async fn test_decrypt(
+    State(state): State<DecryptionState>,
+    Json(body): Json<TestDecryptRequest>,
+) -> Response {
+    // Guard: refuse in production.
+    let app_env = std::env::var("APP_ENV").unwrap_or_else(|_| "development".into());
+    if app_env == "production" {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found"})),
+        )
+            .into_response();
+    }
+
+    if !EncryptedEnvelope::is_envelope(&body.field) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "not_an_envelope",
+                "message": "The 'field' value is not an encrypted envelope"
+            })),
+        )
+            .into_response();
+    }
+
+    let envelope: EncryptedEnvelope = match serde_json::from_value(body.field) {
+        Ok(e) => e,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "malformed_envelope",
+                    "message": e.to_string()
+                })),
+            )
+                .into_response()
+        }
+    };
+
+    if let Err(e) = envelope.validate_algorithms() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "unsupported_algorithm", "message": e.to_string()})),
+        )
+            .into_response();
+    }
+
+    let key_version = match state.key_store.get_for_decryption(&envelope.kid) {
+        Ok(kv) => kv,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "key_error", "message": e.to_string()})),
+            )
+                .into_response()
+        }
+    };
+
+    let session_key = match key_version.unwrap_session_key(&envelope.epk, &envelope.ek) {
+        Ok(k) => k,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "session_key_error", "message": e.to_string()})),
+            )
+                .into_response()
+        }
+    };
+
+    let nonce = match crate::crypto::envelope::decode_nonce(&envelope.iv) {
+        Ok(n) => n,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "nonce_error", "message": e.to_string()})),
+            )
+                .into_response()
+        }
+    };
+
+    let ct_tag = match crate::crypto::envelope::concat_ct_tag(&envelope) {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "ciphertext_error", "message": e.to_string()})),
+            )
+                .into_response()
+        }
+    };
+
+    match crate::crypto::envelope::aes_gcm_decrypt(&session_key, &nonce, &ct_tag) {
+        Ok(plaintext) => {
+            // Return length only — never the plaintext value.
+            Json(TestDecryptResponse {
+                success: true,
+                field_length: plaintext.len(),
+                message: "Decryption successful. Plaintext not returned for security.",
+            })
+            .into_response()
+        }
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "decryption_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}

--- a/src/crypto/envelope.rs
+++ b/src/crypto/envelope.rs
@@ -1,0 +1,163 @@
+//! Encrypted field envelope — serialisation, parsing, and AES-256-GCM operations.
+
+use aes_gcm::{
+    aead::{Aead, KeyInit, OsRng as AeadOsRng},
+    Aes256Gcm, Key, Nonce,
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use super::keys::EncryptionError;
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+/// Marker value that identifies an encrypted field envelope.
+pub const ENVELOPE_MARKER: bool = true;
+
+/// Supported key-agreement + key-wrap algorithm.
+pub const ALG_ECDH_ES_A256KW: &str = "ECDH-ES+A256KW";
+
+/// Supported content-encryption algorithm.
+pub const ENC_A256GCM: &str = "A256GCM";
+
+/// Wire format for an encrypted field value.
+///
+/// All binary fields are base64url-encoded (no padding) for JSON transport.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncryptedEnvelope {
+    /// Marker — always `true`. Used to detect encrypted envelopes in request bodies.
+    #[serde(rename = "__enc")]
+    pub marker: bool,
+
+    /// Key version identifier — matches a key in the platform's key store.
+    pub kid: String,
+
+    /// Key-agreement + key-wrap algorithm.
+    pub alg: String,
+
+    /// Content-encryption algorithm.
+    pub enc: String,
+
+    /// Ephemeral public key (base64url) — the consumer's one-time EC P-384 public key.
+    pub epk: String,
+
+    /// Encrypted (wrapped) session key (base64url).
+    pub ek: String,
+
+    /// AES-GCM nonce / IV (base64url, 12 bytes).
+    pub iv: String,
+
+    /// Ciphertext (base64url).
+    pub ct: String,
+
+    /// GCM authentication tag (base64url, 16 bytes).
+    pub tag: String,
+}
+
+impl EncryptedEnvelope {
+    /// Returns `true` if the JSON value looks like an encrypted envelope.
+    pub fn is_envelope(value: &serde_json::Value) -> bool {
+        value
+            .get("__enc")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    /// Validate algorithm identifiers.
+    pub fn validate_algorithms(&self) -> Result<(), EncryptionError> {
+        if self.alg != ALG_ECDH_ES_A256KW {
+            return Err(EncryptionError::UnsupportedAlgorithm(self.alg.clone()));
+        }
+        if self.enc != ENC_A256GCM {
+            return Err(EncryptionError::UnsupportedAlgorithm(self.enc.clone()));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AES-256-GCM helpers
+// ---------------------------------------------------------------------------
+
+/// Encrypt `plaintext` with a fresh random nonce using the provided 32-byte key.
+///
+/// Returns `(nonce_bytes, ciphertext_with_tag)`.
+pub fn aes_gcm_encrypt(
+    key_bytes: &[u8; 32],
+    plaintext: &[u8],
+) -> Result<([u8; 12], Vec<u8>), EncryptionError> {
+    let key = Key::<Aes256Gcm>::from_slice(key_bytes);
+    let cipher = Aes256Gcm::new(key);
+
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|_| EncryptionError::EncryptionFailed)?;
+
+    Ok((nonce_bytes, ciphertext))
+}
+
+/// Decrypt `ciphertext_with_tag` (AES-256-GCM output, tag appended) using the
+/// provided 32-byte key and 12-byte nonce.
+///
+/// Returns the plaintext as a [`Zeroizing`] buffer so it is wiped on drop.
+pub fn aes_gcm_decrypt(
+    key_bytes: &[u8; 32],
+    nonce_bytes: &[u8; 12],
+    ciphertext_with_tag: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, EncryptionError> {
+    let key = Key::<Aes256Gcm>::from_slice(key_bytes);
+    let cipher = Aes256Gcm::new(key);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext_with_tag)
+        .map_err(|_| EncryptionError::AuthTagVerificationFailed)?;
+
+    Ok(Zeroizing::new(plaintext))
+}
+
+/// Decode the IV field from an envelope into a fixed 12-byte array.
+pub fn decode_nonce(b64: &str) -> Result<[u8; 12], EncryptionError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(b64)
+        .map_err(|_| EncryptionError::MalformedEnvelope("invalid base64 iv".into()))?;
+    bytes
+        .try_into()
+        .map_err(|_| EncryptionError::MalformedEnvelope("iv must be 12 bytes".into()))
+}
+
+/// Decode the ciphertext + tag from an envelope.
+pub fn decode_ciphertext(b64: &str) -> Result<Vec<u8>, EncryptionError> {
+    // ct and tag are stored separately in the envelope; callers concatenate them.
+    URL_SAFE_NO_PAD
+        .decode(b64)
+        .map_err(|_| EncryptionError::MalformedEnvelope("invalid base64 ct".into()))
+}
+
+/// Concatenate `ct` and `tag` fields into a single buffer for `aes_gcm_decrypt`.
+pub fn concat_ct_tag(envelope: &EncryptedEnvelope) -> Result<Vec<u8>, EncryptionError> {
+    let mut ct = decode_ciphertext(&envelope.ct)?;
+    let tag = URL_SAFE_NO_PAD
+        .decode(&envelope.tag)
+        .map_err(|_| EncryptionError::MalformedEnvelope("invalid base64 tag".into()))?;
+    if tag.len() != 16 {
+        return Err(EncryptionError::MalformedEnvelope("tag must be 16 bytes".into()));
+    }
+    ct.extend_from_slice(&tag);
+    Ok(ct)
+}
+
+/// Generate a random 32-byte AES-256 session key.
+pub fn generate_session_key() -> Zeroizing<[u8; 32]> {
+    let mut key = Zeroizing::new([0u8; 32]);
+    AeadOsRng.fill_bytes(key.as_mut());
+    key
+}

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -1,0 +1,443 @@
+//! Platform encryption key infrastructure.
+//!
+//! Manages EC P-384 key pairs for consumer-to-platform payload encryption.
+//! Supports multiple simultaneous key versions for zero-downtime rotation.
+//!
+//! # Key storage
+//! Private keys are loaded from environment variables (secrets manager in production).
+//! They are never written to the database, repository, or logs.
+//!
+//! # ECDH-ES + AES-256-KW session key unwrapping
+//! 1. Decode the consumer's ephemeral public key from the envelope.
+//! 2. Perform ECDH with the platform's private key → shared secret.
+//! 3. Derive a 32-byte key-wrapping key from the shared secret via HKDF-SHA-256.
+//! 4. AES-256-KW unwrap the encrypted session key.
+//! 5. Use the session key to decrypt each field with AES-256-GCM.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use hkdf::Hkdf;
+use p384::{
+    ecdh::EphemeralSecret,
+    elliptic_curve::sec1::ToEncodedPoint,
+    pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey},
+    PublicKey, SecretKey,
+};
+use rand::rngs::OsRng;
+use sha2::Sha256;
+use std::{collections::HashMap, sync::Arc};
+use zeroize::Zeroizing;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+pub enum EncryptionError {
+    #[error("Key version '{0}' not found or retired")]
+    KeyVersionNotFound(String),
+    #[error("Key version '{0}' has been retired")]
+    KeyVersionRetired(String),
+    #[error("Unsupported algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+    #[error("Malformed envelope: {0}")]
+    MalformedEnvelope(String),
+    #[error("Session key decryption failed")]
+    SessionKeyDecryptionFailed,
+    #[error("AES-GCM authentication tag verification failed — possible tampering")]
+    AuthTagVerificationFailed,
+    #[error("Encryption failed")]
+    EncryptionFailed,
+    #[error("Key generation failed: {0}")]
+    KeyGenerationFailed(String),
+    #[error("Invalid key material: {0}")]
+    InvalidKeyMaterial(String),
+    #[error("Plaintext sensitive field submitted without encryption for field '{0}'")]
+    PlaintextSensitiveField(String),
+}
+
+// ---------------------------------------------------------------------------
+// Key version status
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyStatus {
+    /// Current active key — used for new encryptions.
+    Active,
+    /// Transitional key — still accepted for decryption during rotation window.
+    Transitional,
+    /// Retired — no longer accepted.
+    Retired,
+}
+
+// ---------------------------------------------------------------------------
+// Platform key pair
+// ---------------------------------------------------------------------------
+
+/// A versioned platform encryption key pair.
+#[derive(Clone)]
+pub struct PlatformKeyVersion {
+    pub kid: String,
+    pub status: KeyStatus,
+    /// DER-encoded private key bytes — kept in a Zeroizing buffer.
+    private_key_der: Zeroizing<Vec<u8>>,
+    /// PEM-encoded public key for distribution.
+    pub public_key_pem: String,
+    /// Uncompressed SEC1 public key bytes for ECDH.
+    pub public_key_bytes: Vec<u8>,
+}
+
+impl std::fmt::Debug for PlatformKeyVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PlatformKeyVersion")
+            .field("kid", &self.kid)
+            .field("status", &self.status)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PlatformKeyVersion {
+    /// Generate a new P-384 key pair.
+    pub fn generate(kid: impl Into<String>, status: KeyStatus) -> Result<Self, EncryptionError> {
+        let secret = SecretKey::random(&mut OsRng);
+        let public = secret.public_key();
+
+        let private_key_der = Zeroizing::new(
+            secret
+                .to_pkcs8_der()
+                .map_err(|e| EncryptionError::KeyGenerationFailed(e.to_string()))?
+                .as_bytes()
+                .to_vec(),
+        );
+
+        let public_key_pem = public
+            .to_public_key_pem(p384::pkcs8::LineEnding::LF)
+            .map_err(|e| EncryptionError::KeyGenerationFailed(e.to_string()))?;
+
+        let public_key_bytes = public.to_encoded_point(false).as_bytes().to_vec();
+
+        Ok(Self {
+            kid: kid.into(),
+            status,
+            private_key_der,
+            public_key_pem,
+            public_key_bytes,
+        })
+    }
+
+    /// Load from a PEM-encoded private key (from secrets manager / env var).
+    pub fn from_pem(
+        kid: impl Into<String>,
+        status: KeyStatus,
+        private_key_pem: &str,
+    ) -> Result<Self, EncryptionError> {
+        let secret = SecretKey::from_pkcs8_pem(private_key_pem)
+            .map_err(|e| EncryptionError::InvalidKeyMaterial(e.to_string()))?;
+        let public = secret.public_key();
+
+        let private_key_der = Zeroizing::new(
+            secret
+                .to_pkcs8_der()
+                .map_err(|e| EncryptionError::InvalidKeyMaterial(e.to_string()))?
+                .as_bytes()
+                .to_vec(),
+        );
+
+        let public_key_pem = public
+            .to_public_key_pem(p384::pkcs8::LineEnding::LF)
+            .map_err(|e| EncryptionError::InvalidKeyMaterial(e.to_string()))?;
+
+        let public_key_bytes = public.to_encoded_point(false).as_bytes().to_vec();
+
+        Ok(Self {
+            kid: kid.into(),
+            status,
+            private_key_der,
+            public_key_pem,
+            public_key_bytes,
+        })
+    }
+
+    /// Unwrap an encrypted session key using ECDH-ES + AES-256-KW.
+    ///
+    /// `epk_b64` — base64url-encoded ephemeral public key from the envelope.
+    /// `ek_b64`  — base64url-encoded wrapped session key from the envelope.
+    ///
+    /// Returns the 32-byte session key in a Zeroizing buffer.
+    pub fn unwrap_session_key(
+        &self,
+        epk_b64: &str,
+        ek_b64: &str,
+    ) -> Result<Zeroizing<[u8; 32]>, EncryptionError> {
+        // 1. Decode ephemeral public key
+        let epk_bytes = URL_SAFE_NO_PAD
+            .decode(epk_b64)
+            .map_err(|_| EncryptionError::MalformedEnvelope("invalid base64 epk".into()))?;
+        let epk = PublicKey::from_sec1_bytes(&epk_bytes)
+            .map_err(|_| EncryptionError::MalformedEnvelope("invalid epk point".into()))?;
+
+        // 2. Load platform private key
+        let secret = SecretKey::from_pkcs8_der(&self.private_key_der)
+            .map_err(|_| EncryptionError::SessionKeyDecryptionFailed)?;
+
+        // 3. ECDH shared secret
+        let shared = p384::ecdh::diffie_hellman(secret.to_nonzero_scalar(), epk.as_affine());
+        let shared_bytes = Zeroizing::new(shared.raw_secret_bytes().to_vec());
+
+        // 4. HKDF-SHA-256 → 32-byte key-wrapping key
+        let hk = Hkdf::<Sha256>::new(None, &shared_bytes);
+        let mut kek = Zeroizing::new([0u8; 32]);
+        hk.expand(b"aframp-payload-enc-v1", kek.as_mut())
+            .map_err(|_| EncryptionError::SessionKeyDecryptionFailed)?;
+
+        // 5. AES-256-KW unwrap
+        let ek_bytes = URL_SAFE_NO_PAD
+            .decode(ek_b64)
+            .map_err(|_| EncryptionError::MalformedEnvelope("invalid base64 ek".into()))?;
+
+        let session_key = aes_kw_unwrap(&kek, &ek_bytes)?;
+        Ok(session_key)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AES-256 Key Wrap (RFC 3394)
+// ---------------------------------------------------------------------------
+
+/// AES-256 Key Wrap (RFC 3394) — unwrap a wrapped key.
+fn aes_kw_unwrap(kek: &[u8; 32], wrapped: &[u8]) -> Result<Zeroizing<[u8; 32]>, EncryptionError> {
+    use aes_gcm::aes::Aes256;
+    use aes_gcm::aes::cipher::{BlockDecrypt, KeyInit as AesKeyInit};
+
+    // RFC 3394: wrapped key length = n*8 + 8 where n = number of 8-byte blocks
+    if wrapped.len() != 40 {
+        // 32-byte key → 5 blocks → 40 bytes wrapped
+        return Err(EncryptionError::SessionKeyDecryptionFailed);
+    }
+
+    let cipher = Aes256::new_from_slice(kek)
+        .map_err(|_| EncryptionError::SessionKeyDecryptionFailed)?;
+
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&wrapped[..8]);
+    let mut r: Vec<[u8; 8]> = wrapped[8..]
+        .chunks_exact(8)
+        .map(|c| c.try_into().unwrap())
+        .collect();
+    let n = r.len(); // 4
+
+    for j in (0..=5u64).rev() {
+        for i in (0..n).rev() {
+            let t = ((n as u64) * j + (i as u64 + 1)) as u64;
+            let mut b = [0u8; 16];
+            for (k, byte) in a.iter().enumerate() {
+                b[k] = byte ^ ((t >> (8 * (7 - k))) as u8);
+            }
+            b[8..].copy_from_slice(&r[i]);
+            let mut block = aes_gcm::aes::Block::from(b);
+            cipher.decrypt_block(&mut block);
+            a.copy_from_slice(&block[..8]);
+            r[i].copy_from_slice(&block[8..]);
+        }
+    }
+
+    // Integrity check: A must equal the default IV 0xA6A6A6A6A6A6A6A6
+    let iv = [0xA6u8; 8];
+    if a != iv {
+        return Err(EncryptionError::SessionKeyDecryptionFailed);
+    }
+
+    let mut key = Zeroizing::new([0u8; 32]);
+    for (i, block) in r.iter().enumerate() {
+        key[i * 8..(i + 1) * 8].copy_from_slice(block);
+    }
+    Ok(key)
+}
+
+/// AES-256 Key Wrap (RFC 3394) — wrap a key. Used in reference implementations and tests.
+pub fn aes_kw_wrap(kek: &[u8; 32], key_to_wrap: &[u8; 32]) -> Result<Vec<u8>, EncryptionError> {
+    use aes_gcm::aes::Aes256;
+    use aes_gcm::aes::cipher::{BlockEncrypt, KeyInit as AesKeyInit};
+
+    let cipher = Aes256::new_from_slice(kek)
+        .map_err(|_| EncryptionError::EncryptionFailed)?;
+
+    let mut a = [0xA6u8; 8]; // default IV
+    let mut r: Vec<[u8; 8]> = key_to_wrap
+        .chunks_exact(8)
+        .map(|c| c.try_into().unwrap())
+        .collect();
+    let n = r.len(); // 4
+
+    for j in 0..=5u64 {
+        for i in 0..n {
+            let t = ((n as u64) * j + (i as u64 + 1)) as u64;
+            let mut b = [0u8; 16];
+            b[..8].copy_from_slice(&a);
+            b[8..].copy_from_slice(&r[i]);
+            let mut block = aes_gcm::aes::Block::from(b);
+            cipher.encrypt_block(&mut block);
+            for (k, byte) in a.iter_mut().enumerate() {
+                *byte = block[k] ^ ((t >> (8 * (7 - k))) as u8);
+            }
+            r[i].copy_from_slice(&block[8..]);
+        }
+    }
+
+    let mut out = Vec::with_capacity(8 + n * 8);
+    out.extend_from_slice(&a);
+    for block in &r {
+        out.extend_from_slice(block);
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Key store
+// ---------------------------------------------------------------------------
+
+/// Thread-safe store of all platform key versions.
+#[derive(Debug, Clone)]
+pub struct KeyStore {
+    inner: Arc<HashMap<String, PlatformKeyVersion>>,
+    /// kid of the currently active key.
+    pub active_kid: String,
+}
+
+impl KeyStore {
+    pub fn new(versions: Vec<PlatformKeyVersion>) -> Result<Self, EncryptionError> {
+        let active_kid = versions
+            .iter()
+            .find(|v| v.status == KeyStatus::Active)
+            .map(|v| v.kid.clone())
+            .ok_or_else(|| EncryptionError::KeyVersionNotFound("no active key".into()))?;
+
+        let map: HashMap<String, PlatformKeyVersion> =
+            versions.into_iter().map(|v| (v.kid.clone(), v)).collect();
+
+        Ok(Self {
+            inner: Arc::new(map),
+            active_kid,
+        })
+    }
+
+    /// Load from environment variables.
+    ///
+    /// Expects `PAYLOAD_ENC_KEY_V1` (PEM private key) at minimum.
+    /// Optionally `PAYLOAD_ENC_KEY_V2` for rotation.
+    /// `PAYLOAD_ENC_ACTIVE_KID` selects the active version (default: `v1`).
+    pub fn from_env() -> Result<Self, EncryptionError> {
+        let active_kid =
+            std::env::var("PAYLOAD_ENC_ACTIVE_KID").unwrap_or_else(|_| "v1".to_string());
+
+        let mut versions = Vec::new();
+
+        for kid in &["v1", "v2", "v3"] {
+            let env_var = format!("PAYLOAD_ENC_KEY_{}", kid.to_uppercase());
+            if let Ok(pem) = std::env::var(&env_var) {
+                let status = if *kid == active_kid.as_str() {
+                    KeyStatus::Active
+                } else {
+                    KeyStatus::Transitional
+                };
+                versions.push(PlatformKeyVersion::from_pem(*kid, status, &pem)?);
+            }
+        }
+
+        if versions.is_empty() {
+            // Development fallback: generate an ephemeral key pair.
+            tracing::warn!(
+                "PAYLOAD_ENC_KEY_V1 not set — generating ephemeral key pair (development only)"
+            );
+            versions.push(PlatformKeyVersion::generate("v1", KeyStatus::Active)?);
+        }
+
+        Self::new(versions)
+    }
+
+    /// Get a key version for decryption. Returns error if retired or not found.
+    pub fn get_for_decryption(&self, kid: &str) -> Result<&PlatformKeyVersion, EncryptionError> {
+        let kv = self
+            .inner
+            .get(kid)
+            .ok_or_else(|| EncryptionError::KeyVersionNotFound(kid.to_string()))?;
+        if kv.status == KeyStatus::Retired {
+            return Err(EncryptionError::KeyVersionRetired(kid.to_string()));
+        }
+        Ok(kv)
+    }
+
+    /// Get the active key version.
+    pub fn active(&self) -> &PlatformKeyVersion {
+        self.inner.get(&self.active_kid).expect("active key must exist")
+    }
+
+    /// All non-retired key versions (for public key endpoint).
+    pub fn public_versions(&self) -> Vec<PublicKeyInfo> {
+        self.inner
+            .values()
+            .filter(|v| v.status != KeyStatus::Retired)
+            .map(|v| PublicKeyInfo {
+                kid: v.kid.clone(),
+                status: format!("{:?}", v.status).to_lowercase(),
+                alg: "ECDH-ES+A256KW".into(),
+                enc: "A256GCM".into(),
+                public_key_pem: v.public_key_pem.clone(),
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public key info (for GET /api/crypto/public-key)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PublicKeyInfo {
+    pub kid: String,
+    pub status: String,
+    pub alg: String,
+    pub enc: String,
+    pub public_key_pem: String,
+}
+
+// ---------------------------------------------------------------------------
+// Sensitive field catalogue
+// ---------------------------------------------------------------------------
+
+/// Fields that MUST be submitted in encrypted form.
+pub const SENSITIVE_FIELDS: &[&str] = &[
+    "national_id",
+    "passport_number",
+    "drivers_licence",
+    "bank_account_number",
+    "sort_code",
+    "iban",
+    "phone_number",
+    "source_of_funds",
+];
+
+/// Returns `true` if the field name is in the sensitive catalogue.
+pub fn is_sensitive_field(field: &str) -> bool {
+    SENSITIVE_FIELDS.contains(&field)
+}
+
+// ---------------------------------------------------------------------------
+// ECDH helpers for consumer-side reference implementation
+// ---------------------------------------------------------------------------
+
+/// Perform ECDH key agreement and derive a 32-byte KEK.
+///
+/// Used by the Rust reference implementation and tests.
+pub fn ecdh_derive_kek(
+    ephemeral_secret: &EphemeralSecret,
+    platform_public_key: &PublicKey,
+) -> Result<Zeroizing<[u8; 32]>, EncryptionError> {
+    let shared = ephemeral_secret.diffie_hellman(platform_public_key);
+    let shared_bytes = Zeroizing::new(shared.raw_secret_bytes().to_vec());
+
+    let hk = Hkdf::<Sha256>::new(None, &shared_bytes);
+    let mut kek = Zeroizing::new([0u8; 32]);
+    hk.expand(b"aframp-payload-enc-v1", kek.as_mut())
+        .map_err(|_| EncryptionError::SessionKeyDecryptionFailed)?;
+    Ok(kek)
+}

--- a/src/crypto/metrics.rs
+++ b/src/crypto/metrics.rs
@@ -1,0 +1,83 @@
+//! Prometheus metrics for payload encryption operations.
+
+use prometheus::{CounterVec, Registry};
+use std::sync::OnceLock;
+
+static DECRYPTIONS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+static DECRYPTION_FAILURES_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+static KEY_VERSION_USAGE_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+static PLAINTEXT_REJECTIONS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+
+pub fn register(r: &Registry) {
+    DECRYPTIONS_TOTAL
+        .set(
+            prometheus::register_counter_vec_with_registry!(
+                "aframp_payload_decryptions_total",
+                "Total encrypted field decryptions by field type",
+                &["field_type"],
+                r
+            )
+            .unwrap(),
+        )
+        .ok();
+
+    DECRYPTION_FAILURES_TOTAL
+        .set(
+            prometheus::register_counter_vec_with_registry!(
+                "aframp_payload_decryption_failures_total",
+                "Encrypted field decryption failures by field type and reason",
+                &["field_type", "reason"],
+                r
+            )
+            .unwrap(),
+        )
+        .ok();
+
+    KEY_VERSION_USAGE_TOTAL
+        .set(
+            prometheus::register_counter_vec_with_registry!(
+                "aframp_payload_key_version_usage_total",
+                "Decryption requests by key version",
+                &["kid"],
+                r
+            )
+            .unwrap(),
+        )
+        .ok();
+
+    PLAINTEXT_REJECTIONS_TOTAL
+        .set(
+            prometheus::register_counter_vec_with_registry!(
+                "aframp_payload_plaintext_rejections_total",
+                "Requests rejected for submitting plaintext sensitive fields by endpoint",
+                &["endpoint", "field"],
+                r
+            )
+            .unwrap(),
+        )
+        .ok();
+}
+
+pub fn inc_decryption(field_type: &str) {
+    if let Some(c) = DECRYPTIONS_TOTAL.get() {
+        c.with_label_values(&[field_type]).inc();
+    }
+}
+
+pub fn inc_decryption_failure(field_type: &str, reason: &str) {
+    if let Some(c) = DECRYPTION_FAILURES_TOTAL.get() {
+        c.with_label_values(&[field_type, reason]).inc();
+    }
+}
+
+pub fn inc_key_version_usage(kid: &str) {
+    if let Some(c) = KEY_VERSION_USAGE_TOTAL.get() {
+        c.with_label_values(&[kid]).inc();
+    }
+}
+
+pub fn inc_plaintext_rejection(endpoint: &str, field: &str) {
+    if let Some(c) = PLAINTEXT_REJECTIONS_TOTAL.get() {
+        c.with_label_values(&[endpoint, field]).inc();
+    }
+}

--- a/src/crypto/middleware.rs
+++ b/src/crypto/middleware.rs
@@ -1,0 +1,318 @@
+//! Server-side decryption middleware.
+//!
+//! Walks the JSON request body, detects encrypted field envelopes, decrypts
+//! them, and replaces the envelope with the plaintext value before the handler
+//! sees the request.
+//!
+//! # Security guarantees
+//! - Decrypted plaintext is NEVER written to any log at any level.
+//! - The session key is zeroed from memory immediately after all field
+//!   decryptions for a request are complete.
+//! - GCM authentication tag verification is mandatory — any tampered field
+//!   causes the entire request to be rejected.
+//! - Requests using retired key versions are rejected with a clear error.
+
+use axum::{
+    body::{to_bytes, Body},
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::Value;
+use std::sync::Arc;
+use tracing::{error, warn};
+use zeroize::Zeroizing;
+
+use super::{
+    envelope::{aes_gcm_decrypt, concat_ct_tag, decode_nonce, EncryptedEnvelope},
+    keys::{EncryptionError, KeyStore},
+    metrics,
+};
+
+// ---------------------------------------------------------------------------
+// Middleware state
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct DecryptionState {
+    pub key_store: Arc<KeyStore>,
+    /// When `true`, plaintext sensitive fields are accepted with a deprecation
+    /// warning (grace period mode). When `false`, they are rejected.
+    pub grace_period: bool,
+    /// Header name used to extract the consumer ID for alerting.
+    pub consumer_id_header: &'static str,
+}
+
+// ---------------------------------------------------------------------------
+// Error response
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Serialize)]
+struct DecryptionErrorBody {
+    error: &'static str,
+    code: String,
+    message: String,
+}
+
+fn error_response(status: StatusCode, code: impl Into<String>, msg: impl Into<String>) -> Response {
+    (
+        status,
+        Json(DecryptionErrorBody {
+            error: "decryption_error",
+            code: code.into(),
+            message: msg.into(),
+        }),
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Middleware entry point
+// ---------------------------------------------------------------------------
+
+/// Axum middleware layer that decrypts encrypted field envelopes in request bodies.
+pub async fn decryption_middleware(
+    State(state): State<DecryptionState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let (parts, body) = req.into_parts();
+
+    let is_json = parts
+        .headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|ct| ct.contains("application/json"))
+        .unwrap_or(false);
+
+    if !is_json {
+        return next.run(Request::from_parts(parts, body)).await;
+    }
+
+    let body_bytes = match to_bytes(body, 4 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            return error_response(StatusCode::BAD_REQUEST, "body_read_error", "Failed to read request body")
+        }
+    };
+
+    let mut json: Value = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            let new_body = Body::from(body_bytes);
+            return next.run(Request::from_parts(parts, new_body)).await;
+        }
+    };
+
+    let consumer_id = parts
+        .headers
+        .get(state.consumer_id_header)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+
+    if let Err(resp) = decrypt_fields(&mut json, &state, &consumer_id) {
+        return resp;
+    }
+
+    let new_body_bytes = match serde_json::to_vec(&json) {
+        Ok(b) => b,
+        Err(_) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialization_error",
+                "Failed to re-serialize body",
+            )
+        }
+    };
+
+    next.run(Request::from_parts(parts, Body::from(new_body_bytes))).await
+}
+
+// ---------------------------------------------------------------------------
+// Recursive field decryption
+// ---------------------------------------------------------------------------
+
+fn decrypt_fields(
+    value: &mut Value,
+    state: &DecryptionState,
+    consumer_id: &str,
+) -> Result<(), Response> {
+    match value {
+        Value::Object(map) => {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for key in keys {
+                let field_value = map.get_mut(&key).unwrap();
+                if EncryptedEnvelope::is_envelope(field_value) {
+                    let envelope: EncryptedEnvelope =
+                        match serde_json::from_value(field_value.clone()) {
+                            Ok(e) => e,
+                            Err(_) => {
+                                metrics::inc_decryption_failure(&key, "malformed_envelope");
+                                error!(field = %key, consumer_id = %consumer_id, "Malformed encrypted envelope");
+                                return Err(error_response(
+                                    StatusCode::BAD_REQUEST,
+                                    "malformed_envelope",
+                                    format!("Malformed encrypted envelope for field '{key}'"),
+                                ));
+                            }
+                        };
+
+                    let plaintext = decrypt_envelope(&envelope, state, &key, consumer_id)?;
+                    // NEVER log plaintext
+                    *field_value =
+                        Value::String(String::from_utf8(plaintext.to_vec()).unwrap_or_default());
+                } else {
+                    decrypt_fields(field_value, state, consumer_id)?;
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                decrypt_fields(item, state, consumer_id)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn decrypt_envelope(
+    envelope: &EncryptedEnvelope,
+    state: &DecryptionState,
+    field_name: &str,
+    consumer_id: &str,
+) -> Result<Zeroizing<Vec<u8>>, Response> {
+    if let Err(e) = envelope.validate_algorithms() {
+        metrics::inc_decryption_failure(field_name, "unsupported_algorithm");
+        return Err(error_response(StatusCode::BAD_REQUEST, "unsupported_algorithm", e.to_string()));
+    }
+
+    let key_version = match state.key_store.get_for_decryption(&envelope.kid) {
+        Ok(kv) => kv,
+        Err(EncryptionError::KeyVersionRetired(kid)) => {
+            metrics::inc_decryption_failure(field_name, "retired_key_version");
+            warn!(kid = %kid, consumer_id = %consumer_id, field = %field_name, "Request using retired key version");
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "retired_key_version",
+                format!("Key version '{kid}' has been retired. Refresh the public key and re-encrypt."),
+            ));
+        }
+        Err(EncryptionError::KeyVersionNotFound(kid)) => {
+            metrics::inc_decryption_failure(field_name, "unknown_key_version");
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "unknown_key_version",
+                format!("Key version '{kid}' is not recognised."),
+            ));
+        }
+        Err(e) => {
+            metrics::inc_decryption_failure(field_name, "key_lookup_error");
+            error!(error = %e, "Key lookup error");
+            return Err(error_response(StatusCode::INTERNAL_SERVER_ERROR, "key_lookup_error", "Internal key lookup error"));
+        }
+    };
+
+    metrics::inc_key_version_usage(&envelope.kid);
+
+    let session_key = match key_version.unwrap_session_key(&envelope.epk, &envelope.ek) {
+        Ok(k) => k,
+        Err(_) => {
+            metrics::inc_decryption_failure(field_name, "session_key_decryption_failed");
+            error!(field = %field_name, consumer_id = %consumer_id, "Session key decryption failed");
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "session_key_decryption_failed",
+                "Failed to decrypt session key",
+            ));
+        }
+    };
+
+    let nonce = match decode_nonce(&envelope.iv) {
+        Ok(n) => n,
+        Err(e) => {
+            metrics::inc_decryption_failure(field_name, "malformed_nonce");
+            return Err(error_response(StatusCode::BAD_REQUEST, "malformed_nonce", e.to_string()));
+        }
+    };
+
+    let ct_tag = match concat_ct_tag(envelope) {
+        Ok(b) => b,
+        Err(e) => {
+            metrics::inc_decryption_failure(field_name, "malformed_ciphertext");
+            return Err(error_response(StatusCode::BAD_REQUEST, "malformed_ciphertext", e.to_string()));
+        }
+    };
+
+    // session_key is Zeroizing — zeroed on drop after this function returns.
+    let plaintext = match aes_gcm_decrypt(&session_key, &nonce, &ct_tag) {
+        Ok(p) => p,
+        Err(EncryptionError::AuthTagVerificationFailed) => {
+            metrics::inc_decryption_failure(field_name, "auth_tag_verification_failed");
+            error!(field = %field_name, consumer_id = %consumer_id, "GCM auth tag verification failed — possible tampering");
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "auth_tag_verification_failed",
+                format!("Authentication tag verification failed for field '{field_name}' — possible tampering"),
+            ));
+        }
+        Err(e) => {
+            metrics::inc_decryption_failure(field_name, "decryption_failed");
+            error!(field = %field_name, error = %e, "Field decryption failed");
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "decryption_failed",
+                format!("Decryption failed for field '{field_name}'"),
+            ));
+        }
+    };
+
+    metrics::inc_decryption(field_name);
+    Ok(Zeroizing::new(plaintext.to_vec()))
+}
+
+// ---------------------------------------------------------------------------
+// Plaintext sensitive field enforcement
+// ---------------------------------------------------------------------------
+
+/// Check a JSON body for plaintext sensitive fields.
+///
+/// Grace period mode: logs a deprecation warning and allows the request.
+/// Enforcement mode: returns a 422 error response.
+pub fn enforce_sensitive_field_encryption(
+    body: &Value,
+    grace_period: bool,
+    endpoint: &str,
+) -> Result<(), Response> {
+    use super::keys::SENSITIVE_FIELDS;
+
+    if let Value::Object(map) = body {
+        for field in SENSITIVE_FIELDS {
+            if let Some(v) = map.get(*field) {
+                if v.is_string() {
+                    metrics::inc_plaintext_rejection(endpoint, field);
+                    if grace_period {
+                        warn!(
+                            field = %field,
+                            endpoint = %endpoint,
+                            "DEPRECATION: sensitive field submitted as plaintext — will be rejected after grace period expires"
+                        );
+                    } else {
+                        return Err(error_response(
+                            StatusCode::UNPROCESSABLE_ENTITY,
+                            "plaintext_sensitive_field",
+                            format!(
+                                "Field '{field}' must be submitted in encrypted form. \
+                                 See GET /api/crypto/public-key for the platform encryption key."
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,31 @@
+//! End-to-end payload encryption — Issue: Data Security & Encryption
+//!
+//! Hybrid encryption scheme:
+//!   1. Consumer generates a random AES-256 session key.
+//!   2. Consumer encrypts each sensitive field with AES-256-GCM using the session key.
+//!   3. Consumer encrypts the session key with the platform's EC P-384 public key (ECDH-ES + AES-KW).
+//!   4. Consumer transmits both the encrypted fields and the encrypted session key.
+//!   5. Server decrypts the session key with its private key, then decrypts each field.
+//!
+//! # Envelope format (JSON)
+//! ```json
+//! {
+//!   "__enc": true,
+//!   "kid":   "v1",
+//!   "alg":   "ECDH-ES+A256KW",
+//!   "enc":   "A256GCM",
+//!   "epk":   "<base64url-encoded ephemeral public key>",
+//!   "ek":    "<base64url-encoded wrapped session key>",
+//!   "iv":    "<base64url-encoded 12-byte nonce>",
+//!   "ct":    "<base64url-encoded ciphertext>",
+//!   "tag":   "<base64url-encoded 16-byte GCM auth tag>"
+//! }
+//! ```
+
+pub mod envelope;
+pub mod keys;
+pub mod middleware;
+pub mod metrics;
+
+#[cfg(test)]
+pub mod tests;

--- a/src/crypto/tests.rs
+++ b/src/crypto/tests.rs
@@ -1,0 +1,254 @@
+//! Unit and integration tests for the payload encryption module.
+
+#[cfg(test)]
+mod tests {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use p384::{ecdh::EphemeralSecret, elliptic_curve::sec1::ToEncodedPoint, PublicKey};
+    use rand::rngs::OsRng;
+    use zeroize::Zeroizing;
+
+    use crate::crypto::{
+        envelope::{
+            aes_gcm_decrypt, aes_gcm_encrypt, concat_ct_tag, decode_nonce, generate_session_key,
+            EncryptedEnvelope, ALG_ECDH_ES_A256KW, ENC_A256GCM,
+        },
+        keys::{
+            aes_kw_wrap, ecdh_derive_kek, is_sensitive_field, EncryptionError, KeyStatus,
+            KeyStore, PlatformKeyVersion, SENSITIVE_FIELDS,
+        },
+    };
+
+    // -----------------------------------------------------------------------
+    // AES-256-GCM encrypt / decrypt round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_aes_gcm_round_trip() {
+        let key = generate_session_key();
+        let plaintext = b"sensitive-national-id-12345";
+
+        let (nonce, ct_tag) = aes_gcm_encrypt(&key, plaintext).unwrap();
+        let decrypted = aes_gcm_decrypt(&key, &nonce, &ct_tag).unwrap();
+
+        assert_eq!(decrypted.as_slice(), plaintext);
+    }
+
+    #[test]
+    fn test_aes_gcm_auth_tag_verification_rejects_tampered_ciphertext() {
+        let key = generate_session_key();
+        let plaintext = b"bank-account-number";
+
+        let (nonce, mut ct_tag) = aes_gcm_encrypt(&key, plaintext).unwrap();
+        // Flip a byte in the ciphertext.
+        ct_tag[0] ^= 0xFF;
+
+        let result = aes_gcm_decrypt(&key, &nonce, &ct_tag);
+        assert!(matches!(result, Err(EncryptionError::AuthTagVerificationFailed)));
+    }
+
+    #[test]
+    fn test_aes_gcm_auth_tag_verification_rejects_tampered_tag() {
+        let key = generate_session_key();
+        let plaintext = b"iban-value";
+
+        let (nonce, mut ct_tag) = aes_gcm_encrypt(&key, plaintext).unwrap();
+        // Flip a byte in the tag (last 16 bytes).
+        let len = ct_tag.len();
+        ct_tag[len - 1] ^= 0xFF;
+
+        let result = aes_gcm_decrypt(&key, &nonce, &ct_tag);
+        assert!(matches!(result, Err(EncryptionError::AuthTagVerificationFailed)));
+    }
+
+    #[test]
+    fn test_session_key_is_zeroized_on_drop() {
+        // Verify Zeroizing<[u8;32]> zeroes memory on drop.
+        let key_ptr: *const u8;
+        {
+            let key = generate_session_key();
+            key_ptr = key.as_ptr();
+            // key drops here
+        }
+        // We can't reliably read freed memory in safe Rust, but we verify the
+        // type is Zeroizing which guarantees zeroing via the zeroize crate.
+        // This test documents the intent.
+        let _ = key_ptr;
+    }
+
+    // -----------------------------------------------------------------------
+    // Key version validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_key_store_rejects_retired_key_version() {
+        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
+        let retired = PlatformKeyVersion::generate("v2", KeyStatus::Retired).unwrap();
+        let store = KeyStore::new(vec![active, retired]).unwrap();
+
+        let result = store.get_for_decryption("v2");
+        assert!(matches!(result, Err(EncryptionError::KeyVersionRetired(_))));
+    }
+
+    #[test]
+    fn test_key_store_rejects_unknown_key_version() {
+        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
+        let store = KeyStore::new(vec![active]).unwrap();
+
+        let result = store.get_for_decryption("v99");
+        assert!(matches!(result, Err(EncryptionError::KeyVersionNotFound(_))));
+    }
+
+    #[test]
+    fn test_key_store_accepts_transitional_key_version() {
+        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
+        let transitional = PlatformKeyVersion::generate("v2", KeyStatus::Transitional).unwrap();
+        let store = KeyStore::new(vec![active, transitional]).unwrap();
+
+        assert!(store.get_for_decryption("v2").is_ok());
+    }
+
+    #[test]
+    fn test_key_store_requires_active_key() {
+        let retired = PlatformKeyVersion::generate("v1", KeyStatus::Retired).unwrap();
+        let result = KeyStore::new(vec![retired]);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Envelope format parsing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_envelope_is_envelope_detection() {
+        let envelope_json = serde_json::json!({
+            "__enc": true,
+            "kid": "v1",
+            "alg": ALG_ECDH_ES_A256KW,
+            "enc": ENC_A256GCM,
+            "epk": "abc",
+            "ek": "def",
+            "iv": "ghi",
+            "ct": "jkl",
+            "tag": "mno"
+        });
+        assert!(EncryptedEnvelope::is_envelope(&envelope_json));
+
+        let plain = serde_json::json!("some-plaintext");
+        assert!(!EncryptedEnvelope::is_envelope(&plain));
+
+        let obj_no_marker = serde_json::json!({"field": "value"});
+        assert!(!EncryptedEnvelope::is_envelope(&obj_no_marker));
+    }
+
+    #[test]
+    fn test_envelope_algorithm_validation() {
+        let mut env = make_test_envelope("v1");
+        assert!(env.validate_algorithms().is_ok());
+
+        env.alg = "RSA-OAEP".into();
+        assert!(matches!(
+            env.validate_algorithms(),
+            Err(EncryptionError::UnsupportedAlgorithm(_))
+        ));
+    }
+
+    #[test]
+    fn test_decode_nonce_rejects_wrong_length() {
+        let short = URL_SAFE_NO_PAD.encode([0u8; 8]);
+        assert!(decode_nonce(&short).is_err());
+
+        let correct = URL_SAFE_NO_PAD.encode([0u8; 12]);
+        assert!(decode_nonce(&correct).is_ok());
+    }
+
+    #[test]
+    fn test_concat_ct_tag_rejects_wrong_tag_length() {
+        let mut env = make_test_envelope("v1");
+        // tag must be 16 bytes
+        env.tag = URL_SAFE_NO_PAD.encode([0u8; 8]);
+        assert!(concat_ct_tag(&env).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Full ECDH-ES + AES-KW + AES-GCM round-trip (Rust reference impl)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_full_encryption_decryption_round_trip() {
+        // 1. Platform generates key pair.
+        let platform_key = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
+        let platform_pub = PublicKey::from_sec1_bytes(&platform_key.public_key_bytes).unwrap();
+
+        // 2. Consumer side: generate ephemeral key pair.
+        let ephemeral_secret = EphemeralSecret::random(&mut OsRng);
+        let ephemeral_pub = ephemeral_secret.public_key();
+        let epk_bytes = ephemeral_pub.to_encoded_point(false).as_bytes().to_vec();
+        let epk_b64 = URL_SAFE_NO_PAD.encode(&epk_bytes);
+
+        // 3. Consumer derives KEK via ECDH.
+        let kek = ecdh_derive_kek(&ephemeral_secret, &platform_pub).unwrap();
+
+        // 4. Consumer generates session key and wraps it.
+        let session_key = generate_session_key();
+        let wrapped_key = aes_kw_wrap(&kek, &session_key).unwrap();
+        let ek_b64 = URL_SAFE_NO_PAD.encode(&wrapped_key);
+
+        // 5. Consumer encrypts the plaintext field.
+        let plaintext = b"NG12345678";
+        let (nonce, ct_tag) = aes_gcm_encrypt(&session_key, plaintext).unwrap();
+
+        // Split ct and tag (last 16 bytes are the tag in aes-gcm output).
+        let tag_start = ct_tag.len() - 16;
+        let ct_b64 = URL_SAFE_NO_PAD.encode(&ct_tag[..tag_start]);
+        let tag_b64 = URL_SAFE_NO_PAD.encode(&ct_tag[tag_start..]);
+        let iv_b64 = URL_SAFE_NO_PAD.encode(nonce);
+
+        // 6. Server side: unwrap session key and decrypt.
+        let store = KeyStore::new(vec![platform_key]).unwrap();
+        let kv = store.get_for_decryption("v1").unwrap();
+        let decrypted_session_key = kv.unwrap_session_key(&epk_b64, &ek_b64).unwrap();
+
+        let nonce_bytes = decode_nonce(&iv_b64).unwrap();
+        let ct_tag_bytes = {
+            let mut v = URL_SAFE_NO_PAD.decode(&ct_b64).unwrap();
+            v.extend_from_slice(&URL_SAFE_NO_PAD.decode(&tag_b64).unwrap());
+            v
+        };
+
+        let decrypted = aes_gcm_decrypt(&decrypted_session_key, &nonce_bytes, &ct_tag_bytes).unwrap();
+        assert_eq!(decrypted.as_slice(), plaintext);
+    }
+
+    // -----------------------------------------------------------------------
+    // Sensitive field catalogue
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_sensitive_field_catalogue() {
+        assert!(is_sensitive_field("national_id"));
+        assert!(is_sensitive_field("passport_number"));
+        assert!(is_sensitive_field("bank_account_number"));
+        assert!(is_sensitive_field("phone_number"));
+        assert!(is_sensitive_field("iban"));
+        assert!(!is_sensitive_field("wallet_address"));
+        assert!(!is_sensitive_field("amount"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn make_test_envelope(kid: &str) -> EncryptedEnvelope {
+        EncryptedEnvelope {
+            marker: true,
+            kid: kid.to_string(),
+            alg: ALG_ECDH_ES_A256KW.to_string(),
+            enc: ENC_A256GCM.to_string(),
+            epk: URL_SAFE_NO_PAD.encode([0u8; 97]),
+            ek: URL_SAFE_NO_PAD.encode([0u8; 40]),
+            iv: URL_SAFE_NO_PAD.encode([0u8; 12]),
+            ct: URL_SAFE_NO_PAD.encode([0u8; 32]),
+            tag: URL_SAFE_NO_PAD.encode([0u8; 16]),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,6 @@ pub mod cache;
 #[cfg(feature = "database")]
 pub mod services;
 
-#[cfg(feature = "database")]
-pub mod recurring;
-
 // Payment providers
 #[cfg(feature = "database")]
 pub mod payments;
@@ -92,6 +89,10 @@ pub mod metrics;
 // DDoS protection and traffic shaping
 #[cfg(feature = "cache")]
 pub mod ddos;
+
+// End-to-end payload encryption (Issue — Data Security & Encryption)
+#[cfg(feature = "database")]
+pub mod crypto;
 
 // Contract error enum for Soroban (only when not using database feature)
 #[cfg(not(feature = "database"))]

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -550,6 +550,10 @@ pub mod security {
 
     pub fn request_anomaly_flags_total() -> &'static CounterVec {
         REQUEST_ANOMALY_FLAGS_TOTAL
+            .get()
+            .expect("metrics not initialised")
+    }
+
     static REPLAY_ATTEMPTS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
     static TIMESTAMP_REJECTIONS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
     static TIMESTAMP_DELTA_SECONDS: OnceLock<HistogramVec> = OnceLock::new();
@@ -582,6 +586,12 @@ pub mod security {
                     "aframp_request_anomaly_flags_total",
                     "Total non-blocking request anomaly flags by consumer, endpoint, and field",
                     &["consumer_id", "endpoint", "field"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
         REPLAY_ATTEMPTS_TOTAL
             .set(
                 register_counter_vec_with_registry!(
@@ -732,6 +742,7 @@ fn register_all(r: &Registry) {
     security::register(r);
     ip_detection::register(r);
     crate::ddos::metrics::register(r);
+    crate::crypto::metrics::register(r);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -17,9 +17,12 @@ pub mod hmac_signing;
 #[cfg(feature = "database")]
 pub mod ip_blocking;
 
+#[cfg(feature = "database")]
 pub mod replay_prevention;
+
 #[cfg(feature = "database")]
 pub mod scope_middleware;
+
 #[cfg(feature = "database")]
 pub mod logging;
 
@@ -29,13 +32,7 @@ pub mod metrics;
 pub mod rate_limit;
 
 #[cfg(feature = "database")]
-pub mod replay_prevention;
-
-#[cfg(feature = "database")]
 pub mod request_integrity;
-
-#[cfg(feature = "database")]
-pub mod scope_middleware;
 // Security middleware
 pub mod cors;
 pub mod security;

--- a/tests/payload_encryption_test.rs
+++ b/tests/payload_encryption_test.rs
@@ -1,0 +1,277 @@
+//! Integration tests for payload encryption — Issue: Data Security & Encryption
+//!
+//! Tests the full encrypted field submission lifecycle, key rotation,
+//! retired key rejection, plaintext rejection, and reference implementation.
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        middleware,
+        routing::post,
+        Router,
+    };
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use p384::{ecdh::EphemeralSecret, elliptic_curve::sec1::ToEncodedPoint, PublicKey};
+    use rand::rngs::OsRng;
+    use serde_json::{json, Value};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    use Bitmesh_backend::crypto::{
+        envelope::{aes_gcm_encrypt, generate_session_key, EncryptedEnvelope},
+        keys::{aes_kw_wrap, ecdh_derive_kek, KeyStatus, KeyStore, PlatformKeyVersion},
+        middleware::{decryption_middleware, enforce_sensitive_field_encryption, DecryptionState},
+    };
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// Build an encrypted envelope for a plaintext value using the given platform public key.
+    fn encrypt_field(
+        plaintext: &[u8],
+        platform_pub: &PublicKey,
+        kid: &str,
+    ) -> EncryptedEnvelope {
+        let ephemeral_secret = EphemeralSecret::random(&mut OsRng);
+        let ephemeral_pub = ephemeral_secret.public_key();
+        let epk_bytes = ephemeral_pub.to_encoded_point(false).as_bytes().to_vec();
+
+        let kek = ecdh_derive_kek(&ephemeral_secret, platform_pub).unwrap();
+        let session_key = generate_session_key();
+        let wrapped_key = aes_kw_wrap(&kek, &session_key).unwrap();
+
+        let (nonce, ct_tag) = aes_gcm_encrypt(&session_key, plaintext).unwrap();
+        let tag_start = ct_tag.len() - 16;
+
+        EncryptedEnvelope {
+            marker: true,
+            kid: kid.to_string(),
+            alg: "ECDH-ES+A256KW".to_string(),
+            enc: "A256GCM".to_string(),
+            epk: URL_SAFE_NO_PAD.encode(&epk_bytes),
+            ek: URL_SAFE_NO_PAD.encode(&wrapped_key),
+            iv: URL_SAFE_NO_PAD.encode(nonce),
+            ct: URL_SAFE_NO_PAD.encode(&ct_tag[..tag_start]),
+            tag: URL_SAFE_NO_PAD.encode(&ct_tag[tag_start..]),
+        }
+    }
+
+    fn make_store_with_key(kid: &str, status: KeyStatus) -> (KeyStore, PlatformKeyVersion) {
+        let key = PlatformKeyVersion::generate(kid, status.clone()).unwrap();
+        // We need to clone the key for the store and keep one for the public key.
+        // Since PlatformKeyVersion is Clone, we can do this.
+        let key_clone = key.clone();
+        let store = KeyStore::new(vec![key]).unwrap();
+        (store, key_clone)
+    }
+
+    fn decryption_state(store: KeyStore, grace_period: bool) -> DecryptionState {
+        DecryptionState {
+            key_store: Arc::new(store),
+            grace_period,
+            consumer_id_header: "x-aframp-key-id",
+        }
+    }
+
+    fn build_app(state: DecryptionState) -> Router {
+        // Echo handler — returns the decrypted body as-is.
+        async fn echo(body: axum::extract::Json<Value>) -> axum::Json<Value> {
+            body
+        }
+
+        Router::new()
+            .route("/test", post(echo))
+            .layer(middleware::from_fn_with_state(
+                state,
+                decryption_middleware,
+            ))
+    }
+
+    async fn post_json(app: Router, body: Value) -> (StatusCode, Value) {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, json)
+    }
+
+    // -----------------------------------------------------------------------
+    // Full encrypted field submission and decryption
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_encrypted_field_is_decrypted_in_request_context() {
+        let (store, key) = make_store_with_key("v1", KeyStatus::Active);
+        let platform_pub = PublicKey::from_sec1_bytes(&key.public_key_bytes).unwrap();
+
+        let envelope = encrypt_field(b"NG12345678", &platform_pub, "v1");
+        let body = json!({ "national_id": serde_json::to_value(&envelope).unwrap() });
+
+        let app = build_app(decryption_state(store, false));
+        let (status, resp) = post_json(app, body).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp["national_id"], "NG12345678");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_encrypted_fields_decrypted() {
+        let (store, key) = make_store_with_key("v1", KeyStatus::Active);
+        let platform_pub = PublicKey::from_sec1_bytes(&key.public_key_bytes).unwrap();
+
+        let id_env = encrypt_field(b"AB123456", &platform_pub, "v1");
+        let phone_env = encrypt_field(b"+254712345678", &platform_pub, "v1");
+
+        let body = json!({
+            "national_id": serde_json::to_value(&id_env).unwrap(),
+            "phone_number": serde_json::to_value(&phone_env).unwrap(),
+            "amount": "5000"
+        });
+
+        let app = build_app(decryption_state(store, false));
+        let (status, resp) = post_json(app, body).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp["national_id"], "AB123456");
+        assert_eq!(resp["phone_number"], "+254712345678");
+        assert_eq!(resp["amount"], "5000"); // non-sensitive field unchanged
+    }
+
+    // -----------------------------------------------------------------------
+    // Key rotation — simultaneous old and new key validity
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_transitional_key_still_accepted_during_rotation() {
+        let old_key = PlatformKeyVersion::generate("v1", KeyStatus::Transitional).unwrap();
+        let new_key = PlatformKeyVersion::generate("v2", KeyStatus::Active).unwrap();
+
+        let old_pub = PublicKey::from_sec1_bytes(&old_key.public_key_bytes).unwrap();
+        let store = KeyStore::new(vec![old_key, new_key]).unwrap();
+
+        // Encrypt with old (transitional) key.
+        let envelope = encrypt_field(b"passport-XYZ", &old_pub, "v1");
+        let body = json!({ "passport_number": serde_json::to_value(&envelope).unwrap() });
+
+        let app = build_app(decryption_state(store, false));
+        let (status, resp) = post_json(app, body).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp["passport_number"], "passport-XYZ");
+    }
+
+    // -----------------------------------------------------------------------
+    // Retired key version rejection
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_retired_key_version_is_rejected() {
+        let active = PlatformKeyVersion::generate("v2", KeyStatus::Active).unwrap();
+        let retired = PlatformKeyVersion::generate("v1", KeyStatus::Retired).unwrap();
+        let retired_pub = PublicKey::from_sec1_bytes(&retired.public_key_bytes).unwrap();
+
+        let store = KeyStore::new(vec![active, retired]).unwrap();
+
+        let envelope = encrypt_field(b"secret", &retired_pub, "v1");
+        let body = json!({ "national_id": serde_json::to_value(&envelope).unwrap() });
+
+        let app = build_app(decryption_state(store, false));
+        let (status, resp) = post_json(app, body).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(resp["code"], "retired_key_version");
+    }
+
+    // -----------------------------------------------------------------------
+    // Plaintext sensitive field rejection after grace period
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_plaintext_sensitive_field_rejected_after_grace_period() {
+        let body = json!({ "national_id": "NG12345678" });
+        let result = enforce_sensitive_field_encryption(&body, false, "/api/kyc/submit");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_plaintext_sensitive_field_allowed_during_grace_period() {
+        let body = json!({ "national_id": "NG12345678" });
+        // Grace period = true → should succeed (with a warning log).
+        let result = enforce_sensitive_field_encryption(&body, true, "/api/kyc/submit");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_non_sensitive_plaintext_field_always_allowed() {
+        let body = json!({ "amount": "5000", "wallet_address": "GXXX..." });
+        let result = enforce_sensitive_field_encryption(&body, false, "/api/onramp/initiate");
+        assert!(result.is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // GCM authentication tag verification
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_tampered_ciphertext_is_rejected() {
+        let (store, key) = make_store_with_key("v1", KeyStatus::Active);
+        let platform_pub = PublicKey::from_sec1_bytes(&key.public_key_bytes).unwrap();
+
+        let mut envelope = encrypt_field(b"sensitive-data", &platform_pub, "v1");
+        // Tamper with the ciphertext.
+        let mut ct_bytes = URL_SAFE_NO_PAD.decode(&envelope.ct).unwrap();
+        ct_bytes[0] ^= 0xFF;
+        envelope.ct = URL_SAFE_NO_PAD.encode(&ct_bytes);
+
+        let body = json!({ "national_id": serde_json::to_value(&envelope).unwrap() });
+
+        let app = build_app(decryption_state(store, false));
+        let (status, resp) = post_json(app, body).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(resp["code"], "auth_tag_verification_failed");
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-JSON body passes through unchanged
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_non_json_body_passes_through() {
+        let (store, _) = make_store_with_key("v1", KeyStatus::Active);
+        let state = decryption_state(store, false);
+
+        async fn echo_text(body: String) -> String {
+            body
+        }
+
+        let app = Router::new()
+            .route("/test", post(echo_text))
+            .layer(middleware::from_fn_with_state(
+                state,
+                decryption_middleware,
+            ));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(Body::from("plain text body"))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}


### PR DESCRIPTION
closes #199
Implements hybrid ECDH-ES + AES-256-GCM payload encryption for sensitive fields transmitted between API consumers and the platform.

## What's included

### Core crypto module (src/crypto/)
- envelope.rs  — EncryptedEnvelope wire format, AES-256-GCM helpers, session key generation, nonce/ciphertext decoding
- keys.rs       — EC P-384 key pair management, ECDH-ES + AES-256-KW
                  session key unwrapping, KeyStore with versioning,
                  sensitive field catalogue, aes_kw_wrap/unwrap (RFC 3394)
- middleware.rs  — Axum decryption middleware: detects envelopes, decrypts
                  fields, enforces grace-period / mandatory encryption,
                  zeroes session key after use, never logs plaintext
- metrics.rs    — Prometheus counters: decryptions, failures, key version
                  usage, plaintext rejections

### API endpoints (src/api/crypto.rs)
- GET  /api/crypto/public-key      — returns current + transitional keys
- POST /api/crypto/test-decrypt    — non-production integration test helper

### Database migration
- migrations/20260328200000_payload_encryption_keys.sql Key version registry table (public key PEM only; private key in secrets manager)

### Tests
- src/crypto/tests.rs              — unit tests: AES-GCM round-trip,
  auth tag tamper rejection, key version validation, envelope parsing,
  full ECDH-ES + AES-KW + AES-GCM round-trip, sensitive field catalogue
- tests/payload_encryption_test.rs — integration tests: encrypted field
  decryption, multiple fields, key rotation (transitional key), retired
  key rejection, plaintext rejection, grace period, tamper detection

### Module wiring fixes
- src/lib.rs: add pub mod crypto, remove duplicate pub mod recurring
- src/metrics/mod.rs: fix truncated request_anomaly_flags_total fn body
- src/middleware/mod.rs: remove duplicate replay_prevention + scope_middleware

## Security properties
- Private keys never stored in DB, repo, or logs
- Session key zeroed (Zeroizing) immediately after all field decryptions
- GCM auth tag verified on every field — tampered ciphertext rejected
- Retired key versions rejected with clear error code
- Plaintext sensitive fields rejected after grace period expires
- Decrypted values never appear in any log at any level