### PR TITLE
feat: implement LP Payout Engine for Liquidity Providers

### DIFF
--- a/migrations/20260430000000_lp_payout_engine.sql
+++ b/migrations/20260430000000_lp_payout_engine.sql
@@ -1,0 +1,109 @@
+-- LP Payout Engine Schema
+-- Supports: hourly pool snapshots, reward accrual, epoch disbursement,
+--           wash-trade exclusion, and compliance flagging.
+
+-- ---------------------------------------------------------------------------
+-- Enums
+-- ---------------------------------------------------------------------------
+DO $$ BEGIN
+    CREATE TYPE lp_reward_type AS ENUM ('fee_based', 'liquidity_mining');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE lp_payout_status AS ENUM ('pending', 'processing', 'completed', 'failed', 'flagged');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- lp_providers — registered liquidity providers
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lp_providers (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    stellar_address     TEXT NOT NULL UNIQUE,
+    display_name        TEXT NOT NULL,
+    is_active           BOOLEAN NOT NULL DEFAULT TRUE,
+    whitelisted_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lp_providers_active ON lp_providers (is_active);
+
+-- ---------------------------------------------------------------------------
+-- lp_pool_snapshots — hourly pro-rata share snapshots
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lp_pool_snapshots (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    snapshot_at         TIMESTAMPTZ NOT NULL,
+    lp_provider_id      UUID NOT NULL REFERENCES lp_providers(id),
+    pool_id             TEXT NOT NULL,                  -- Stellar liquidity pool ID
+    lp_balance_stroops  BIGINT NOT NULL,                -- LP's pool share in stroops
+    total_pool_stroops  BIGINT NOT NULL,                -- Total pool size in stroops
+    pro_rata_share      NUMERIC(20, 10) NOT NULL,       -- lp_balance / total_pool
+    volume_stroops      BIGINT NOT NULL DEFAULT 0,      -- Volume traded in this hour
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (snapshot_at, lp_provider_id, pool_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lp_snapshots_provider_time
+    ON lp_pool_snapshots (lp_provider_id, snapshot_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lp_snapshots_pool_time
+    ON lp_pool_snapshots (pool_id, snapshot_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- lp_reward_epochs — weekly (or configurable) reward periods
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lp_reward_epochs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    epoch_start     TIMESTAMPTZ NOT NULL,
+    epoch_end       TIMESTAMPTZ NOT NULL,
+    total_fees_stroops      BIGINT NOT NULL DEFAULT 0,  -- Dynamic fees collected
+    total_volume_stroops    BIGINT NOT NULL DEFAULT 0,
+    mining_rate_per_1000    NUMERIC(20, 10) NOT NULL DEFAULT 0, -- cNGN per 1000 NGN/hr
+    is_finalized    BOOLEAN NOT NULL DEFAULT FALSE,
+    finalized_at    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (epoch_start, epoch_end)
+);
+
+-- ---------------------------------------------------------------------------
+-- lp_accrued_rewards — per-LP accrued rewards within an epoch
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lp_accrued_rewards (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    epoch_id            UUID NOT NULL REFERENCES lp_reward_epochs(id),
+    lp_provider_id      UUID NOT NULL REFERENCES lp_providers(id),
+    reward_type         lp_reward_type NOT NULL,
+    accrued_stroops     BIGINT NOT NULL DEFAULT 0,      -- Total accrued (stroop precision)
+    paid_stroops        BIGINT NOT NULL DEFAULT 0,
+    is_wash_trade_excluded BOOLEAN NOT NULL DEFAULT FALSE,
+    compliance_flagged  BOOLEAN NOT NULL DEFAULT FALSE,
+    compliance_reason   TEXT,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (epoch_id, lp_provider_id, reward_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lp_accrued_epoch ON lp_accrued_rewards (epoch_id);
+CREATE INDEX IF NOT EXISTS idx_lp_accrued_provider ON lp_accrued_rewards (lp_provider_id);
+
+-- ---------------------------------------------------------------------------
+-- lp_payouts — disbursement records (one per LP per epoch)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS lp_payouts (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    epoch_id            UUID NOT NULL REFERENCES lp_reward_epochs(id),
+    lp_provider_id      UUID NOT NULL REFERENCES lp_providers(id),
+    stellar_address     TEXT NOT NULL,
+    total_stroops       BIGINT NOT NULL,
+    status              lp_payout_status NOT NULL DEFAULT 'pending',
+    stellar_tx_hash     TEXT,
+    compliance_withheld BOOLEAN NOT NULL DEFAULT FALSE,
+    compliance_reason   TEXT,
+    attempted_at        TIMESTAMPTZ,
+    completed_at        TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (epoch_id, lp_provider_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lp_payouts_status ON lp_payouts (status);
+CREATE INDEX IF NOT EXISTS idx_lp_payouts_epoch ON lp_payouts (epoch_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,10 @@ pub mod admin;
 #[cfg(feature = "database")]
 pub mod analytics;
 
+// LP Payout Engine — reward calculation and disbursement for Liquidity Providers
+#[cfg(feature = "database")]
+pub mod lp_payout;
+
 // Data classification framework — authoritative sensitivity taxonomy and
 // policy enforcement for every data field on the platform.
 #[cfg(feature = "database")]

--- a/src/lp_payout/engine.rs
+++ b/src/lp_payout/engine.rs
@@ -1,0 +1,224 @@
+//! LP Reward Calculation Engine
+//!
+//! Implements two reward modes:
+//!   1. Fee-based  — LP's pro-rata share of dynamic fees collected in the epoch.
+//!   2. Mining     — Fixed cNGN per 1,000 NGN provided per hour.
+//!
+//! Wash-trade detection: any snapshot whose volume exceeds a configurable
+//! multiple of the pool's average volume is excluded from reward eligibility.
+
+use crate::lp_payout::{
+    models::{compliance_threshold_stroops, default_mining_rate_per_1000, LpPoolSnapshot},
+    repository::LpPayoutRepository,
+};
+use chrono::{DateTime, Datelike, Duration, Utc};
+use sqlx::types::BigDecimal;
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// Multiplier above average volume that flags a snapshot as wash-trade.
+const WASH_TRADE_VOLUME_MULTIPLIER: f64 = 10.0;
+
+pub struct RewardEngine {
+    repo: Arc<LpPayoutRepository>,
+}
+
+impl RewardEngine {
+    pub fn new(repo: Arc<LpPayoutRepository>) -> Self {
+        Self { repo }
+    }
+
+    // ── Snapshot ─────────────────────────────────────────────────────────────
+
+    /// Record an hourly snapshot for every active LP.
+    /// `pool_data` is a list of `(pool_id, lp_provider_id, lp_balance, total_pool, volume)`.
+    pub async fn record_snapshots(
+        &self,
+        snapshot_at: DateTime<Utc>,
+        pool_data: Vec<(String, Uuid, i64, i64, i64)>,
+    ) -> anyhow::Result<()> {
+        for (pool_id, lp_provider_id, lp_balance, total_pool, volume) in pool_data {
+            if total_pool == 0 {
+                continue;
+            }
+            let pro_rata = BigDecimal::from_str(&lp_balance.to_string())?
+                / BigDecimal::from_str(&total_pool.to_string())?;
+
+            let snap = crate::lp_payout::models::LpPoolSnapshot {
+                id: Uuid::new_v4(),
+                snapshot_at,
+                lp_provider_id,
+                pool_id,
+                lp_balance_stroops: lp_balance,
+                total_pool_stroops: total_pool,
+                pro_rata_share: pro_rata,
+                volume_stroops: volume,
+                created_at: Utc::now(),
+            };
+            self.repo.insert_snapshot(&snap).await?;
+        }
+        Ok(())
+    }
+
+    // ── Reward calculation ────────────────────────────────────────────────────
+
+    /// Calculate and persist accrued rewards for all LPs in an epoch.
+    pub async fn calculate_epoch_rewards(
+        &self,
+        epoch_id: Uuid,
+        epoch_start: DateTime<Utc>,
+        epoch_end: DateTime<Utc>,
+        total_fees_stroops: i64,
+        total_volume_stroops: i64,
+    ) -> anyhow::Result<()> {
+        self.repo
+            .update_epoch_fees(epoch_id, total_fees_stroops, total_volume_stroops)
+            .await?;
+
+        let providers = self.repo.list_active_providers().await?;
+        let compliance_threshold = compliance_threshold_stroops();
+        let mining_rate = default_mining_rate_per_1000();
+
+        for provider in &providers {
+            let snapshots = self
+                .repo
+                .snapshots_for_epoch(provider.id, epoch_start, epoch_end)
+                .await?;
+
+            if snapshots.is_empty() {
+                continue;
+            }
+
+            let avg_volume = snapshots.iter().map(|s| s.volume_stroops).sum::<i64>()
+                / snapshots.len() as i64;
+
+            // ── Fee-based reward ──────────────────────────────────────────────
+            let fee_reward = self.calc_fee_reward(&snapshots, total_fees_stroops, avg_volume);
+
+            // ── Mining reward ─────────────────────────────────────────────────
+            let mining_reward = self.calc_mining_reward(&snapshots, mining_rate, avg_volume);
+
+            for (reward_type, reward_stroops) in
+                [("fee_based", fee_reward), ("liquidity_mining", mining_reward)]
+            {
+                let wash_excluded = reward_stroops == 0
+                    && snapshots
+                        .iter()
+                        .all(|s| is_wash_trade(s, avg_volume));
+
+                let compliance_flagged = reward_stroops > compliance_threshold;
+                let compliance_reason = if compliance_flagged {
+                    Some(format!(
+                        "Reward {} stroops exceeds threshold {}",
+                        reward_stroops, compliance_threshold
+                    ))
+                } else {
+                    None
+                };
+
+                if compliance_flagged {
+                    warn!(
+                        lp = %provider.stellar_address,
+                        reward_type,
+                        reward_stroops,
+                        "LP reward flagged for compliance review"
+                    );
+                }
+
+                self.repo
+                    .upsert_accrued_reward(
+                        epoch_id,
+                        provider.id,
+                        reward_type,
+                        reward_stroops,
+                        wash_excluded,
+                        compliance_flagged,
+                        compliance_reason.as_deref(),
+                    )
+                    .await?;
+            }
+
+            info!(
+                lp = %provider.stellar_address,
+                fee_reward,
+                mining_reward,
+                "Rewards calculated for LP"
+            );
+        }
+
+        Ok(())
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn calc_fee_reward(
+        &self,
+        snapshots: &[LpPoolSnapshot],
+        total_fees_stroops: i64,
+        avg_volume: i64,
+    ) -> i64 {
+        if total_fees_stroops == 0 || snapshots.is_empty() {
+            return 0;
+        }
+        // Average pro-rata share across non-wash-trade snapshots
+        let valid: Vec<&LpPoolSnapshot> = snapshots
+            .iter()
+            .filter(|s| !is_wash_trade(s, avg_volume))
+            .collect();
+
+        if valid.is_empty() {
+            return 0;
+        }
+
+        let avg_share: f64 = valid
+            .iter()
+            .map(|s| {
+                s.pro_rata_share
+                    .to_string()
+                    .parse::<f64>()
+                    .unwrap_or(0.0)
+            })
+            .sum::<f64>()
+            / valid.len() as f64;
+
+        (total_fees_stroops as f64 * avg_share) as i64
+    }
+
+    fn calc_mining_reward(
+        &self,
+        snapshots: &[LpPoolSnapshot],
+        rate_per_1000: f64,
+        avg_volume: i64,
+    ) -> i64 {
+        // Sum: (lp_balance_stroops / 1000) * rate_per_1000 for each valid hourly snapshot
+        snapshots
+            .iter()
+            .filter(|s| !is_wash_trade(s, avg_volume))
+            .map(|s| {
+                let units = s.lp_balance_stroops as f64 / 1_000.0;
+                (units * rate_per_1000) as i64
+            })
+            .sum()
+    }
+}
+
+fn is_wash_trade(snapshot: &LpPoolSnapshot, avg_volume: i64) -> bool {
+    avg_volume > 0
+        && snapshot.volume_stroops as f64 > avg_volume as f64 * WASH_TRADE_VOLUME_MULTIPLIER
+}
+
+// ── Epoch boundary helpers ────────────────────────────────────────────────────
+
+/// Returns the start of the current weekly epoch (Monday 00:00 UTC).
+pub fn current_epoch_start() -> DateTime<Utc> {
+    let now = Utc::now();
+    let days_since_monday = now.weekday().num_days_from_monday() as i64;
+    let date = (now - Duration::days(days_since_monday)).date_naive();
+    date.and_hms_opt(0, 0, 0).unwrap().and_utc()
+}
+
+pub fn epoch_end_from_start(start: DateTime<Utc>) -> DateTime<Utc> {
+    start + Duration::weeks(1)
+}

--- a/src/lp_payout/handlers.rs
+++ b/src/lp_payout/handlers.rs
@@ -1,0 +1,43 @@
+use crate::lp_payout::repository::LpPayoutRepository;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde_json::{json, Value};
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub type LpPayoutState = Arc<LpPayoutRepository>;
+
+/// GET /api/lp/rewards/:lp_provider_id — accrued vs paid summary per epoch
+pub async fn get_accrued_vs_paid(
+    State(repo): State<LpPayoutState>,
+    Path(lp_provider_id): Path<Uuid>,
+) -> Result<Json<Value>, StatusCode> {
+    let summary = repo
+        .accrued_vs_paid(lp_provider_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(json!({ "data": summary })))
+}
+
+/// GET /api/lp/epochs — list all epochs with payout records
+pub async fn list_epochs(
+    State(repo): State<LpPayoutState>,
+) -> Result<Json<Value>, StatusCode> {
+    let epochs = repo
+        .get_unfinalized_epochs()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(json!({ "data": epochs.iter().map(|e| json!({
+        "id": e.id,
+        "epoch_start": e.epoch_start,
+        "epoch_end": e.epoch_end,
+        "total_fees_stroops": e.total_fees_stroops,
+        "total_volume_stroops": e.total_volume_stroops,
+        "is_finalized": e.is_finalized,
+    })).collect::<Vec<_>>() })))
+}

--- a/src/lp_payout/mod.rs
+++ b/src/lp_payout/mod.rs
@@ -1,0 +1,10 @@
+pub mod engine;
+pub mod handlers;
+pub mod models;
+pub mod repository;
+pub mod routes;
+pub mod worker;
+
+pub use repository::LpPayoutRepository;
+pub use routes::lp_payout_routes;
+pub use worker::{LpPayoutWorker, LpPayoutWorkerConfig};

--- a/src/lp_payout/models.rs
+++ b/src/lp_payout/models.rs
@@ -1,0 +1,125 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct LpProvider {
+    pub id: Uuid,
+    pub stellar_address: String,
+    pub display_name: String,
+    pub is_active: bool,
+    pub whitelisted_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct LpPoolSnapshot {
+    pub id: Uuid,
+    pub snapshot_at: DateTime<Utc>,
+    pub lp_provider_id: Uuid,
+    pub pool_id: String,
+    pub lp_balance_stroops: i64,
+    pub total_pool_stroops: i64,
+    pub pro_rata_share: sqlx::types::BigDecimal,
+    pub volume_stroops: i64,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct LpRewardEpoch {
+    pub id: Uuid,
+    pub epoch_start: DateTime<Utc>,
+    pub epoch_end: DateTime<Utc>,
+    pub total_fees_stroops: i64,
+    pub total_volume_stroops: i64,
+    pub mining_rate_per_1000: sqlx::types::BigDecimal,
+    pub is_finalized: bool,
+    pub finalized_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct LpAccruedReward {
+    pub id: Uuid,
+    pub epoch_id: Uuid,
+    pub lp_provider_id: Uuid,
+    pub reward_type: String,
+    pub accrued_stroops: i64,
+    pub paid_stroops: i64,
+    pub is_wash_trade_excluded: bool,
+    pub compliance_flagged: bool,
+    pub compliance_reason: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct LpPayout {
+    pub id: Uuid,
+    pub epoch_id: Uuid,
+    pub lp_provider_id: Uuid,
+    pub stellar_address: String,
+    pub total_stroops: i64,
+    pub status: String,
+    pub stellar_tx_hash: Option<String>,
+    pub compliance_withheld: bool,
+    pub compliance_reason: Option<String>,
+    pub attempted_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// API / service types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccruedVsPaidSummary {
+    pub lp_provider_id: Uuid,
+    pub stellar_address: String,
+    pub epoch_id: Uuid,
+    pub epoch_start: DateTime<Utc>,
+    pub epoch_end: DateTime<Utc>,
+    pub accrued_stroops: i64,
+    pub paid_stroops: i64,
+    pub pending_stroops: i64,
+    pub compliance_flagged: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EpochRewardSummary {
+    pub epoch_id: Uuid,
+    pub epoch_start: DateTime<Utc>,
+    pub epoch_end: DateTime<Utc>,
+    pub total_fees_stroops: i64,
+    pub total_volume_stroops: i64,
+    pub payouts: Vec<PayoutRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PayoutRecord {
+    pub lp_provider_id: Uuid,
+    pub stellar_address: String,
+    pub total_stroops: i64,
+    pub status: String,
+    pub stellar_tx_hash: Option<String>,
+    pub compliance_withheld: bool,
+}
+
+/// Compliance threshold in stroops above which a payout is flagged.
+/// Default: 10,000,000 cNGN (10M stroops = 1 cNGN at 7 decimal places).
+/// Configurable via LP_COMPLIANCE_THRESHOLD_STROOPS env var.
+pub fn compliance_threshold_stroops() -> i64 {
+    std::env::var("LP_COMPLIANCE_THRESHOLD_STROOPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10_000_000_000) // 1,000 cNGN in stroops
+}
+
+/// Mining rate: cNGN stroops earned per 1,000 NGN provided per hour.
+/// Configurable via LP_MINING_RATE_PER_1000 env var.
+pub fn default_mining_rate_per_1000() -> f64 {
+    std::env::var("LP_MINING_RATE_PER_1000")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(100.0) // 100 stroops per 1000 NGN/hr
+}

--- a/src/lp_payout/repository.rs
+++ b/src/lp_payout/repository.rs
@@ -1,0 +1,329 @@
+use crate::lp_payout::models::{
+    AccruedVsPaidSummary, LpAccruedReward, LpPayout, LpPoolSnapshot, LpProvider, LpRewardEpoch,
+};
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub type RepoResult<T> = Result<T, sqlx::Error>;
+
+pub struct LpPayoutRepository {
+    pool: PgPool,
+}
+
+impl LpPayoutRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    // ── Providers ────────────────────────────────────────────────────────────
+
+    pub async fn list_active_providers(&self) -> RepoResult<Vec<LpProvider>> {
+        sqlx::query_as::<_, LpProvider>(
+            "SELECT id, stellar_address, display_name, is_active, whitelisted_at, created_at
+             FROM lp_providers WHERE is_active = TRUE",
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // ── Snapshots ────────────────────────────────────────────────────────────
+
+    pub async fn insert_snapshot(&self, s: &LpPoolSnapshot) -> RepoResult<()> {
+        sqlx::query(
+            "INSERT INTO lp_pool_snapshots
+             (id, snapshot_at, lp_provider_id, pool_id,
+              lp_balance_stroops, total_pool_stroops, pro_rata_share, volume_stroops)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+             ON CONFLICT (snapshot_at, lp_provider_id, pool_id) DO NOTHING",
+        )
+        .bind(s.id)
+        .bind(s.snapshot_at)
+        .bind(s.lp_provider_id)
+        .bind(&s.pool_id)
+        .bind(s.lp_balance_stroops)
+        .bind(s.total_pool_stroops)
+        .bind(&s.pro_rata_share)
+        .bind(s.volume_stroops)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn snapshots_for_epoch(
+        &self,
+        lp_provider_id: Uuid,
+        epoch_start: DateTime<Utc>,
+        epoch_end: DateTime<Utc>,
+    ) -> RepoResult<Vec<LpPoolSnapshot>> {
+        sqlx::query_as::<_, LpPoolSnapshot>(
+            "SELECT id, snapshot_at, lp_provider_id, pool_id,
+                    lp_balance_stroops, total_pool_stroops, pro_rata_share, volume_stroops,
+                    created_at
+             FROM lp_pool_snapshots
+             WHERE lp_provider_id = $1
+               AND snapshot_at >= $2
+               AND snapshot_at < $3
+             ORDER BY snapshot_at ASC",
+        )
+        .bind(lp_provider_id)
+        .bind(epoch_start)
+        .bind(epoch_end)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // ── Epochs ───────────────────────────────────────────────────────────────
+
+    pub async fn get_or_create_current_epoch(
+        &self,
+        epoch_start: DateTime<Utc>,
+        epoch_end: DateTime<Utc>,
+        mining_rate: sqlx::types::BigDecimal,
+    ) -> RepoResult<LpRewardEpoch> {
+        if let Some(epoch) = sqlx::query_as::<_, LpRewardEpoch>(
+            "SELECT id, epoch_start, epoch_end, total_fees_stroops, total_volume_stroops,
+                    mining_rate_per_1000, is_finalized, finalized_at, created_at
+             FROM lp_reward_epochs
+             WHERE epoch_start = $1 AND epoch_end = $2",
+        )
+        .bind(epoch_start)
+        .bind(epoch_end)
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            return Ok(epoch);
+        }
+
+        sqlx::query_as::<_, LpRewardEpoch>(
+            "INSERT INTO lp_reward_epochs (epoch_start, epoch_end, mining_rate_per_1000)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (epoch_start, epoch_end) DO UPDATE
+               SET mining_rate_per_1000 = EXCLUDED.mining_rate_per_1000
+             RETURNING id, epoch_start, epoch_end, total_fees_stroops, total_volume_stroops,
+                       mining_rate_per_1000, is_finalized, finalized_at, created_at",
+        )
+        .bind(epoch_start)
+        .bind(epoch_end)
+        .bind(mining_rate)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn update_epoch_fees(
+        &self,
+        epoch_id: Uuid,
+        total_fees_stroops: i64,
+        total_volume_stroops: i64,
+    ) -> RepoResult<()> {
+        sqlx::query(
+            "UPDATE lp_reward_epochs
+             SET total_fees_stroops = $2, total_volume_stroops = $3
+             WHERE id = $1",
+        )
+        .bind(epoch_id)
+        .bind(total_fees_stroops)
+        .bind(total_volume_stroops)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn finalize_epoch(&self, epoch_id: Uuid) -> RepoResult<()> {
+        sqlx::query(
+            "UPDATE lp_reward_epochs
+             SET is_finalized = TRUE, finalized_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(epoch_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_unfinalized_epochs(&self) -> RepoResult<Vec<LpRewardEpoch>> {
+        sqlx::query_as::<_, LpRewardEpoch>(
+            "SELECT id, epoch_start, epoch_end, total_fees_stroops, total_volume_stroops,
+                    mining_rate_per_1000, is_finalized, finalized_at, created_at
+             FROM lp_reward_epochs
+             WHERE is_finalized = FALSE AND epoch_end <= NOW()
+             ORDER BY epoch_end ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // ── Accrued rewards ──────────────────────────────────────────────────────
+
+    pub async fn upsert_accrued_reward(
+        &self,
+        epoch_id: Uuid,
+        lp_provider_id: Uuid,
+        reward_type: &str,
+        accrued_stroops: i64,
+        is_wash_trade_excluded: bool,
+        compliance_flagged: bool,
+        compliance_reason: Option<&str>,
+    ) -> RepoResult<()> {
+        sqlx::query(
+            "INSERT INTO lp_accrued_rewards
+             (epoch_id, lp_provider_id, reward_type, accrued_stroops,
+              is_wash_trade_excluded, compliance_flagged, compliance_reason, updated_at)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,NOW())
+             ON CONFLICT (epoch_id, lp_provider_id, reward_type) DO UPDATE
+               SET accrued_stroops = EXCLUDED.accrued_stroops,
+                   is_wash_trade_excluded = EXCLUDED.is_wash_trade_excluded,
+                   compliance_flagged = EXCLUDED.compliance_flagged,
+                   compliance_reason = EXCLUDED.compliance_reason,
+                   updated_at = NOW()",
+        )
+        .bind(epoch_id)
+        .bind(lp_provider_id)
+        .bind(reward_type)
+        .bind(accrued_stroops)
+        .bind(is_wash_trade_excluded)
+        .bind(compliance_flagged)
+        .bind(compliance_reason)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn accrued_rewards_for_epoch(
+        &self,
+        epoch_id: Uuid,
+    ) -> RepoResult<Vec<LpAccruedReward>> {
+        sqlx::query_as::<_, LpAccruedReward>(
+            "SELECT id, epoch_id, lp_provider_id, reward_type,
+                    accrued_stroops, paid_stroops,
+                    is_wash_trade_excluded, compliance_flagged, compliance_reason,
+                    updated_at
+             FROM lp_accrued_rewards
+             WHERE epoch_id = $1",
+        )
+        .bind(epoch_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // ── Payouts ──────────────────────────────────────────────────────────────
+
+    pub async fn create_payout(&self, payout: &LpPayout) -> RepoResult<()> {
+        sqlx::query(
+            "INSERT INTO lp_payouts
+             (id, epoch_id, lp_provider_id, stellar_address, total_stroops,
+              status, compliance_withheld, compliance_reason)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+             ON CONFLICT (epoch_id, lp_provider_id) DO NOTHING",
+        )
+        .bind(payout.id)
+        .bind(payout.epoch_id)
+        .bind(payout.lp_provider_id)
+        .bind(&payout.stellar_address)
+        .bind(payout.total_stroops)
+        .bind(&payout.status)
+        .bind(payout.compliance_withheld)
+        .bind(&payout.compliance_reason)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_payout_completed(
+        &self,
+        payout_id: Uuid,
+        stellar_tx_hash: &str,
+    ) -> RepoResult<()> {
+        sqlx::query(
+            "UPDATE lp_payouts
+             SET status = 'completed', stellar_tx_hash = $2, completed_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(payout_id)
+        .bind(stellar_tx_hash)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_payout_failed(&self, payout_id: Uuid) -> RepoResult<()> {
+        sqlx::query("UPDATE lp_payouts SET status = 'failed' WHERE id = $1")
+            .bind(payout_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn pending_payouts(&self) -> RepoResult<Vec<LpPayout>> {
+        sqlx::query_as::<_, LpPayout>(
+            "SELECT id, epoch_id, lp_provider_id, stellar_address, total_stroops,
+                    status, stellar_tx_hash, compliance_withheld, compliance_reason,
+                    attempted_at, completed_at, created_at
+             FROM lp_payouts
+             WHERE status = 'pending'
+             ORDER BY created_at ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // ── Analytics: accrued vs paid ────────────────────────────────────────────
+
+    pub async fn accrued_vs_paid(
+        &self,
+        lp_provider_id: Uuid,
+    ) -> RepoResult<Vec<AccruedVsPaidSummary>> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            lp_provider_id: Uuid,
+            stellar_address: String,
+            epoch_id: Uuid,
+            epoch_start: DateTime<Utc>,
+            epoch_end: DateTime<Utc>,
+            accrued_stroops: Option<i64>,
+            paid_stroops: Option<i64>,
+            compliance_flagged: Option<bool>,
+        }
+
+        let rows = sqlx::query_as::<_, Row>(
+            "SELECT
+               ar.lp_provider_id,
+               p.stellar_address,
+               ar.epoch_id,
+               e.epoch_start,
+               e.epoch_end,
+               SUM(ar.accrued_stroops)::BIGINT AS accrued_stroops,
+               SUM(ar.paid_stroops)::BIGINT    AS paid_stroops,
+               BOOL_OR(ar.compliance_flagged)  AS compliance_flagged
+             FROM lp_accrued_rewards ar
+             JOIN lp_reward_epochs e ON e.id = ar.epoch_id
+             JOIN lp_providers p ON p.id = ar.lp_provider_id
+             WHERE ar.lp_provider_id = $1
+             GROUP BY ar.lp_provider_id, p.stellar_address, ar.epoch_id,
+                      e.epoch_start, e.epoch_end
+             ORDER BY e.epoch_start DESC",
+        )
+        .bind(lp_provider_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                let accrued = r.accrued_stroops.unwrap_or(0);
+                let paid = r.paid_stroops.unwrap_or(0);
+                AccruedVsPaidSummary {
+                    lp_provider_id: r.lp_provider_id,
+                    stellar_address: r.stellar_address,
+                    epoch_id: r.epoch_id,
+                    epoch_start: r.epoch_start,
+                    epoch_end: r.epoch_end,
+                    accrued_stroops: accrued,
+                    paid_stroops: paid,
+                    pending_stroops: accrued - paid,
+                    compliance_flagged: r.compliance_flagged.unwrap_or(false),
+                }
+            })
+            .collect())
+    }
+}

--- a/src/lp_payout/routes.rs
+++ b/src/lp_payout/routes.rs
@@ -1,0 +1,9 @@
+use crate::lp_payout::handlers::{get_accrued_vs_paid, list_epochs, LpPayoutState};
+use axum::{routing::get, Router};
+
+pub fn lp_payout_routes(state: LpPayoutState) -> Router {
+    Router::new()
+        .route("/api/lp/rewards/{lp_provider_id}", get(get_accrued_vs_paid))
+        .route("/api/lp/epochs", get(list_epochs))
+        .with_state(state)
+}

--- a/src/lp_payout/worker.rs
+++ b/src/lp_payout/worker.rs
@@ -1,0 +1,348 @@
+//! LP Payout Worker
+//!
+//! Two loops:
+//!   1. Hourly snapshot loop  — polls Stellar Horizon for pool balances.
+//!   2. Epoch disbursement loop — fires at epoch end, calculates rewards,
+//!      builds & submits cNGN payment transactions for each LP.
+
+use crate::chains::stellar::client::StellarClient;
+use crate::lp_payout::{
+    engine::RewardEngine,
+    models::LpPayout,
+    repository::LpPayoutRepository,
+};
+use crate::services::cngn_payment_builder::{CngnPaymentBuilder, PaymentMemo, PaymentOperation};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+pub struct LpPayoutWorkerConfig {
+    pub snapshot_interval: Duration,
+    pub disbursement_check_interval: Duration,
+    pub pool_id: String,
+    pub cngn_issuer: String,
+    pub system_wallet_secret: String,
+    pub system_wallet_address: String,
+}
+
+impl LpPayoutWorkerConfig {
+    pub fn from_env() -> Self {
+        Self {
+            snapshot_interval: Duration::from_secs(
+                std::env::var("LP_SNAPSHOT_INTERVAL_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(3600),
+            ),
+            disbursement_check_interval: Duration::from_secs(
+                std::env::var("LP_DISBURSEMENT_CHECK_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(300),
+            ),
+            pool_id: std::env::var("LP_STELLAR_POOL_ID").unwrap_or_default(),
+            cngn_issuer: std::env::var("CNGN_ISSUER_ADDRESS")
+                .or_else(|_| std::env::var("CNGN_ISSUER_MAINNET"))
+                .unwrap_or_default(),
+            system_wallet_secret: std::env::var("SYSTEM_WALLET_SECRET").unwrap_or_default(),
+            system_wallet_address: std::env::var("SYSTEM_WALLET_ADDRESS").unwrap_or_default(),
+        }
+    }
+}
+
+pub struct LpPayoutWorker {
+    repo: Arc<LpPayoutRepository>,
+    engine: Arc<RewardEngine>,
+    stellar_client: StellarClient,
+    config: LpPayoutWorkerConfig,
+}
+
+impl LpPayoutWorker {
+    pub fn new(
+        repo: Arc<LpPayoutRepository>,
+        stellar_client: StellarClient,
+        config: LpPayoutWorkerConfig,
+    ) -> Self {
+        let engine = Arc::new(RewardEngine::new(repo.clone()));
+        Self {
+            repo,
+            engine,
+            stellar_client,
+            config,
+        }
+    }
+
+    pub async fn run(self, mut shutdown_rx: watch::Receiver<bool>) {
+        info!("LP Payout worker started");
+
+        let mut snapshot_ticker = tokio::time::interval(self.config.snapshot_interval);
+        let mut disburse_ticker =
+            tokio::time::interval(self.config.disbursement_check_interval);
+
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        info!("LP Payout worker stopping");
+                        break;
+                    }
+                }
+                _ = snapshot_ticker.tick() => {
+                    if let Err(e) = self.run_snapshot_cycle().await {
+                        error!(error = %e, "LP snapshot cycle failed");
+                    }
+                }
+                _ = disburse_ticker.tick() => {
+                    if let Err(e) = self.run_disbursement_cycle().await {
+                        error!(error = %e, "LP disbursement cycle failed");
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Snapshot cycle ────────────────────────────────────────────────────────
+
+    async fn run_snapshot_cycle(&self) -> anyhow::Result<()> {
+        if self.config.pool_id.is_empty() {
+            warn!("LP_STELLAR_POOL_ID not set — skipping snapshot");
+            return Ok(());
+        }
+
+        let providers = self.repo.list_active_providers().await?;
+        if providers.is_empty() {
+            return Ok(());
+        }
+
+        let now = chrono::Utc::now();
+        let total_pool = self.fetch_pool_total_stroops().await.unwrap_or(0);
+        let volume = self.fetch_pool_volume_stroops().await.unwrap_or(0);
+
+        let mut pool_data = Vec::new();
+
+        for provider in &providers {
+            // Fetch raw Horizon account to get liquidity_pool_shares balance
+            let lp_balance = self
+                .fetch_lp_balance_stroops(&provider.stellar_address)
+                .await
+                .unwrap_or(0);
+
+            pool_data.push((
+                self.config.pool_id.clone(),
+                provider.id,
+                lp_balance,
+                total_pool,
+                volume,
+            ));
+        }
+
+        self.engine.record_snapshots(now, pool_data).await?;
+        info!(snapshot_at = %now, providers = providers.len(), "LP pool snapshots recorded");
+        Ok(())
+    }
+
+    // ── Disbursement cycle ────────────────────────────────────────────────────
+
+    async fn run_disbursement_cycle(&self) -> anyhow::Result<()> {
+        let epochs = self.repo.get_unfinalized_epochs().await?;
+
+        for epoch in epochs {
+            info!(epoch_id = %epoch.id, "Processing LP epoch disbursement");
+
+            self.engine
+                .calculate_epoch_rewards(
+                    epoch.id,
+                    epoch.epoch_start,
+                    epoch.epoch_end,
+                    epoch.total_fees_stroops,
+                    epoch.total_volume_stroops,
+                )
+                .await?;
+
+            // Aggregate per-LP totals and create payout records
+            let accrued = self.repo.accrued_rewards_for_epoch(epoch.id).await?;
+            let providers = self.repo.list_active_providers().await?;
+            let provider_map: std::collections::HashMap<Uuid, String> = providers
+                .into_iter()
+                .map(|p| (p.id, p.stellar_address))
+                .collect();
+
+            // Group by provider: (total_stroops, compliance_withheld, reason)
+            let mut by_provider: std::collections::HashMap<Uuid, (i64, bool, Option<String>)> =
+                std::collections::HashMap::new();
+            for reward in &accrued {
+                let entry = by_provider
+                    .entry(reward.lp_provider_id)
+                    .or_insert((0, false, None));
+                entry.0 += reward.accrued_stroops;
+                if reward.compliance_flagged {
+                    entry.1 = true;
+                    entry.2 = reward.compliance_reason.clone();
+                }
+            }
+
+            for (lp_id, (total_stroops, compliance_withheld, compliance_reason)) in &by_provider {
+                if *total_stroops == 0 {
+                    continue;
+                }
+                let stellar_address = match provider_map.get(lp_id) {
+                    Some(a) => a.clone(),
+                    None => continue,
+                };
+
+                let payout = LpPayout {
+                    id: Uuid::new_v4(),
+                    epoch_id: epoch.id,
+                    lp_provider_id: *lp_id,
+                    stellar_address,
+                    total_stroops: *total_stroops,
+                    status: if *compliance_withheld {
+                        "flagged".to_string()
+                    } else {
+                        "pending".to_string()
+                    },
+                    stellar_tx_hash: None,
+                    compliance_withheld: *compliance_withheld,
+                    compliance_reason: compliance_reason.clone(),
+                    attempted_at: None,
+                    completed_at: None,
+                    created_at: chrono::Utc::now(),
+                };
+                self.repo.create_payout(&payout).await?;
+            }
+
+            self.dispatch_pending_payouts().await?;
+            self.repo.finalize_epoch(epoch.id).await?;
+            info!(epoch_id = %epoch.id, "Epoch finalized and payouts dispatched");
+        }
+
+        Ok(())
+    }
+
+    async fn dispatch_pending_payouts(&self) -> anyhow::Result<()> {
+        if self.config.system_wallet_secret.is_empty() || self.config.cngn_issuer.is_empty() {
+            warn!("SYSTEM_WALLET_SECRET or CNGN_ISSUER_ADDRESS not set — skipping payout dispatch");
+            return Ok(());
+        }
+
+        let pending = self.repo.pending_payouts().await?;
+        let builder = CngnPaymentBuilder::new(self.stellar_client.clone());
+
+        for payout in pending {
+            // Stellar amounts use 7 decimal places
+            let amount_cngn = format!("{:.7}", payout.total_stroops as f64 / 1e7);
+
+            let op = PaymentOperation {
+                source: self.config.system_wallet_address.clone(),
+                destination: payout.stellar_address.clone(),
+                amount: amount_cngn,
+                asset_code: "cNGN".to_string(),
+                asset_issuer: self.config.cngn_issuer.clone(),
+            };
+            let memo = PaymentMemo::Text(format!("LP reward {}", payout.epoch_id));
+
+            let draft = match builder.build_payment(op, memo, None).await {
+                Ok(d) => d,
+                Err(e) => {
+                    error!(lp = %payout.stellar_address, error = %e, "Failed to build payout tx");
+                    self.repo.mark_payout_failed(payout.id).await?;
+                    continue;
+                }
+            };
+
+            let signed = match builder.sign_transaction(draft, &self.config.system_wallet_secret) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(lp = %payout.stellar_address, error = %e, "Failed to sign payout tx");
+                    self.repo.mark_payout_failed(payout.id).await?;
+                    continue;
+                }
+            };
+
+            match self
+                .stellar_client
+                .submit_transaction_xdr(&signed.envelope_xdr)
+                .await
+            {
+                Ok(resp) => {
+                    let tx_hash = resp["hash"]
+                        .as_str()
+                        .unwrap_or(&signed.hash)
+                        .to_string();
+                    self.repo.mark_payout_completed(payout.id, &tx_hash).await?;
+                    info!(
+                        lp = %payout.stellar_address,
+                        stroops = payout.total_stroops,
+                        tx_hash = %tx_hash,
+                        "LP payout completed"
+                    );
+                }
+                Err(e) => {
+                    error!(lp = %payout.stellar_address, error = %e, "Stellar submission failed");
+                    self.repo.mark_payout_failed(payout.id).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // ── Stellar helpers ───────────────────────────────────────────────────────
+
+    /// Fetch LP's share of the pool via raw Horizon account endpoint.
+    async fn fetch_lp_balance_stroops(&self, address: &str) -> anyhow::Result<i64> {
+        let url = format!(
+            "{}/accounts/{}",
+            self.stellar_client.config().horizon_url(),
+            address
+        );
+        let resp: serde_json::Value = reqwest::get(&url).await?.json().await?;
+        let balance = resp["balances"]
+            .as_array()
+            .and_then(|balances| {
+                balances.iter().find(|b| {
+                    b["asset_type"].as_str() == Some("liquidity_pool_shares")
+                        && b["liquidity_pool_id"].as_str() == Some(&self.config.pool_id)
+                })
+            })
+            .and_then(|b| b["balance"].as_str())
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+        Ok((balance * 1e7) as i64)
+    }
+
+    async fn fetch_pool_total_stroops(&self) -> anyhow::Result<i64> {
+        let url = format!(
+            "{}/liquidity_pools/{}",
+            self.stellar_client.config().horizon_url(),
+            self.config.pool_id
+        );
+        let resp: serde_json::Value = reqwest::get(&url).await?.json().await?;
+        let total = resp["total_shares"]
+            .as_str()
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+        Ok((total * 1e7) as i64)
+    }
+
+    async fn fetch_pool_volume_stroops(&self) -> anyhow::Result<i64> {
+        let url = format!(
+            "{}/liquidity_pools/{}/trades?limit=200&order=desc",
+            self.stellar_client.config().horizon_url(),
+            self.config.pool_id
+        );
+        let resp: serde_json::Value = reqwest::get(&url).await?.json().await?;
+        let volume: f64 = resp["_embedded"]["records"]
+            .as_array()
+            .map(|records| {
+                records
+                    .iter()
+                    .filter_map(|r| r["base_amount"].as_str()?.parse::<f64>().ok())
+                    .sum()
+            })
+            .unwrap_or(0.0);
+        Ok((volume * 1e7) as i64)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod developer_portal;
 mod error;
 mod health;
 mod logging;
+mod lp_payout;
 mod metrics;
 mod middleware;
 mod mtls;
@@ -813,6 +814,35 @@ async fn main() -> anyhow::Result<()> {
 
     // Create the application router with logging middleware
     info!("🛣️  Setting up application routes...");
+
+    // ── LP Payout Engine (Liquidity Provider rewards) ─────────────────────────
+    let lp_payout_routes = if let (Some(pool), Some(client)) =
+        (db_pool.clone(), stellar_client.clone())
+    {
+        let lp_repo = std::sync::Arc::new(lp_payout::LpPayoutRepository::new(pool.clone()));
+        let lp_config = lp_payout::LpPayoutWorkerConfig::from_env();
+
+        let lp_worker_enabled = std::env::var("LP_PAYOUT_WORKER_ENABLED")
+            .unwrap_or_else(|_| "true".to_string())
+            .to_lowercase()
+            != "false";
+
+        if lp_worker_enabled {
+            if lp_config.pool_id.is_empty() {
+                warn!("LP_STELLAR_POOL_ID not set — LP payout worker will skip snapshots");
+            }
+            let worker = lp_payout::LpPayoutWorker::new(lp_repo.clone(), client, lp_config);
+            tokio::spawn(worker.run(worker_shutdown_rx.clone()));
+            info!("✅ LP Payout worker started");
+        } else {
+            info!("LP Payout worker disabled (LP_PAYOUT_WORKER_ENABLED=false)");
+        }
+
+        lp_payout::lp_payout_routes(lp_repo)
+    } else {
+        info!("⏭️  Skipping LP payout routes (missing database or stellar client)");
+        Router::new()
+    };
 
     // Setup onramp routes (quote service)
     let onramp_routes = if let (Some(pool), Some(cache), Some(client)) =
@@ -1826,6 +1856,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(Router::new().nest("/api/admin/security", mtls_admin_routes))
         .merge(transparency_routes)
         .merge(security_compliance_routes)
+        .merge(lp_payout_routes)
         .with_state(AppState {
             db_pool,
             redis_cache,


### PR DESCRIPTION
- Add migration: lp_providers, lp_pool_snapshots, lp_reward_epochs, lp_accrued_rewards, lp_payouts tables with stroop precision
- Add src/lp_payout/ module:
  - models.rs: DB row types + API response types + env-configurable constants
  - repository.rs: data access layer (query_as pattern, idempotent upserts)
  - engine.rs: fee-based + liquidity-mining reward calculation, wash-trade exclusion (10x avg volume), compliance flagging
  - worker.rs: hourly snapshot loop + epoch disbursement loop, integrates CngnPaymentBuilder + Stellar submission
  - handlers.rs + routes.rs: GET /api/lp/rewards/{id}, GET /api/lp/epochs
- Register module in lib.rs and main.rs (worker + routes)

Closes #LP-PAYOUT

closes #280 