### PR TITLE
feat(alerting): implement Prometheus + Alertmanager alerting system (…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,65 +1,11 @@
-version: "3.9"
-
-# =============================================================================
-# Local development stack
-# Secrets come from .env (never committed). See .env.example.
-# =============================================================================
-
-services:
-  app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    ports:
-      - "8000:8000"
-    environment:
-      APP_ENV: development
-      SERVER_HOST: "0.0.0.0"
-      SERVER_PORT: "8000"
-      DATABASE_URL: "postgres://aframp:aframp_dev@postgres:5432/aframp_dev?sslmode=disable"
-      REDIS_URL: "redis://redis:6379"
-      LOG_LEVEL: "${LOG_LEVEL:-DEBUG}"
-      LOG_FORMAT: "${LOG_FORMAT:-plain}"
-    env_file:
-      - .env
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
-    restart: unless-stopped
-
-  postgres:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: aframp
-      POSTGRES_PASSWORD: aframp_dev
-      POSTGRES_DB: aframp_dev
-    ports:
-      - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - ./db/afri_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
-    command: >
-      postgres
-      -c shared_preload_libraries=pg_stat_statements
-      -c pg_stat_statements.track=all
-      -c log_min_duration_statement=200
-      -c log_statement=none
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aframp -d aframp_dev"]
 # Aframp Backend — local development stack
 #
 # Services:
-#   postgres  — PostgreSQL 16 with persistent volume
-#   redis     — Redis 7 with persistent volume
-#   app       — Aframp backend (built from source)
+#   postgres      — PostgreSQL 16 with persistent volume
+#   redis         — Redis 7 with persistent volume
+#   app           — Aframp backend (built from source)
+#   prometheus    — Prometheus metrics collection and alert evaluation
+#   alertmanager  — Alert routing, deduplication, and notification dispatch
 #
 # Usage:
 #   docker compose up --build          # first run
@@ -89,27 +35,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-
-    restart: unless-stopped
-
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    volumes:
-      - redis_data:/data
-    command: >
-      redis-server
-      --appendonly yes
-      --maxmemory 256mb
-      --maxmemory-policy allkeys-lru
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    restart: unless-stopped
-
 
   # ---------------------------------------------------------------------------
   # Redis
@@ -152,12 +77,8 @@ services:
     ports:
       - "${SERVER_PORT:-8000}:8000"
     environment:
-      # Server
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "${SERVER_PORT:-8000}"
-
-      # Database — constructed from individual parts so credentials are not
-      # hard-coded in the image or compose file.
       DATABASE_URL: "postgres://${POSTGRES_USER:-aframp}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-aframp}"
       DB_HOST: "postgres"
       DB_PORT: "5432"
@@ -166,19 +87,13 @@ services:
       DB_CONNECTION_TIMEOUT: "${DB_CONNECTION_TIMEOUT:-30}"
       DB_IDLE_TIMEOUT: "${DB_IDLE_TIMEOUT:-600}"
       DB_MAX_LIFETIME: "${DB_MAX_LIFETIME:-1800}"
-
-      # Redis
       REDIS_URL: "redis://:${REDIS_PASSWORD}@redis:6379"
       REDIS_MAX_CONNECTIONS: "${REDIS_MAX_CONNECTIONS:-20}"
       REDIS_MIN_IDLE: "${REDIS_MIN_IDLE:-5}"
-
-      # Application
       APP_ENV: "${APP_ENV:-development}"
       LOG_LEVEL: "${LOG_LEVEL:-INFO}"
       LOG_FORMAT: "${LOG_FORMAT:-json}"
       CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-http://localhost:3000}"
-
-      # Stellar
       STELLAR_NETWORK: "${STELLAR_NETWORK:-testnet}"
       STELLAR_HORIZON_URL: "${STELLAR_HORIZON_URL:-https://horizon-testnet.stellar.org}"
       STELLAR_REQUEST_TIMEOUT: "${STELLAR_REQUEST_TIMEOUT:-15}"
@@ -186,8 +101,6 @@ services:
       SYSTEM_WALLET_ADDRESS: "${SYSTEM_WALLET_ADDRESS}"
       SYSTEM_WALLET_SECRET: "${SYSTEM_WALLET_SECRET}"
       CNGN_ISSUER_ADDRESS: "${CNGN_ISSUER_ADDRESS}"
-
-      # Payment providers
       PAYSTACK_SECRET_KEY: "${PAYSTACK_SECRET_KEY}"
       PAYSTACK_PUBLIC_KEY: "${PAYSTACK_PUBLIC_KEY}"
       FLUTTERWAVE_SECRET_KEY: "${FLUTTERWAVE_SECRET_KEY}"
@@ -196,24 +109,16 @@ services:
       MPESA_CONSUMER_SECRET: "${MPESA_CONSUMER_SECRET}"
       MPESA_PASSKEY: "${MPESA_PASSKEY}"
       MPESA_SHORTCODE: "${MPESA_SHORTCODE}"
-
-      # JWT
       JWT_SECRET: "${JWT_SECRET:?JWT_SECRET is required}"
-
-      # OpenTelemetry (optional — leave blank to disable)
       OTEL_SERVICE_NAME: "${OTEL_SERVICE_NAME:-aframp-backend}"
       OTEL_EXPORTER_OTLP_ENDPOINT: "${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4317}"
       OTEL_SAMPLING_RATE: "${OTEL_SAMPLING_RATE:-1.0}"
-
-      # Workers
       TX_MONITOR_ENABLED: "${TX_MONITOR_ENABLED:-true}"
       OFFRAMP_PROCESSOR_ENABLED: "${OFFRAMP_PROCESSOR_ENABLED:-true}"
       ONRAMP_PROCESSOR_ENABLED: "${ONRAMP_PROCESSOR_ENABLED:-true}"
       BILL_PROCESSOR_ENABLED: "${BILL_PROCESSOR_ENABLED:-true}"
       PAYMENT_POLLER_ENABLED: "${PAYMENT_POLLER_ENABLED:-true}"
       WEBHOOK_RETRY_ENABLED: "${WEBHOOK_RETRY_ENABLED:-true}"
-
-      # Migration gate
       RUN_MIGRATIONS: "true"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${SERVER_PORT:-8000}/health"]
@@ -222,7 +127,64 @@ services:
       retries: 3
       start_period: 90s
 
+  # ---------------------------------------------------------------------------
+  # Prometheus — metrics collection and alert rule evaluation
+  # ---------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    restart: unless-stopped
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+      - "--web.enable-admin-api"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+
+  # ---------------------------------------------------------------------------
+  # Alertmanager — alert routing, deduplication, and notification dispatch
+  # ---------------------------------------------------------------------------
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    restart: unless-stopped
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+      # Disable clustering for single-node development setup
+      - "--cluster.listen-address="
+    volumes:
+      - ./monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    ports:
+      - "${ALERTMANAGER_PORT:-9093}:9093"
+    environment:
+      ALERTMANAGER_ONCALL_SLACK_WEBHOOK: "${ALERTMANAGER_ONCALL_SLACK_WEBHOOK:-}"
+      ALERTMANAGER_ENGINEERING_SLACK_WEBHOOK: "${ALERTMANAGER_ENGINEERING_SLACK_WEBHOOK:-}"
+      ALERTMANAGER_ONCALL_CHANNEL: "${ALERTMANAGER_ONCALL_CHANNEL:-#oncall}"
+      ALERTMANAGER_ENGINEERING_CHANNEL: "${ALERTMANAGER_ENGINEERING_CHANNEL:-#engineering-alerts}"
+    depends_on:
+      - prometheus
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
 
 volumes:
   postgres_data:
   redis_data:
+  prometheus_data:
+  alertmanager_data:

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,133 @@
+global:
+  # How long to wait before sending a notification about new alerts that are
+  # added to a group of alerts for which an initial notification has already
+  # been sent.
+  resolve_timeout: 5m
+
+  # SMTP configuration (set via environment variables in production)
+  smtp_smarthost: "${ALERTMANAGER_SMTP_HOST:-localhost:587}"
+  smtp_from: "${ALERTMANAGER_SMTP_FROM:-alerts@aframp.io}"
+  smtp_auth_username: "${ALERTMANAGER_SMTP_USER:-}"
+  smtp_auth_password: "${ALERTMANAGER_SMTP_PASSWORD:-}"
+
+# Templates for notification formatting
+templates:
+  - "/etc/alertmanager/templates/*.tmpl"
+
+# The root route — all alerts enter here and are matched against child routes.
+route:
+  # Group alerts by alertname + severity to avoid alert storms.
+  # Alerts with the same group_by values are batched into a single notification.
+  group_by: ["alertname", "severity", "service"]
+
+  # Wait this long before sending the first notification for a new group.
+  group_wait: 30s
+
+  # Wait this long before sending a notification about new alerts added to
+  # an already-firing group.
+  group_interval: 5m
+
+  # How long to wait before re-sending a notification for an alert that is
+  # still firing. Prevents alert storms for persistent conditions.
+  repeat_interval: 4h
+
+  # Default receiver for unmatched alerts
+  receiver: "engineering-channel"
+
+  routes:
+    # Critical alerts → on-call channel (immediate, shorter repeat)
+    - match:
+        severity: critical
+      receiver: "oncall-channel"
+      group_wait: 10s
+      group_interval: 2m
+      repeat_interval: 1h
+      continue: false
+
+    # Warning alerts → engineering channel
+    - match:
+        severity: warning
+      receiver: "engineering-channel"
+      group_wait: 1m
+      group_interval: 10m
+      repeat_interval: 6h
+      continue: false
+
+    # Stellar-specific critical alerts — also page on-call
+    - match_re:
+        alertname: "Stellar.*"
+        severity: critical
+      receiver: "oncall-channel"
+      group_wait: 10s
+      repeat_interval: 30m
+      continue: false
+
+# Inhibition rules prevent alert storms by suppressing lower-severity alerts
+# when a higher-severity alert for the same component is already firing.
+inhibit_rules:
+  # Suppress warning alerts when a critical alert for the same alertname fires
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: ["alertname", "service"]
+
+  # Suppress transaction failure warnings when critical fires for same tx_type
+  - source_match:
+      alertname: "HighTransactionFailureRate"
+    target_match:
+      alertname: "ElevatedTransactionFailureRate"
+    equal: ["tx_type"]
+
+  # Suppress Stellar warning when critical Horizon unavailability fires
+  - source_match:
+      alertname: "StellarHorizonUnavailable"
+    target_match:
+      alertname: "StellarHorizonHighLatency"
+    equal: []
+
+  # Suppress elevated 5xx warning when high 5xx critical fires
+  - source_match:
+      alertname: "HighHttp5xxErrorRate"
+    target_match:
+      alertname: "ElevatedHttp5xxErrorRate"
+    equal: []
+
+# Receivers define notification channels
+receivers:
+  # On-call channel — receives critical alerts
+  - name: "oncall-channel"
+    slack_configs:
+      - api_url: "${ALERTMANAGER_ONCALL_SLACK_WEBHOOK:-}"
+        channel: "${ALERTMANAGER_ONCALL_CHANNEL:-#oncall}"
+        send_resolved: true
+        title: |-
+          [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+        text: |-
+          {{ range .Alerts }}
+          *Alert:* {{ .Annotations.summary }}
+          *Severity:* {{ .Labels.severity }}
+          *Description:* {{ .Annotations.description }}
+          *Runbook:* {{ .Annotations.runbook }}
+          *Started:* {{ .StartsAt | since }}
+          {{ end }}
+        color: |-
+          {{ if eq .Status "firing" }}danger{{ else }}good{{ end }}
+
+  # Engineering channel — receives warning alerts
+  - name: "engineering-channel"
+    slack_configs:
+      - api_url: "${ALERTMANAGER_ENGINEERING_SLACK_WEBHOOK:-}"
+        channel: "${ALERTMANAGER_ENGINEERING_CHANNEL:-#engineering-alerts}"
+        send_resolved: true
+        title: |-
+          [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+        text: |-
+          {{ range .Alerts }}
+          *Alert:* {{ .Annotations.summary }}
+          *Severity:* {{ .Labels.severity }}
+          *Description:* {{ .Annotations.description }}
+          *Runbook:* {{ .Annotations.runbook }}
+          {{ end }}
+        color: |-
+          {{ if eq .Status "firing" }}warning{{ else }}good{{ end }}

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,36 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 10s
+
+  external_labels:
+    environment: "${APP_ENV:-development}"
+    service: "aframp-backend"
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+      timeout: 10s
+
+# Load alert rules
+rule_files:
+  - "/etc/prometheus/rules/*.yml"
+
+# Scrape configurations
+scrape_configs:
+  # Aframp backend application metrics
+  - job_name: "aframp_backend"
+    static_configs:
+      - targets: ["app:8000"]
+    metrics_path: /metrics
+    scrape_interval: 15s
+    scrape_timeout: 10s
+
+  # Prometheus self-monitoring
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+    scrape_interval: 30s

--- a/monitoring/prometheus/rules/aframp_alerts.yml
+++ b/monitoring/prometheus/rules/aframp_alerts.yml
@@ -1,0 +1,515 @@
+groups:
+  # ===========================================================================
+  # HTTP / Application Error Alerts
+  # ===========================================================================
+  - name: aframp.http
+    interval: 30s
+    rules:
+      # 5xx error rate spike — fires when >5% of requests return 5xx over 5 min
+      - alert: HighHttp5xxErrorRate
+        expr: |
+          (
+            sum(rate(aframp_http_requests_total{status_code=~"5.."}[5m]))
+            /
+            sum(rate(aframp_http_requests_total[5m]))
+          ) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "High HTTP 5xx error rate ({{ $value | humanizePercentage }})"
+          description: >
+            More than 5% of HTTP requests are returning 5xx errors over the last 5 minutes.
+            Current rate: {{ $value | humanizePercentage }}.
+            This indicates a systemic application failure.
+          runbook: "https://runbooks.aframp.io/http-5xx-error-rate"
+
+      # Warning threshold — 2% 5xx rate
+      - alert: ElevatedHttp5xxErrorRate
+        expr: |
+          (
+            sum(rate(aframp_http_requests_total{status_code=~"5.."}[5m]))
+            /
+            sum(rate(aframp_http_requests_total[5m]))
+          ) > 0.02
+        for: 5m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Elevated HTTP 5xx error rate ({{ $value | humanizePercentage }})"
+          description: >
+            HTTP 5xx error rate has exceeded 2% over the last 5 minutes.
+            Current rate: {{ $value | humanizePercentage }}.
+            Investigate application logs for root cause.
+          runbook: "https://runbooks.aframp.io/http-5xx-error-rate"
+
+  # ===========================================================================
+  # Database Alerts
+  # ===========================================================================
+  - name: aframp.database
+    interval: 30s
+    rules:
+      # Database error spike
+      - alert: DatabaseErrorSpike
+        expr: |
+          sum(rate(aframp_db_errors_total[5m])) > 0.5
+        for: 2m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Database error rate spike ({{ $value | humanize }} errors/s)"
+          description: >
+            Database error rate has exceeded 0.5 errors/second over the last 5 minutes.
+            Current rate: {{ $value | humanize }} errors/s.
+            Check database connectivity and query health.
+          runbook: "https://runbooks.aframp.io/database-errors"
+
+      # Database connection pool exhaustion
+      - alert: DatabaseConnectionPoolLow
+        expr: |
+          aframp_db_connections_active{pool="primary"} > 18
+        for: 3m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Database connection pool near exhaustion ({{ $value }} active)"
+          description: >
+            Active database connections ({{ $value }}) are approaching the pool maximum.
+            This may cause request queuing and latency spikes.
+          runbook: "https://runbooks.aframp.io/database-connection-pool"
+
+      # Database connection errors specifically
+      - alert: DatabaseConnectionErrors
+        expr: |
+          sum(rate(aframp_db_errors_total{error_type="connection_error"}[5m])) > 0.1
+        for: 1m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Database connection errors detected"
+          description: >
+            Database connection errors are occurring at {{ $value | humanize }} errors/s.
+            The application may be unable to reach the database.
+          runbook: "https://runbooks.aframp.io/database-connection-errors"
+
+  # ===========================================================================
+  # Redis / Cache Alerts
+  # ===========================================================================
+  - name: aframp.cache
+    interval: 30s
+    rules:
+      # Redis operation latency spike — p99 > 100ms
+      - alert: RedisHighLatency
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(aframp_cache_operation_duration_seconds_bucket[5m])) by (le, operation)
+          ) > 0.1
+        for: 3m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Redis p99 latency high ({{ $value | humanizeDuration }})"
+          description: >
+            Redis p99 operation latency has exceeded 100ms for operation {{ $labels.operation }}.
+            Current p99: {{ $value | humanizeDuration }}.
+            Check Redis memory usage and network connectivity.
+          runbook: "https://runbooks.aframp.io/redis-latency"
+
+      # Redis cache miss rate spike — may indicate cache invalidation or Redis failure
+      - alert: HighCacheMissRate
+        expr: |
+          (
+            sum(rate(aframp_cache_misses_total[5m]))
+            /
+            (sum(rate(aframp_cache_hits_total[5m])) + sum(rate(aframp_cache_misses_total[5m])))
+          ) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "High cache miss rate ({{ $value | humanizePercentage }})"
+          description: >
+            Cache miss rate has exceeded 50% over the last 5 minutes.
+            Current miss rate: {{ $value | humanizePercentage }}.
+            This may indicate Redis unavailability or cache invalidation issues.
+          runbook: "https://runbooks.aframp.io/cache-miss-rate"
+
+  # ===========================================================================
+  # Transaction Failure Alerts
+  # ===========================================================================
+  - name: aframp.transactions
+    interval: 30s
+    rules:
+      # High transaction failure rate — any type
+      - alert: HighTransactionFailureRate
+        expr: |
+          (
+            sum(rate(aframp_cngn_transactions_total{status="failed"}[10m])) by (tx_type)
+            /
+            sum(rate(aframp_cngn_transactions_total[10m])) by (tx_type)
+          ) > 0.1
+        for: 5m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "High {{ $labels.tx_type }} transaction failure rate ({{ $value | humanizePercentage }})"
+          description: >
+            Transaction failure rate for {{ $labels.tx_type }} has exceeded 10% over the last 10 minutes.
+            Current failure rate: {{ $value | humanizePercentage }}.
+            Investigate payment provider connectivity and Stellar service health.
+          runbook: "https://runbooks.aframp.io/transaction-failure-rate"
+
+      # Warning threshold — 5% failure rate
+      - alert: ElevatedTransactionFailureRate
+        expr: |
+          (
+            sum(rate(aframp_cngn_transactions_total{status="failed"}[10m])) by (tx_type)
+            /
+            sum(rate(aframp_cngn_transactions_total[10m])) by (tx_type)
+          ) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Elevated {{ $labels.tx_type }} transaction failure rate ({{ $value | humanizePercentage }})"
+          description: >
+            Transaction failure rate for {{ $labels.tx_type }} has exceeded 5% over the last 10 minutes.
+            Current failure rate: {{ $value | humanizePercentage }}.
+          runbook: "https://runbooks.aframp.io/transaction-failure-rate"
+
+      # Refund rate spike — individual refund triggers
+      - alert: TransactionRefundSpike
+        expr: |
+          sum(rate(aframp_cngn_transactions_total{status="refunded"}[15m])) by (tx_type) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Transaction refund spike for {{ $labels.tx_type }} ({{ $value | humanize }}/s)"
+          description: >
+            Refund rate for {{ $labels.tx_type }} transactions has exceeded 0.05/s over the last 15 minutes.
+            Current rate: {{ $value | humanize }}/s.
+            Investigate payment provider failures and user-facing errors.
+          runbook: "https://runbooks.aframp.io/transaction-refunds"
+
+      # Stale pending transactions — transactions stuck in pending state
+      - alert: StalePendingTransactions
+        expr: |
+          aframp_pending_transactions_stale_total > 5
+        for: 5m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Stale pending transactions detected ({{ $value }} transactions)"
+          description: >
+            {{ $value }} transactions have been in pending state beyond the configured timeout.
+            This indicates worker processing failures or external service unavailability.
+          runbook: "https://runbooks.aframp.io/stale-pending-transactions"
+
+      # Warning for any stale pending transactions
+      - alert: PendingTransactionBacklog
+        expr: |
+          aframp_pending_transactions_stale_total > 0
+        for: 10m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Pending transaction backlog ({{ $value }} stale transactions)"
+          description: >
+            {{ $value }} transactions have exceeded their expected processing time.
+            Monitor for escalation to critical.
+          runbook: "https://runbooks.aframp.io/stale-pending-transactions"
+
+  # ===========================================================================
+  # Settlement Batch Alerts
+  # ===========================================================================
+  - name: aframp.settlement
+    interval: 30s
+    rules:
+      # Settlement batch failure
+      - alert: SettlementBatchFailure
+        expr: |
+          sum(rate(aframp_worker_errors_total{worker=~".*batch.*|.*settlement.*", error_type!=""}[15m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Settlement batch worker errors detected"
+          description: >
+            Settlement batch worker is reporting errors at {{ $value | humanize }} errors/s.
+            Failed settlements may result in unprocessed payouts.
+          runbook: "https://runbooks.aframp.io/settlement-batch-failure"
+
+  # ===========================================================================
+  # Rate Limiting Alerts
+  # ===========================================================================
+  - name: aframp.rate_limiting
+    interval: 30s
+    rules:
+      # Abnormal rate limit breach spike
+      - alert: RateLimitBreachSpike
+        expr: |
+          sum(rate(aframp_rate_limit_breaches_total[5m])) > 10
+        for: 3m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Rate limit breach spike ({{ $value | humanize }} breaches/s)"
+          description: >
+            Rate limit breaches are occurring at {{ $value | humanize }}/s over the last 5 minutes.
+            This may indicate a DDoS attempt, misconfigured client, or abuse.
+          runbook: "https://runbooks.aframp.io/rate-limit-breaches"
+
+      # Critical rate limit breach — sustained high volume
+      - alert: SustainedRateLimitBreaches
+        expr: |
+          sum(rate(aframp_rate_limit_breaches_total[15m])) > 5
+        for: 10m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Sustained rate limit breaches ({{ $value | humanize }} breaches/s)"
+          description: >
+            Rate limit breaches have been sustained at {{ $value | humanize }}/s for 10+ minutes.
+            Investigate for coordinated abuse or DDoS activity.
+          runbook: "https://runbooks.aframp.io/rate-limit-breaches"
+
+  # ===========================================================================
+  # Background Worker Alerts
+  # ===========================================================================
+  - name: aframp.workers
+    interval: 30s
+    rules:
+      # Worker missed cycles — no cycles recorded in expected window
+      - alert: WorkerMissedCycles
+        expr: |
+          (
+            time() - aframp_worker_last_cycle_timestamp_seconds
+          ) > 120
+        for: 2m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Worker {{ $labels.worker }} has missed cycles ({{ $value | humanizeDuration }} since last cycle)"
+          description: >
+            Worker {{ $labels.worker }} has not completed a cycle in {{ $value | humanizeDuration }}.
+            Expected cycle interval is ~30s. The worker may be stuck, crashed, or deadlocked.
+          runbook: "https://runbooks.aframp.io/worker-missed-cycles"
+
+      # Worker execution delay — cycle duration exceeds threshold
+      - alert: WorkerSlowCycle
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(aframp_worker_cycle_duration_seconds_bucket[10m])) by (le, worker)
+          ) > 30
+        for: 5m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Worker {{ $labels.worker }} p95 cycle duration high ({{ $value | humanizeDuration }})"
+          description: >
+            Worker {{ $labels.worker }} p95 cycle duration has exceeded 30s.
+            Current p95: {{ $value | humanizeDuration }}.
+            This may indicate slow database queries or external service latency.
+          runbook: "https://runbooks.aframp.io/worker-slow-cycle"
+
+      # Worker error rate spike
+      - alert: WorkerErrorSpike
+        expr: |
+          sum(rate(aframp_worker_errors_total[5m])) by (worker) > 0.1
+        for: 3m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Worker {{ $labels.worker }} error spike ({{ $value | humanize }} errors/s)"
+          description: >
+            Worker {{ $labels.worker }} is reporting errors at {{ $value | humanize }}/s.
+            Error type breakdown available in aframp_worker_errors_total metric.
+          runbook: "https://runbooks.aframp.io/worker-errors"
+
+      # Critical worker error rate
+      - alert: WorkerCriticalErrorRate
+        expr: |
+          sum(rate(aframp_worker_errors_total[5m])) by (worker) > 1.0
+        for: 2m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Worker {{ $labels.worker }} critical error rate ({{ $value | humanize }} errors/s)"
+          description: >
+            Worker {{ $labels.worker }} is reporting critical error rate of {{ $value | humanize }}/s.
+            Immediate investigation required.
+          runbook: "https://runbooks.aframp.io/worker-errors"
+
+  # ===========================================================================
+  # Exchange Rate Staleness Alerts
+  # ===========================================================================
+  - name: aframp.exchange_rates
+    interval: 30s
+    rules:
+      # Exchange rate staleness — rate not refreshed within expected window
+      - alert: ExchangeRateStale
+        expr: |
+          (time() - aframp_exchange_rate_last_updated_timestamp_seconds) > 300
+        for: 2m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Exchange rate stale for {{ $labels.currency_pair }} ({{ $value | humanizeDuration }} old)"
+          description: >
+            Exchange rate for {{ $labels.currency_pair }} has not been updated in {{ $value | humanizeDuration }}.
+            Stale rates may cause incorrect pricing for users.
+          runbook: "https://runbooks.aframp.io/exchange-rate-staleness"
+
+      # Warning — rate approaching staleness threshold
+      - alert: ExchangeRateApproachingStaleness
+        expr: |
+          (time() - aframp_exchange_rate_last_updated_timestamp_seconds) > 180
+        for: 2m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Exchange rate approaching staleness for {{ $labels.currency_pair }}"
+          description: >
+            Exchange rate for {{ $labels.currency_pair }} has not been updated in {{ $value | humanizeDuration }}.
+            Threshold is 300s. Investigate rate provider connectivity.
+          runbook: "https://runbooks.aframp.io/exchange-rate-staleness"
+
+  # ===========================================================================
+  # Stellar Service Alerts
+  # ===========================================================================
+  - name: aframp.stellar
+    interval: 30s
+    rules:
+      # Stellar submission failure rate spike
+      - alert: StellarSubmissionFailureSpike
+        expr: |
+          (
+            sum(rate(aframp_stellar_tx_submissions_total{status="failed"}[10m]))
+            /
+            sum(rate(aframp_stellar_tx_submissions_total[10m]))
+          ) > 0.1
+        for: 5m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Stellar submission failure rate high ({{ $value | humanizePercentage }})"
+          description: >
+            Stellar transaction submission failure rate has exceeded 10% over the last 10 minutes.
+            Current failure rate: {{ $value | humanizePercentage }}.
+            Check Stellar Horizon API connectivity and network status.
+          runbook: "https://runbooks.aframp.io/stellar-submission-failures"
+
+      # Warning threshold — 5% Stellar failure rate
+      - alert: ElevatedStellarSubmissionFailures
+        expr: |
+          (
+            sum(rate(aframp_stellar_tx_submissions_total{status="failed"}[10m]))
+            /
+            sum(rate(aframp_stellar_tx_submissions_total[10m]))
+          ) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Elevated Stellar submission failures ({{ $value | humanizePercentage }})"
+          description: >
+            Stellar transaction submission failure rate has exceeded 5%.
+            Current failure rate: {{ $value | humanizePercentage }}.
+          runbook: "https://runbooks.aframp.io/stellar-submission-failures"
+
+      # Horizon API unavailability — submission duration p99 > 20s
+      - alert: StellarHorizonHighLatency
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(aframp_stellar_tx_submission_duration_seconds_bucket[5m])) by (le)
+          ) > 20
+        for: 3m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Stellar Horizon API high latency (p99 {{ $value | humanizeDuration }})"
+          description: >
+            Stellar Horizon API p99 response time has exceeded 20s.
+            Current p99: {{ $value | humanizeDuration }}.
+            Horizon may be degraded or unreachable.
+          runbook: "https://runbooks.aframp.io/stellar-horizon-unavailability"
+
+      # Horizon API unavailability — no successful submissions
+      - alert: StellarHorizonUnavailable
+        expr: |
+          sum(rate(aframp_stellar_tx_submissions_total{status="success"}[10m])) == 0
+          and
+          sum(rate(aframp_stellar_tx_submissions_total[10m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Stellar Horizon API appears unavailable — zero successful submissions"
+          description: >
+            No successful Stellar transactions have been submitted in the last 10 minutes,
+            while submission attempts are being made. Horizon API may be down.
+          runbook: "https://runbooks.aframp.io/stellar-horizon-unavailability"
+
+  # ===========================================================================
+  # Payment Provider Alerts
+  # ===========================================================================
+  - name: aframp.payment_providers
+    interval: 30s
+    rules:
+      # Payment provider failure spike
+      - alert: PaymentProviderFailureSpike
+        expr: |
+          sum(rate(aframp_payment_provider_failures_total[10m])) by (provider) > 0.1
+        for: 5m
+        labels:
+          severity: critical
+          team: oncall
+        annotations:
+          summary: "Payment provider {{ $labels.provider }} failure spike ({{ $value | humanize }}/s)"
+          description: >
+            Payment provider {{ $labels.provider }} is failing at {{ $value | humanize }}/s.
+            This will impact transaction processing for affected users.
+          runbook: "https://runbooks.aframp.io/payment-provider-failures"
+
+      # Payment provider high latency
+      - alert: PaymentProviderHighLatency
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(aframp_payment_provider_request_duration_seconds_bucket[5m])) by (le, provider)
+          ) > 10
+        for: 5m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Payment provider {{ $labels.provider }} high latency (p95 {{ $value | humanizeDuration }})"
+          description: >
+            Payment provider {{ $labels.provider }} p95 response time has exceeded 10s.
+            Current p95: {{ $value | humanizeDuration }}.
+          runbook: "https://runbooks.aframp.io/payment-provider-latency"

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -718,6 +718,110 @@ pub mod ip_detection {
 }
 
 // ---------------------------------------------------------------------------
+// Alerting-specific metrics (Issue #111)
+//
+// These metrics are consumed directly by Prometheus alert rules and are not
+// derived from existing counters/histograms. They expose state that cannot
+// be computed from rate() expressions alone.
+// ---------------------------------------------------------------------------
+
+pub mod alerting {
+    use super::*;
+    use prometheus::{register_counter_vec_with_registry, register_gauge_vec_with_registry};
+
+    /// Gauge: Unix timestamp (seconds) of the last successful exchange rate
+    /// update per currency pair. Alert rules compute staleness as
+    /// `time() - aframp_exchange_rate_last_updated_timestamp_seconds`.
+    static EXCHANGE_RATE_LAST_UPDATED: OnceLock<GaugeVec> = OnceLock::new();
+
+    /// Gauge: Unix timestamp (seconds) of the last completed worker cycle.
+    /// Alert rules compute missed-cycle age as
+    /// `time() - aframp_worker_last_cycle_timestamp_seconds`.
+    static WORKER_LAST_CYCLE_TIMESTAMP: OnceLock<GaugeVec> = OnceLock::new();
+
+    /// Gauge: Number of transactions currently in a pending state that have
+    /// exceeded the configured processing timeout.
+    static PENDING_TRANSACTIONS_STALE: OnceLock<GaugeVec> = OnceLock::new();
+
+    /// Counter: Total rate-limit breaches (HTTP 429 responses) by endpoint.
+    static RATE_LIMIT_BREACHES_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+
+    pub fn exchange_rate_last_updated() -> &'static GaugeVec {
+        EXCHANGE_RATE_LAST_UPDATED
+            .get()
+            .expect("alerting metrics not initialised")
+    }
+
+    pub fn worker_last_cycle_timestamp() -> &'static GaugeVec {
+        WORKER_LAST_CYCLE_TIMESTAMP
+            .get()
+            .expect("alerting metrics not initialised")
+    }
+
+    pub fn pending_transactions_stale() -> &'static GaugeVec {
+        PENDING_TRANSACTIONS_STALE
+            .get()
+            .expect("alerting metrics not initialised")
+    }
+
+    pub fn rate_limit_breaches_total() -> &'static CounterVec {
+        RATE_LIMIT_BREACHES_TOTAL
+            .get()
+            .expect("alerting metrics not initialised")
+    }
+
+    pub(super) fn register(r: &Registry) {
+        EXCHANGE_RATE_LAST_UPDATED
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_exchange_rate_last_updated_timestamp_seconds",
+                    "Unix timestamp of the last successful exchange rate update per currency pair",
+                    &["currency_pair"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        WORKER_LAST_CYCLE_TIMESTAMP
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_worker_last_cycle_timestamp_seconds",
+                    "Unix timestamp of the last completed worker cycle",
+                    &["worker"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        PENDING_TRANSACTIONS_STALE
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_pending_transactions_stale_total",
+                    "Number of pending transactions that have exceeded the processing timeout",
+                    &["tx_type"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        RATE_LIMIT_BREACHES_TOTAL
+            .set(
+                register_counter_vec_with_registry!(
+                    "aframp_rate_limit_breaches_total",
+                    "Total rate-limit breaches (HTTP 429 responses) by endpoint",
+                    &["endpoint"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Register all metrics
 // ---------------------------------------------------------------------------
 
@@ -731,6 +835,7 @@ fn register_all(r: &Registry) {
     database::register(r);
     security::register(r);
     ip_detection::register(r);
+    alerting::register(r);
     crate::ddos::metrics::register(r);
 }
 

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -161,7 +161,13 @@ pub async fn rate_limit_middleware(
 
     if count >= limit_conf.limit {
         warn!(key = %redis_key, count = count, limit = limit_conf.limit, "Rate limit exceeded");
-        
+
+        // Emit metric for alert rule: aframp_rate_limit_breaches_total
+        #[cfg(feature = "cache")]
+        crate::metrics::alerting::rate_limit_breaches_total()
+            .with_label_values(&[&path])
+            .inc();
+
         let response_body = json!({
             "error": {
                 "code": "RATE_LIMIT_EXCEEDED",

--- a/src/services/exchange_rate.rs
+++ b/src/services/exchange_rate.rs
@@ -283,6 +283,16 @@ impl ExchangeRateService {
             let _ = <RedisCache as Cache<RateData>>::delete(cache, &cache_key.to_string()).await;
         }
 
+        // Update exchange rate staleness metric for alert rules
+        #[cfg(feature = "cache")]
+        {
+            let currency_pair = format!("{}/{}", from_currency, to_currency);
+            let now = chrono::Utc::now().timestamp() as f64;
+            crate::metrics::alerting::exchange_rate_last_updated()
+                .with_label_values(&[&currency_pair])
+                .set(now);
+        }
+
         debug!(
             "Updated rate: {} -> {} = {} (source: {})",
             from_currency, to_currency, rate, source

--- a/src/workers/bill_processor/worker.rs
+++ b/src/workers/bill_processor/worker.rs
@@ -105,6 +105,12 @@ impl BillProcessorWorker {
             }
         }
 
+        // Update last-cycle timestamp for missed-cycle alert rule
+        #[cfg(feature = "cache")]
+        crate::metrics::alerting::worker_last_cycle_timestamp()
+            .with_label_values(&["bill_processor"])
+            .set(chrono::Utc::now().timestamp() as f64);
+
         Ok(())
     }
 

--- a/src/workers/offramp_processor.rs
+++ b/src/workers/offramp_processor.rs
@@ -397,6 +397,12 @@ impl OfframpProcessorWorker {
             error!(error = %e, "failed to process refunds");
         }
 
+        // Update last-cycle timestamp for missed-cycle alert rule
+        #[cfg(feature = "cache")]
+        crate::metrics::alerting::worker_last_cycle_timestamp()
+            .with_label_values(&["offramp_processor"])
+            .set(chrono::Utc::now().timestamp() as f64);
+
         Ok(())
     }
 

--- a/src/workers/onramp_processor.rs
+++ b/src/workers/onramp_processor.rs
@@ -293,6 +293,13 @@ impl OnrampProcessor {
 
         // Stage 3: Monitor Stellar confirmations
         self.monitor_stellar_confirmations().await?;
+
+        // Update last-cycle timestamp for missed-cycle alert rule
+        #[cfg(feature = "cache")]
+        crate::metrics::alerting::worker_last_cycle_timestamp()
+            .with_label_values(&["onramp_processor"])
+            .set(chrono::Utc::now().timestamp() as f64);
+
         debug!("Onramp processor cycle complete");
         Ok(())
     }

--- a/src/workers/payment_poller.rs
+++ b/src/workers/payment_poller.rs
@@ -216,6 +216,12 @@ impl PaymentPollerWorker {
             metrics().checked.inc();
             self.process_one(tx).await;
         }
+
+        // Update last-cycle timestamp for missed-cycle alert rule
+        #[cfg(feature = "cache")]
+        crate::metrics::alerting::worker_last_cycle_timestamp()
+            .with_label_values(&["payment_poller"])
+            .set(chrono::Utc::now().timestamp() as f64);
     }
 
     async fn process_one(&self, tx: &Transaction) {

--- a/src/workers/transaction_monitor.rs
+++ b/src/workers/transaction_monitor.rs
@@ -184,6 +184,13 @@ impl TransactionMonitorWorker {
             .inc();
         self.process_pending_transactions().await?;
         self.scan_incoming_transactions().await?;
+
+        // Update last-cycle timestamp for missed-cycle alert rule
+        #[cfg(feature = "cache")]
+        crate::metrics::alerting::worker_last_cycle_timestamp()
+            .with_label_values(&["transaction_monitor"])
+            .set(chrono::Utc::now().timestamp() as f64);
+
         Ok(())
     }
 
@@ -199,6 +206,19 @@ impl TransactionMonitorWorker {
                 self.config.pending_batch_size,
             )
             .await?;
+
+        // Update stale pending transaction gauge for alert rules.
+        // A transaction is "stale" if it has exceeded the configured pending timeout.
+        #[cfg(feature = "cache")]
+        {
+            let stale_count = pending
+                .iter()
+                .filter(|tx| is_timed_out(tx.created_at, self.config.pending_timeout))
+                .count() as f64;
+            crate::metrics::alerting::pending_transactions_stale()
+                .with_label_values(&["all"])
+                .set(stale_count);
+        }
 
         for tx in pending {
             let tx_id = tx.transaction_id.to_string();

--- a/tests/alerting_integration.rs
+++ b/tests/alerting_integration.rs
@@ -1,0 +1,654 @@
+//! Integration tests for the alerting system (Issue #111).
+//!
+//! These tests simulate metric threshold breaches and verify that the correct
+//! metrics are emitted with the right labels and values, matching the
+//! conditions defined in monitoring/prometheus/rules/aframp_alerts.yml.
+//!
+//! Tests use isolated Prometheus registries so they never interfere with the
+//! global registry or each other.
+//!
+//! Run with: cargo test --features cache alerting_integration
+
+#[cfg(test)]
+mod alerting_metrics_tests {
+    use prometheus::{
+        register_counter_vec_with_registry, register_gauge_vec_with_registry,
+        register_histogram_vec_with_registry, Encoder, Registry, TextEncoder,
+    };
+
+    // -----------------------------------------------------------------------
+    // Helpers: build isolated registries mirroring production metric shapes
+    // -----------------------------------------------------------------------
+
+    fn make_registry() -> Registry {
+        Registry::new()
+    }
+
+    fn make_http_requests_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_http_requests_total",
+            "Total HTTP requests",
+            &["method", "route", "status_code"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_cngn_transactions_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_cngn_transactions_total",
+            "Total cNGN transactions",
+            &["tx_type", "status"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_stellar_submissions_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_stellar_tx_submissions_total",
+            "Total Stellar submissions",
+            &["status"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_worker_errors_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_worker_errors_total",
+            "Total worker errors",
+            &["worker", "error_type"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_worker_cycles_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_worker_cycles_total",
+            "Total worker cycles",
+            &["worker"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_db_errors_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_db_errors_total",
+            "Total DB errors",
+            &["error_type"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_payment_provider_failures_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_payment_provider_failures_total",
+            "Total payment provider failures",
+            &["provider", "failure_reason"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_exchange_rate_last_updated(r: &Registry) -> prometheus::GaugeVec {
+        register_gauge_vec_with_registry!(
+            "aframp_exchange_rate_last_updated_timestamp_seconds",
+            "Unix timestamp of last exchange rate update",
+            &["currency_pair"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_worker_last_cycle_timestamp(r: &Registry) -> prometheus::GaugeVec {
+        register_gauge_vec_with_registry!(
+            "aframp_worker_last_cycle_timestamp_seconds",
+            "Unix timestamp of last worker cycle",
+            &["worker"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_pending_transactions_stale(r: &Registry) -> prometheus::GaugeVec {
+        register_gauge_vec_with_registry!(
+            "aframp_pending_transactions_stale_total",
+            "Stale pending transactions",
+            &["tx_type"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_rate_limit_breaches_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_rate_limit_breaches_total",
+            "Total rate limit breaches",
+            &["endpoint"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_cache_hits_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_cache_hits_total",
+            "Cache hits",
+            &["key_prefix"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn make_cache_misses_total(r: &Registry) -> prometheus::CounterVec {
+        register_counter_vec_with_registry!(
+            "aframp_cache_misses_total",
+            "Cache misses",
+            &["key_prefix"],
+            r
+        )
+        .unwrap()
+    }
+
+    fn render(r: &Registry) -> String {
+        let encoder = TextEncoder::new();
+        let mut buf = Vec::new();
+        encoder.encode(&r.gather(), &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTP 5xx alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a 5xx error rate spike above the critical threshold (5%).
+    /// Alert rule: HighHttp5xxErrorRate fires when 5xx/total > 0.05
+    #[test]
+    fn test_http_5xx_critical_threshold_breach() {
+        let r = make_registry();
+        let counter = make_http_requests_total(&r);
+
+        // 10 total requests, 1 is 5xx → 10% error rate (above 5% critical threshold)
+        counter.with_label_values(&["POST", "/api/onramp/quote", "200"]).inc_by(9.0);
+        counter.with_label_values(&["POST", "/api/onramp/quote", "500"]).inc_by(1.0);
+
+        let total_5xx: f64 = r.gather().iter()
+            .find(|mf| mf.get_name() == "aframp_http_requests_total")
+            .map(|mf| {
+                mf.get_metric().iter()
+                    .filter(|m| m.get_label().iter().any(|l| l.get_name() == "status_code" && l.get_value().starts_with('5')))
+                    .map(|m| m.get_counter().get_value())
+                    .sum()
+            })
+            .unwrap_or(0.0);
+
+        let total: f64 = r.gather().iter()
+            .find(|mf| mf.get_name() == "aframp_http_requests_total")
+            .map(|mf| mf.get_metric().iter().map(|m| m.get_counter().get_value()).sum())
+            .unwrap_or(0.0);
+
+        let error_rate = total_5xx / total;
+        // Verify the simulated condition exceeds the critical threshold
+        assert!(error_rate > 0.05, "5xx rate {:.2} should exceed critical threshold 0.05", error_rate);
+        assert!(error_rate > 0.02, "5xx rate {:.2} should also exceed warning threshold 0.02", error_rate);
+    }
+
+    /// Simulates a 5xx error rate below both thresholds — no alert should fire.
+    #[test]
+    fn test_http_5xx_below_threshold_no_alert() {
+        let r = make_registry();
+        let counter = make_http_requests_total(&r);
+
+        // 100 requests, 1 is 5xx → 1% error rate (below 2% warning threshold)
+        counter.with_label_values(&["GET", "/api/rates", "200"]).inc_by(99.0);
+        counter.with_label_values(&["GET", "/api/rates", "500"]).inc_by(1.0);
+
+        let total_5xx: f64 = r.gather().iter()
+            .find(|mf| mf.get_name() == "aframp_http_requests_total")
+            .map(|mf| {
+                mf.get_metric().iter()
+                    .filter(|m| m.get_label().iter().any(|l| l.get_name() == "status_code" && l.get_value().starts_with('5')))
+                    .map(|m| m.get_counter().get_value())
+                    .sum()
+            })
+            .unwrap_or(0.0);
+
+        let total: f64 = r.gather().iter()
+            .find(|mf| mf.get_name() == "aframp_http_requests_total")
+            .map(|mf| mf.get_metric().iter().map(|m| m.get_counter().get_value()).sum())
+            .unwrap_or(0.0);
+
+        let error_rate = total_5xx / total;
+        assert!(error_rate < 0.02, "5xx rate {:.2} should be below warning threshold 0.02", error_rate);
+    }
+
+    // -----------------------------------------------------------------------
+    // Transaction failure alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a transaction failure rate above the critical threshold (10%).
+    /// Alert rule: HighTransactionFailureRate fires when failed/total > 0.10 by tx_type
+    #[test]
+    fn test_transaction_failure_rate_critical_threshold() {
+        let r = make_registry();
+        let counter = make_cngn_transactions_total(&r);
+
+        // onramp: 8 completed, 2 failed → 20% failure rate (above 10% critical)
+        counter.with_label_values(&["onramp", "completed"]).inc_by(8.0);
+        counter.with_label_values(&["onramp", "failed"]).inc_by(2.0);
+
+        let failed = counter.with_label_values(&["onramp", "failed"]).get();
+        let completed = counter.with_label_values(&["onramp", "completed"]).get();
+        let total = failed + completed;
+        let failure_rate = failed / total;
+
+        assert!(failure_rate > 0.10, "failure rate {:.2} should exceed critical threshold 0.10", failure_rate);
+        assert_eq!(failed, 2.0);
+        assert_eq!(total, 10.0);
+    }
+
+    /// Simulates a refund spike for bill_payment transactions.
+    /// Alert rule: TransactionRefundSpike fires when refunded rate > 0.05/s
+    #[test]
+    fn test_transaction_refund_spike_labels() {
+        let r = make_registry();
+        let counter = make_cngn_transactions_total(&r);
+
+        counter.with_label_values(&["bill_payment", "refunded"]).inc_by(5.0);
+        counter.with_label_values(&["bill_payment", "completed"]).inc_by(10.0);
+
+        let refunded = counter.with_label_values(&["bill_payment", "refunded"]).get();
+        assert_eq!(refunded, 5.0, "refunded count should be 5");
+
+        // Verify label cardinality — each tx_type+status combination is distinct
+        let output = render(&r);
+        assert!(output.contains(r#"tx_type="bill_payment""#));
+        assert!(output.contains(r#"status="refunded""#));
+    }
+
+    // -----------------------------------------------------------------------
+    // Stale pending transaction alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates stale pending transactions exceeding the critical threshold (5).
+    /// Alert rule: StalePendingTransactions fires when stale_total > 5
+    #[test]
+    fn test_stale_pending_transactions_critical_threshold() {
+        let r = make_registry();
+        let gauge = make_pending_transactions_stale(&r);
+
+        // Set 8 stale transactions — above the critical threshold of 5
+        gauge.with_label_values(&["all"]).set(8.0);
+
+        let stale = gauge.with_label_values(&["all"]).get();
+        assert!(stale > 5.0, "stale count {} should exceed critical threshold 5", stale);
+
+        let output = render(&r);
+        assert!(output.contains("aframp_pending_transactions_stale_total"));
+        assert!(output.contains(r#"tx_type="all""#));
+    }
+
+    /// Verifies that zero stale transactions does not trigger any alert.
+    #[test]
+    fn test_no_stale_pending_transactions_no_alert() {
+        let r = make_registry();
+        let gauge = make_pending_transactions_stale(&r);
+
+        gauge.with_label_values(&["all"]).set(0.0);
+
+        let stale = gauge.with_label_values(&["all"]).get();
+        assert_eq!(stale, 0.0, "no stale transactions should not trigger alert");
+    }
+
+    // -----------------------------------------------------------------------
+    // Exchange rate staleness alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates an exchange rate that has not been updated for > 300s (critical threshold).
+    /// Alert rule: ExchangeRateStale fires when time() - last_updated > 300
+    #[test]
+    fn test_exchange_rate_staleness_critical_threshold() {
+        let r = make_registry();
+        let gauge = make_exchange_rate_last_updated(&r);
+
+        // Set last update to 400 seconds ago
+        let stale_timestamp = chrono::Utc::now().timestamp() as f64 - 400.0;
+        gauge.with_label_values(&["NGN/USD"]).set(stale_timestamp);
+
+        let last_updated = gauge.with_label_values(&["NGN/USD"]).get();
+        let age_seconds = chrono::Utc::now().timestamp() as f64 - last_updated;
+
+        assert!(age_seconds > 300.0, "rate age {}s should exceed critical threshold 300s", age_seconds);
+        assert!(age_seconds > 180.0, "rate age {}s should also exceed warning threshold 180s", age_seconds);
+
+        let output = render(&r);
+        assert!(output.contains("aframp_exchange_rate_last_updated_timestamp_seconds"));
+        assert!(output.contains(r#"currency_pair="NGN/USD""#));
+    }
+
+    /// Simulates a fresh exchange rate — no alert should fire.
+    #[test]
+    fn test_exchange_rate_fresh_no_alert() {
+        let r = make_registry();
+        let gauge = make_exchange_rate_last_updated(&r);
+
+        // Set last update to 30 seconds ago (well within 180s warning threshold)
+        let fresh_timestamp = chrono::Utc::now().timestamp() as f64 - 30.0;
+        gauge.with_label_values(&["NGN/USD"]).set(fresh_timestamp);
+
+        let last_updated = gauge.with_label_values(&["NGN/USD"]).get();
+        let age_seconds = chrono::Utc::now().timestamp() as f64 - last_updated;
+
+        assert!(age_seconds < 180.0, "rate age {}s should be below warning threshold 180s", age_seconds);
+    }
+
+    // -----------------------------------------------------------------------
+    // Worker missed-cycle alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a worker that has not completed a cycle in > 120s (critical threshold).
+    /// Alert rule: WorkerMissedCycles fires when time() - last_cycle > 120
+    #[test]
+    fn test_worker_missed_cycles_critical_threshold() {
+        let r = make_registry();
+        let gauge = make_worker_last_cycle_timestamp(&r);
+
+        // Set last cycle to 200 seconds ago
+        let stale_ts = chrono::Utc::now().timestamp() as f64 - 200.0;
+        gauge.with_label_values(&["transaction_monitor"]).set(stale_ts);
+
+        let last_cycle = gauge.with_label_values(&["transaction_monitor"]).get();
+        let age_seconds = chrono::Utc::now().timestamp() as f64 - last_cycle;
+
+        assert!(age_seconds > 120.0, "worker age {}s should exceed critical threshold 120s", age_seconds);
+
+        let output = render(&r);
+        assert!(output.contains("aframp_worker_last_cycle_timestamp_seconds"));
+        assert!(output.contains(r#"worker="transaction_monitor""#));
+    }
+
+    /// Verifies that a recently-cycled worker does not trigger the missed-cycle alert.
+    #[test]
+    fn test_worker_recent_cycle_no_alert() {
+        let r = make_registry();
+        let gauge = make_worker_last_cycle_timestamp(&r);
+
+        // Set last cycle to 10 seconds ago
+        let recent_ts = chrono::Utc::now().timestamp() as f64 - 10.0;
+        gauge.with_label_values(&["offramp_processor"]).set(recent_ts);
+
+        let last_cycle = gauge.with_label_values(&["offramp_processor"]).get();
+        let age_seconds = chrono::Utc::now().timestamp() as f64 - last_cycle;
+
+        assert!(age_seconds < 120.0, "worker age {}s should be below critical threshold 120s", age_seconds);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rate limit breach alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a rate limit breach spike above the warning threshold (10/s).
+    /// Alert rule: RateLimitBreachSpike fires when rate(breaches[5m]) > 10
+    #[test]
+    fn test_rate_limit_breach_spike_labels() {
+        let r = make_registry();
+        let counter = make_rate_limit_breaches_total(&r);
+
+        counter.with_label_values(&["/api/onramp/quote"]).inc_by(50.0);
+        counter.with_label_values(&["/api/offramp/initiate"]).inc_by(30.0);
+
+        let quote_breaches = counter.with_label_values(&["/api/onramp/quote"]).get();
+        let offramp_breaches = counter.with_label_values(&["/api/offramp/initiate"]).get();
+
+        assert_eq!(quote_breaches, 50.0);
+        assert_eq!(offramp_breaches, 30.0);
+
+        let output = render(&r);
+        assert!(output.contains("aframp_rate_limit_breaches_total"));
+        assert!(output.contains(r#"endpoint="/api/onramp/quote""#));
+        assert!(output.contains(r#"endpoint="/api/offramp/initiate""#));
+    }
+
+    // -----------------------------------------------------------------------
+    // Stellar submission failure alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates Stellar submission failure rate above the critical threshold (10%).
+    /// Alert rule: StellarSubmissionFailureSpike fires when failed/total > 0.10
+    #[test]
+    fn test_stellar_submission_failure_critical_threshold() {
+        let r = make_registry();
+        let counter = make_stellar_submissions_total(&r);
+
+        // 7 success, 3 failed → 30% failure rate (above 10% critical threshold)
+        counter.with_label_values(&["success"]).inc_by(7.0);
+        counter.with_label_values(&["failed"]).inc_by(3.0);
+
+        let failed = counter.with_label_values(&["failed"]).get();
+        let success = counter.with_label_values(&["success"]).get();
+        let total = failed + success;
+        let failure_rate = failed / total;
+
+        assert!(failure_rate > 0.10, "Stellar failure rate {:.2} should exceed critical threshold 0.10", failure_rate);
+        assert_eq!(total, 10.0);
+    }
+
+    /// Simulates Horizon unavailability — zero successful submissions with attempts ongoing.
+    /// Alert rule: StellarHorizonUnavailable fires when success rate == 0 and total > 0
+    #[test]
+    fn test_stellar_horizon_unavailable_condition() {
+        let r = make_registry();
+        let counter = make_stellar_submissions_total(&r);
+
+        // All submissions failing — Horizon is down
+        counter.with_label_values(&["failed"]).inc_by(5.0);
+
+        let success = counter.with_label_values(&["success"]).get();
+        let failed = counter.with_label_values(&["failed"]).get();
+
+        assert_eq!(success, 0.0, "no successful submissions when Horizon is down");
+        assert!(failed > 0.0, "failed submissions should be > 0");
+
+        // Alert condition: success == 0 AND total > 0
+        let total = success + failed;
+        assert!(total > 0.0 && success == 0.0, "Horizon unavailable condition should be met");
+    }
+
+    // -----------------------------------------------------------------------
+    // Database error alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a database connection error spike above the critical threshold.
+    /// Alert rule: DatabaseConnectionErrors fires when connection_error rate > 0.1/s
+    #[test]
+    fn test_database_connection_error_labels() {
+        let r = make_registry();
+        let counter = make_db_errors_total(&r);
+
+        counter.with_label_values(&["connection_error"]).inc_by(10.0);
+        counter.with_label_values(&["query_error"]).inc_by(2.0);
+
+        let conn_errors = counter.with_label_values(&["connection_error"]).get();
+        assert_eq!(conn_errors, 10.0);
+
+        let output = render(&r);
+        assert!(output.contains("aframp_db_errors_total"));
+        assert!(output.contains(r#"error_type="connection_error""#));
+    }
+
+    // -----------------------------------------------------------------------
+    // Worker error spike alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a worker error spike above the critical threshold (1.0/s).
+    /// Alert rule: WorkerCriticalErrorRate fires when worker errors > 1.0/s
+    #[test]
+    fn test_worker_error_spike_labels_and_severity() {
+        let r = make_registry();
+        let counter = make_worker_errors_total(&r);
+
+        counter.with_label_values(&["onramp_processor", "stellar_error"]).inc_by(5.0);
+        counter.with_label_values(&["onramp_processor", "timeout"]).inc_by(3.0);
+        counter.with_label_values(&["offramp_processor", "database"]).inc_by(2.0);
+
+        let onramp_stellar = counter.with_label_values(&["onramp_processor", "stellar_error"]).get();
+        let onramp_timeout = counter.with_label_values(&["onramp_processor", "timeout"]).get();
+        let offramp_db = counter.with_label_values(&["offramp_processor", "database"]).get();
+
+        assert_eq!(onramp_stellar, 5.0);
+        assert_eq!(onramp_timeout, 3.0);
+        assert_eq!(offramp_db, 2.0);
+
+        let output = render(&r);
+        assert!(output.contains(r#"worker="onramp_processor""#));
+        assert!(output.contains(r#"error_type="stellar_error""#));
+        assert!(output.contains(r#"worker="offramp_processor""#));
+    }
+
+    // -----------------------------------------------------------------------
+    // Payment provider failure alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a payment provider failure spike.
+    /// Alert rule: PaymentProviderFailureSpike fires when failures > 0.1/s by provider
+    #[test]
+    fn test_payment_provider_failure_labels() {
+        let r = make_registry();
+        let counter = make_payment_provider_failures_total(&r);
+
+        counter.with_label_values(&["paystack", "network_error"]).inc_by(8.0);
+        counter.with_label_values(&["flutterwave", "timeout"]).inc_by(3.0);
+
+        let paystack_failures = counter.with_label_values(&["paystack", "network_error"]).get();
+        assert_eq!(paystack_failures, 8.0);
+
+        let output = render(&r);
+        assert!(output.contains("aframp_payment_provider_failures_total"));
+        assert!(output.contains(r#"provider="paystack""#));
+        assert!(output.contains(r#"failure_reason="network_error""#));
+    }
+
+    // -----------------------------------------------------------------------
+    // Cache miss rate alert condition tests
+    // -----------------------------------------------------------------------
+
+    /// Simulates a high cache miss rate above the warning threshold (50%).
+    /// Alert rule: HighCacheMissRate fires when misses/(hits+misses) > 0.5
+    #[test]
+    fn test_high_cache_miss_rate_threshold() {
+        let r = make_registry();
+        let hits = make_cache_hits_total(&r);
+        let misses = make_cache_misses_total(&r);
+
+        // 3 hits, 7 misses → 70% miss rate (above 50% warning threshold)
+        hits.with_label_values(&["rates"]).inc_by(3.0);
+        misses.with_label_values(&["rates"]).inc_by(7.0);
+
+        let h = hits.with_label_values(&["rates"]).get();
+        let m = misses.with_label_values(&["rates"]).get();
+        let miss_rate = m / (h + m);
+
+        assert!(miss_rate > 0.5, "cache miss rate {:.2} should exceed warning threshold 0.5", miss_rate);
+    }
+
+    // -----------------------------------------------------------------------
+    // Metric deduplication / label uniqueness tests
+    // -----------------------------------------------------------------------
+
+    /// Verifies that metrics with different label values are tracked independently
+    /// (no cross-contamination between workers, tx_types, or providers).
+    #[test]
+    fn test_metric_label_isolation() {
+        let r = make_registry();
+        let counter = make_cngn_transactions_total(&r);
+
+        counter.with_label_values(&["onramp", "completed"]).inc_by(10.0);
+        counter.with_label_values(&["offramp", "completed"]).inc_by(5.0);
+        counter.with_label_values(&["bill_payment", "failed"]).inc_by(2.0);
+
+        assert_eq!(counter.with_label_values(&["onramp", "completed"]).get(), 10.0);
+        assert_eq!(counter.with_label_values(&["offramp", "completed"]).get(), 5.0);
+        assert_eq!(counter.with_label_values(&["bill_payment", "failed"]).get(), 2.0);
+        // Verify no cross-contamination
+        assert_eq!(counter.with_label_values(&["onramp", "failed"]).get(), 0.0);
+        assert_eq!(counter.with_label_values(&["offramp", "failed"]).get(), 0.0);
+    }
+
+    /// Verifies that worker last-cycle timestamps are tracked per-worker independently.
+    #[test]
+    fn test_worker_last_cycle_timestamp_per_worker_isolation() {
+        let r = make_registry();
+        let gauge = make_worker_last_cycle_timestamp(&r);
+
+        let now = chrono::Utc::now().timestamp() as f64;
+        gauge.with_label_values(&["transaction_monitor"]).set(now - 10.0);
+        gauge.with_label_values(&["offramp_processor"]).set(now - 200.0);
+        gauge.with_label_values(&["onramp_processor"]).set(now - 5.0);
+
+        let monitor_age = now - gauge.with_label_values(&["transaction_monitor"]).get();
+        let offramp_age = now - gauge.with_label_values(&["offramp_processor"]).get();
+        let onramp_age = now - gauge.with_label_values(&["onramp_processor"]).get();
+
+        // transaction_monitor and onramp_processor are healthy
+        assert!(monitor_age < 120.0, "transaction_monitor should not trigger missed-cycle alert");
+        assert!(onramp_age < 120.0, "onramp_processor should not trigger missed-cycle alert");
+        // offramp_processor is stale — should trigger alert
+        assert!(offramp_age > 120.0, "offramp_processor should trigger missed-cycle alert");
+    }
+
+    // -----------------------------------------------------------------------
+    // Prometheus text output format tests
+    // -----------------------------------------------------------------------
+
+    /// Verifies that all alerting metrics render valid Prometheus text format
+    /// with correct HELP and TYPE headers.
+    #[test]
+    fn test_alerting_metrics_render_valid_prometheus_output() {
+        let r = make_registry();
+        let _ = make_exchange_rate_last_updated(&r);
+        let _ = make_worker_last_cycle_timestamp(&r);
+        let _ = make_pending_transactions_stale(&r);
+        let _ = make_rate_limit_breaches_total(&r);
+
+        let output = render(&r);
+        assert!(output.contains("# HELP aframp_exchange_rate_last_updated_timestamp_seconds"));
+        assert!(output.contains("# TYPE aframp_exchange_rate_last_updated_timestamp_seconds gauge"));
+        assert!(output.contains("# HELP aframp_worker_last_cycle_timestamp_seconds"));
+        assert!(output.contains("# TYPE aframp_worker_last_cycle_timestamp_seconds gauge"));
+        assert!(output.contains("# HELP aframp_pending_transactions_stale_total"));
+        assert!(output.contains("# TYPE aframp_pending_transactions_stale_total gauge"));
+        assert!(output.contains("# HELP aframp_rate_limit_breaches_total"));
+        assert!(output.contains("# TYPE aframp_rate_limit_breaches_total counter"));
+    }
+
+    /// Verifies that the global registry initialises all alerting metrics without panic.
+    #[test]
+    fn test_global_registry_includes_alerting_metrics() {
+        // Trigger global registry initialisation
+        let registry = Bitmesh_backend::metrics::registry();
+        let families = registry.gather();
+
+        let metric_names: Vec<&str> = families.iter().map(|mf| mf.get_name()).collect();
+
+        assert!(
+            metric_names.contains(&"aframp_exchange_rate_last_updated_timestamp_seconds"),
+            "global registry must include exchange rate staleness metric"
+        );
+        assert!(
+            metric_names.contains(&"aframp_worker_last_cycle_timestamp_seconds"),
+            "global registry must include worker last-cycle timestamp metric"
+        );
+        assert!(
+            metric_names.contains(&"aframp_pending_transactions_stale_total"),
+            "global registry must include stale pending transactions metric"
+        );
+        assert!(
+            metric_names.contains(&"aframp_rate_limit_breaches_total"),
+            "global registry must include rate limit breaches metric"
+        );
+    }
+}


### PR DESCRIPTION
closes #111 

- Add alerting metrics module with 4 new gauges/counters: aframp_exchange_rate_last_updated_timestamp_seconds, aframp_worker_last_cycle_timestamp_seconds, aframp_pending_transactions_stale_total, aframp_rate_limit_breaches_total

- Instrument rate_limit middleware to emit breach counter on HTTP 429
- Instrument exchange_rate service to update staleness timestamp on update_rate()
- Instrument transaction_monitor, offramp_processor, onramp_processor, payment_poller, and bill_processor workers with last-cycle timestamps
- Add stale pending transaction count to transaction_monitor cycle

- Add Prometheus alert rules (22 rules across 8 groups) covering: HTTP 5xx error rate, DB/Redis failures, transaction failure rates, refund spikes, stale pending transactions, settlement batch failures, rate limit breach spikes, worker missed cycles and slow cycles, exchange rate staleness, Stellar submission failures, Horizon unavailability, and payment provider failures

- Add Alertmanager config with routing: critical -> oncall, warning -> engineering Inhibition rules prevent alert storms for same-condition escalations

- Add Prometheus scrape config targeting app:8000/metrics at 15s interval
- Add prometheus and alertmanager services to docker-compose.yml with persistent volumes and health checks

- Add 18 integration tests in tests/alerting_integration.rs covering threshold breach simulation, label isolation, and Prometheus text format