### PR TITLE
feat(transparency): implement Stablecoin Reserve Management & Proof-o…

### DIFF
--- a/migrations/20260423000000_proof_of_reserves_por.sql
+++ b/migrations/20260423000000_proof_of_reserves_por.sql
@@ -1,0 +1,81 @@
+-- Migration: Stablecoin Reserve Management & Proof-of-Reserves (PoR) — Issue #297
+--
+-- Creates the tables that back the automated PoR service:
+--   * por_snapshots          — hourly PoR snapshots (supply + bank reserves + ratio)
+--   * por_bank_balances      — per-bank settled balances for each snapshot
+--   * por_discrepancy_alerts — investigation alerts when ratio deviates > 0.05%
+
+-- ── PoR Snapshots ─────────────────────────────────────────────────────────────
+-- Populated by the PoR worker every 60 minutes.
+-- The public /v1/transparency/por endpoint always reads the most-recent row.
+CREATE TABLE IF NOT EXISTS por_snapshots (
+    id                      UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- On-chain cNGN circulating supply (Total Minted − Total Burned)
+    total_on_chain_supply   NUMERIC(36, 8) NOT NULL CHECK (total_on_chain_supply >= 0),
+    -- Sum of all custodian bank settled balances in NGN
+    total_bank_assets       NUMERIC(36, 8) NOT NULL CHECK (total_bank_assets >= 0),
+    -- (total_bank_assets / total_on_chain_supply) * 100
+    collateralization_ratio NUMERIC(12, 6) NOT NULL CHECK (collateralization_ratio >= 0),
+    -- true when ratio >= 100.01 (fully collateralised)
+    is_fully_collateralized BOOLEAN        NOT NULL DEFAULT false,
+    -- ISO-8601 timestamp provided by the custodian bank (Proof of Solvency)
+    custodian_solvency_ts   TIMESTAMPTZ    NOT NULL,
+    -- Ed25519 signature over the canonical payload
+    signature               TEXT           NOT NULL,
+    -- Hex-encoded Ed25519 public key
+    signing_key             TEXT           NOT NULL,
+    recorded_at             TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    created_at              TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE por_snapshots IS
+    'Hourly Proof-of-Reserves snapshots linking cNGN on-chain supply to NGN custodian bank balances.';
+COMMENT ON COLUMN por_snapshots.collateralization_ratio IS
+    'Ratio expressed as a percentage: 100.00 = fully backed 1:1.';
+COMMENT ON COLUMN por_snapshots.custodian_solvency_ts IS
+    'Timestamp from the custodian bank confirming the settled balance (Proof of Solvency).';
+
+CREATE INDEX IF NOT EXISTS idx_por_snapshots_recorded_at
+    ON por_snapshots (recorded_at DESC);
+
+-- ── Per-bank Balances ─────────────────────────────────────────────────────────
+-- Anonymised per-bank settled balances attached to each snapshot.
+CREATE TABLE IF NOT EXISTS por_bank_balances (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    snapshot_id     UUID        NOT NULL REFERENCES por_snapshots(id) ON DELETE CASCADE,
+    -- Anonymised label, e.g. "Reserve Vault A"
+    bank_label      TEXT        NOT NULL,
+    -- Settled balance in NGN (read-only credential, cannot move funds)
+    settled_balance NUMERIC(36, 8) NOT NULL CHECK (settled_balance >= 0),
+    currency        TEXT        NOT NULL DEFAULT 'NGN',
+    -- ISO-8601 timestamp from the bank API confirming the balance
+    balance_as_of   TIMESTAMPTZ NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_por_bank_balances_snapshot
+    ON por_bank_balances (snapshot_id);
+
+-- ── Discrepancy Alerts ────────────────────────────────────────────────────────
+-- Investigation alerts raised when the collateralization ratio deviates > 0.05%
+-- from 100.00% (i.e. ratio < 99.95% or ratio < 100.01% per issue spec).
+CREATE TABLE IF NOT EXISTS por_discrepancy_alerts (
+    id                      UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    snapshot_id             UUID        NOT NULL REFERENCES por_snapshots(id) ON DELETE CASCADE,
+    collateralization_ratio NUMERIC(12, 6) NOT NULL,
+    total_on_chain_supply   NUMERIC(36, 8) NOT NULL,
+    total_bank_assets       NUMERIC(36, 8) NOT NULL,
+    -- Absolute shortfall (supply − bank_assets), positive means under-collateralised
+    shortfall               NUMERIC(36, 8) NOT NULL,
+    -- Deviation percentage from 100.00
+    deviation_pct           NUMERIC(10, 6) NOT NULL,
+    alert_level             TEXT        NOT NULL DEFAULT 'INVESTIGATION', -- INVESTIGATION | CRITICAL
+    resolved                BOOLEAN     NOT NULL DEFAULT false,
+    resolved_at             TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_por_discrepancy_alerts_created
+    ON por_discrepancy_alerts (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_por_discrepancy_alerts_unresolved
+    ON por_discrepancy_alerts (resolved) WHERE resolved = false;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,6 +15,7 @@ pub mod batch;
 pub mod key_rotation;
 pub mod developer;
 pub mod transparency;
+pub mod por;
 pub mod service_admin;
 pub mod mint;
 

--- a/src/api/por.rs
+++ b/src/api/por.rs
@@ -1,0 +1,238 @@
+//! Proof-of-Reserves (PoR) public API — Issue #297
+//!
+//! Provides the unauthenticated public endpoint:
+//!   GET /v1/transparency/por
+//!
+//! Returns a signed JSON object containing:
+//!   * Current cNGN circulating supply
+//!   * Total NGN custodian bank assets
+//!   * Collateralization ratio
+//!   * Proof-of-Solvency timestamp from the custodian bank
+//!   * Ed25519 signature for offline verification
+//!
+//! The response is cached for 60 seconds (CDN-friendly).
+
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::sync::Arc;
+use tracing::info;
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct PorState {
+    pub db: PgPool,
+}
+
+// ── DB row ────────────────────────────────────────────────────────────────────
+
+#[derive(sqlx::FromRow)]
+struct PorSnapshotRow {
+    total_on_chain_supply: sqlx::types::BigDecimal,
+    total_bank_assets: sqlx::types::BigDecimal,
+    collateralization_ratio: sqlx::types::BigDecimal,
+    is_fully_collateralized: bool,
+    custodian_solvency_ts: DateTime<Utc>,
+    signature: String,
+    signing_key: String,
+    recorded_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow)]
+struct PorBankRow {
+    bank_label: String,
+    settled_balance: sqlx::types::BigDecimal,
+    currency: String,
+    balance_as_of: DateTime<Utc>,
+}
+
+// ── Response types ────────────────────────────────────────────────────────────
+
+/// Per-bank balance entry in the PoR response.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PorBankBalance {
+    /// Anonymised label, e.g. "Reserve Vault A".
+    pub label: String,
+    /// Settled NGN balance (string to preserve precision).
+    pub settled_balance: String,
+    pub currency: String,
+    /// Timestamp from the bank API confirming this balance.
+    pub balance_as_of: DateTime<Utc>,
+}
+
+/// The canonical Proof-of-Reserves payload.
+///
+/// This is the object that is signed with the platform's Ed25519 key.
+/// Consumers can verify the signature offline using `signing_key`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProofOfReservesResponse {
+    /// Total cNGN in circulation on the Stellar network.
+    pub total_on_chain_supply: String,
+    /// Total NGN held in regulated custodian bank Reserve Vault Accounts.
+    pub total_bank_assets: String,
+    /// `(total_bank_assets / total_on_chain_supply) × 100`.
+    /// 100.00 = exactly 1:1 backed.
+    pub collateralization_ratio: String,
+    /// `true` when `collateralization_ratio >= 100.01`.
+    pub is_fully_collateralized: bool,
+    /// ISO-8601 timestamp from the custodian bank confirming the settled balance
+    /// (Proof of Solvency).
+    pub custodian_solvency_timestamp: DateTime<Utc>,
+    /// ISO-8601 timestamp of this PoR snapshot.
+    pub recorded_at: DateTime<Utc>,
+    /// Per-bank breakdown of settled balances.
+    pub bank_balances: Vec<PorBankBalance>,
+    /// Ed25519 signature over the canonical payload bytes.
+    pub signature: String,
+    /// Hex-encoded Ed25519 public key used to produce `signature`.
+    pub signing_key: String,
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+/// GET /v1/transparency/por
+///
+/// Public, unauthenticated endpoint.  Returns the most recent signed
+/// Proof-of-Reserves snapshot.
+pub async fn get_por(State(state): State<Arc<PorState>>) -> Response {
+    info!("📊 GET /v1/transparency/por accessed");
+
+    let snap: Option<PorSnapshotRow> = sqlx::query_as(
+        r#"
+        SELECT total_on_chain_supply, total_bank_assets, collateralization_ratio,
+               is_fully_collateralized, custodian_solvency_ts, signature, signing_key,
+               recorded_at
+        FROM por_snapshots
+        ORDER BY recorded_at DESC
+        LIMIT 1
+        "#,
+    )
+    .fetch_optional(&state.db)
+    .await
+    .unwrap_or(None);
+
+    let snap = match snap {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "No Proof-of-Reserves snapshot available yet. \
+                              The PoR worker runs every 60 minutes."
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // Fetch per-bank balances for this snapshot
+    let banks: Vec<PorBankRow> = sqlx::query_as(
+        r#"
+        SELECT bank_label, settled_balance, currency, balance_as_of
+        FROM por_bank_balances
+        WHERE snapshot_id = (
+            SELECT id FROM por_snapshots ORDER BY recorded_at DESC LIMIT 1
+        )
+        ORDER BY bank_label
+        "#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let payload = ProofOfReservesResponse {
+        total_on_chain_supply: snap.total_on_chain_supply.to_string(),
+        total_bank_assets: snap.total_bank_assets.to_string(),
+        collateralization_ratio: snap.collateralization_ratio.to_string(),
+        is_fully_collateralized: snap.is_fully_collateralized,
+        custodian_solvency_timestamp: snap.custodian_solvency_ts,
+        recorded_at: snap.recorded_at,
+        bank_balances: banks
+            .into_iter()
+            .map(|b| PorBankBalance {
+                label: b.bank_label,
+                settled_balance: b.settled_balance.to_string(),
+                currency: b.currency,
+                balance_as_of: b.balance_as_of,
+            })
+            .collect(),
+        signature: snap.signature,
+        signing_key: snap.signing_key,
+    };
+
+    (
+        StatusCode::OK,
+        [
+            (
+                header::CACHE_CONTROL,
+                "public, max-age=60, stale-while-revalidate=30",
+            ),
+            (header::CONTENT_TYPE, "application/json"),
+        ],
+        Json(payload),
+    )
+        .into_response()
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+pub fn por_routes(state: Arc<PorState>) -> Router {
+    Router::new()
+        .route("/v1/transparency/por", get(get_por))
+        .with_state(state)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn por_response_serializes_correctly() {
+        let resp = ProofOfReservesResponse {
+            total_on_chain_supply: "1000000.000000".to_string(),
+            total_bank_assets: "1001000.000000".to_string(),
+            collateralization_ratio: "100.100000".to_string(),
+            is_fully_collateralized: true,
+            custodian_solvency_timestamp: Utc::now(),
+            recorded_at: Utc::now(),
+            bank_balances: vec![PorBankBalance {
+                label: "Reserve Vault A".to_string(),
+                settled_balance: "1001000.000000".to_string(),
+                currency: "NGN".to_string(),
+                balance_as_of: Utc::now(),
+            }],
+            signature: "aabbcc".to_string(),
+            signing_key: "ddeeff".to_string(),
+        };
+
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("total_on_chain_supply"));
+        assert!(json.contains("collateralization_ratio"));
+        assert!(json.contains("custodian_solvency_timestamp"));
+        assert!(json.contains("is_fully_collateralized"));
+        assert!(json.contains("Reserve Vault A"));
+    }
+
+    #[test]
+    fn por_bank_balance_serializes_correctly() {
+        let b = PorBankBalance {
+            label: "Reserve Vault B".to_string(),
+            settled_balance: "500000.00".to_string(),
+            currency: "NGN".to_string(),
+            balance_as_of: Utc::now(),
+        };
+        let json = serde_json::to_string(&b).unwrap();
+        assert!(json.contains("Reserve Vault B"));
+        assert!(json.contains("500000.00"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -780,6 +780,38 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    // Start Proof-of-Reserves (PoR) Worker — Issue #297
+    let por_enabled = std::env::var("POR_WORKER_ENABLED")
+        .unwrap_or_else(|_| "true".to_string())
+        .to_lowercase()
+        != "false";
+    if por_enabled {
+        if let (Some(pool), Some(client)) = (db_pool.clone(), stellar_client.clone()) {
+            let asset_issuer = std::env::var("CNGN_ISSUER_ADDRESS")
+                .or_else(|_| std::env::var("CNGN_ISSUER_MAINNET"))
+                .unwrap_or_default();
+
+            if asset_issuer.is_empty() {
+                warn!("CNGN_ISSUER_ADDRESS not set — skipping PoR worker");
+            } else {
+                let por_signing_key = api::transparency::load_signing_key();
+                let por_worker = workers::por_worker::ProofOfReservesWorker::new(
+                    pool,
+                    client,
+                    por_signing_key,
+                    audit_writer.clone(),
+                    asset_issuer,
+                );
+                tokio::spawn(por_worker.run(worker_shutdown_rx.clone()));
+                info!("✅ Proof-of-Reserves (PoR) worker started (60-min interval)");
+            }
+        } else {
+            info!("⏭️  Skipping PoR worker (no database or Stellar client)");
+        }
+    } else {
+        info!("PoR worker disabled (POR_WORKER_ENABLED=false)");
+    }
+
     // Initialize webhook processor and retry worker
     let webhook_routes = if let Some(pool) = db_pool.clone() {
         let webhook_repo = std::sync::Arc::new(
@@ -1956,6 +1988,16 @@ async fn main() -> anyhow::Result<()> {
         Router::new()
     };
 
+    // ── Proof-of-Reserves public endpoint (Issue #297) ───────────────────────
+    let por_routes = if let Some(pool) = db_pool.clone() {
+        let state = std::sync::Arc::new(api::por::PorState { db: pool });
+        info!("🔍 Proof-of-Reserves (PoR) routes enabled");
+        api::por::por_routes(state)
+    } else {
+        info!("⏭️  Skipping PoR routes (no database)");
+        Router::new()
+    };
+
     // ── Peg Integrity Monitor ─────────────────────────────────────────────────
     let peg_monitor_routes = if let (Some(pool), Some(client)) =
         (db_pool.clone(), stellar_client.clone())
@@ -2049,6 +2091,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(pentest_routes)
         .merge(liquidity_routes)
         .merge(transparency_routes)
+        .merge(por_routes)
         .merge(bug_bounty_routes)
         .merge(developer_portal::routes::register_developer_portal_routes(Router::new(), db_pool.clone()))
         .merge(Router::new().nest("/api/admin/security", mtls_admin_routes))

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -15,5 +15,5 @@ pub mod stellar_submitter_worker;
 pub mod transaction_monitor;
 pub mod webhook_retry;
 pub mod supply_monitor_worker;
-pub mod reconciliation_worker;
 pub mod liquidity_monitor_worker;
+pub mod por_worker;

--- a/src/workers/por_worker.rs
+++ b/src/workers/por_worker.rs
@@ -1,0 +1,566 @@
+//! Proof-of-Reserves (PoR) Worker — Issue #297
+//!
+//! Runs every 60 minutes and:
+//!   1. Fetches the current cNGN circulating supply from Stellar Horizon.
+//!   2. Aggregates settled NGN balances from custodian bank APIs (read-only).
+//!   3. Calculates the collateralization ratio:
+//!        ratio = (total_bank_assets / total_on_chain_supply) × 100
+//!   4. Persists a signed PoR snapshot to `por_snapshots`.
+//!   5. Raises an investigation alert to the Audit Trail if the ratio deviates
+//!      more than 0.05% from 100.00% (i.e. ratio < 99.95%).
+//!   6. Raises an under-collateralization alert if ratio < 100.01%.
+
+use crate::audit::models::{AuditActorType, AuditEventCategory, AuditOutcome, PendingAuditEntry};
+use crate::audit::writer::AuditWriter;
+use crate::chains::stellar::client::StellarClient;
+use bigdecimal::BigDecimal;
+use chrono::Utc;
+use ed25519_dalek::Signer;
+use sqlx::PgPool;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+use tracing::{error, info, instrument, warn};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Ratio must be >= 100.01% to be considered fully collateralised (issue spec).
+const UNDER_COLLATERAL_THRESHOLD: f64 = 100.01;
+/// Discrepancies > 0.05% from 100.00% trigger an investigation alert.
+const DISCREPANCY_ALERT_THRESHOLD_PCT: f64 = 0.05;
+/// Default PoR refresh interval: 60 minutes.
+const DEFAULT_INTERVAL_SECS: u64 = 60 * 60;
+
+// ── Bank credential (read-only) ───────────────────────────────────────────────
+
+/// A single custodian bank configured via environment variables.
+/// Only "settled balance" (read-only) credentials are stored — the service
+/// cannot initiate transfers.
+#[derive(Debug, Clone)]
+pub struct BankCredential {
+    /// Anonymised label shown in the public PoR response, e.g. "Reserve Vault A".
+    pub label: String,
+    /// Base URL of the bank's balance API.
+    pub api_base_url: String,
+    /// Read-only API key / bearer token.
+    pub api_key: String,
+    /// Account identifier to query.
+    pub account_id: String,
+}
+
+impl BankCredential {
+    /// Load all configured bank credentials from environment variables.
+    ///
+    /// Convention:
+    ///   RESERVE_BANK_1_LABEL, RESERVE_BANK_1_API_URL,
+    ///   RESERVE_BANK_1_API_KEY, RESERVE_BANK_1_ACCOUNT_ID
+    ///   … up to RESERVE_BANK_9_*
+    pub fn load_from_env() -> Vec<Self> {
+        let mut banks = Vec::new();
+        for i in 1..=9 {
+            let label = std::env::var(format!("RESERVE_BANK_{i}_LABEL")).unwrap_or_default();
+            let url = std::env::var(format!("RESERVE_BANK_{i}_API_URL")).unwrap_or_default();
+            let key = std::env::var(format!("RESERVE_BANK_{i}_API_KEY")).unwrap_or_default();
+            let account = std::env::var(format!("RESERVE_BANK_{i}_ACCOUNT_ID")).unwrap_or_default();
+
+            if label.is_empty() || url.is_empty() || key.is_empty() || account.is_empty() {
+                continue;
+            }
+            banks.push(BankCredential {
+                label,
+                api_base_url: url,
+                api_key: key,
+                account_id: account,
+            });
+        }
+        banks
+    }
+}
+
+// ── Bank balance result ───────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct BankBalance {
+    pub label: String,
+    pub settled_balance: BigDecimal,
+    pub currency: String,
+    /// Timestamp from the bank API confirming the balance (Proof of Solvency).
+    pub balance_as_of: chrono::DateTime<Utc>,
+}
+
+// ── Worker ────────────────────────────────────────────────────────────────────
+
+pub struct ProofOfReservesWorker {
+    pool: PgPool,
+    stellar_client: StellarClient,
+    banks: Vec<BankCredential>,
+    signing_key: Arc<ed25519_dalek::SigningKey>,
+    audit_writer: Option<Arc<AuditWriter>>,
+    cngn_asset_code: String,
+    cngn_issuer: String,
+    interval: Duration,
+    http: reqwest::Client,
+}
+
+impl ProofOfReservesWorker {
+    pub fn new(
+        pool: PgPool,
+        stellar_client: StellarClient,
+        signing_key: Arc<ed25519_dalek::SigningKey>,
+        audit_writer: Option<Arc<AuditWriter>>,
+        cngn_issuer: String,
+    ) -> Self {
+        let interval_secs = std::env::var("POR_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_INTERVAL_SECS);
+
+        Self {
+            pool,
+            stellar_client,
+            banks: BankCredential::load_from_env(),
+            signing_key,
+            audit_writer,
+            cngn_asset_code: "cNGN".to_string(),
+            cngn_issuer,
+            interval: Duration::from_secs(interval_secs),
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
+        }
+    }
+
+    pub async fn run(self, mut shutdown_rx: watch::Receiver<bool>) {
+        info!(
+            interval_mins = self.interval.as_secs() / 60,
+            asset = %format!("{}:{}", self.cngn_asset_code, self.cngn_issuer),
+            banks = self.banks.len(),
+            "Proof-of-Reserves worker started"
+        );
+
+        let mut ticker = tokio::time::interval(self.interval);
+
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        info!("Proof-of-Reserves worker stopping");
+                        break;
+                    }
+                }
+                _ = ticker.tick() => {
+                    if let Err(e) = self.run_cycle().await {
+                        error!(error = %e, "PoR cycle failed");
+                    }
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self), name = "por_cycle")]
+    async fn run_cycle(&self) -> anyhow::Result<()> {
+        info!("Starting Proof-of-Reserves cycle");
+
+        // 1. On-chain supply
+        let total_on_chain_supply = self.fetch_on_chain_supply().await?;
+
+        // 2. Bank balances
+        let bank_balances = self.fetch_bank_balances().await;
+
+        // 3. Aggregate bank assets
+        let total_bank_assets: BigDecimal = bank_balances
+            .iter()
+            .fold(BigDecimal::from(0), |acc, b| acc + &b.settled_balance);
+
+        // Custodian solvency timestamp: earliest balance_as_of across all banks
+        // (most conservative — all banks must have confirmed by this time).
+        let custodian_solvency_ts = bank_balances
+            .iter()
+            .map(|b| b.balance_as_of)
+            .min()
+            .unwrap_or_else(Utc::now);
+
+        // 4. Collateralization ratio
+        let ratio_pct = if total_on_chain_supply == BigDecimal::from(0) {
+            // No supply → trivially 100% backed
+            BigDecimal::from(100)
+        } else {
+            (&total_bank_assets / &total_on_chain_supply) * BigDecimal::from(100)
+        };
+        let ratio_f64: f64 = ratio_pct.to_string().parse().unwrap_or(0.0);
+
+        let is_fully_collateralized = ratio_f64 >= UNDER_COLLATERAL_THRESHOLD;
+
+        // 5. Build and sign canonical payload
+        let canonical = format!(
+            r#"{{"collateralization_ratio":"{ratio_pct}","custodian_solvency_ts":"{custodian_ts}","total_bank_assets":"{bank}","total_on_chain_supply":"{supply}"}}"#,
+            ratio_pct = ratio_pct,
+            custodian_ts = custodian_solvency_ts.to_rfc3339(),
+            bank = total_bank_assets,
+            supply = total_on_chain_supply,
+        );
+        let sig_bytes = self.signing_key.sign(canonical.as_bytes());
+        let signature = hex::encode(sig_bytes.to_bytes());
+        let signing_key_hex = hex::encode(self.signing_key.verifying_key().to_bytes());
+
+        // 6. Persist snapshot
+        let snapshot_id = self
+            .persist_snapshot(
+                &total_on_chain_supply,
+                &total_bank_assets,
+                &ratio_pct,
+                is_fully_collateralized,
+                custodian_solvency_ts,
+                &signature,
+                &signing_key_hex,
+                &bank_balances,
+            )
+            .await?;
+
+        info!(
+            snapshot_id = %snapshot_id,
+            supply = %total_on_chain_supply,
+            bank_assets = %total_bank_assets,
+            ratio_pct = ratio_f64,
+            fully_collateralized = is_fully_collateralized,
+            "PoR snapshot recorded"
+        );
+
+        // 7. Under-collateralization alert (ratio < 100.01%)
+        if !is_fully_collateralized {
+            warn!(
+                ratio_pct = ratio_f64,
+                threshold = UNDER_COLLATERAL_THRESHOLD,
+                "⚠️  cNGN is UNDER-COLLATERALIZED — ratio below 100.01%"
+            );
+            self.raise_discrepancy_alert(
+                snapshot_id,
+                &ratio_pct,
+                &total_on_chain_supply,
+                &total_bank_assets,
+                "CRITICAL",
+            )
+            .await;
+        }
+
+        // 8. Discrepancy investigation alert (deviation > 0.05% from 100.00%)
+        let deviation = (ratio_f64 - 100.0_f64).abs();
+        if deviation > DISCREPANCY_ALERT_THRESHOLD_PCT {
+            warn!(
+                deviation_pct = deviation,
+                threshold_pct = DISCREPANCY_ALERT_THRESHOLD_PCT,
+                "🔍 PoR discrepancy exceeds 0.05% — raising investigation alert"
+            );
+            self.raise_discrepancy_alert(
+                snapshot_id,
+                &ratio_pct,
+                &total_on_chain_supply,
+                &total_bank_assets,
+                "INVESTIGATION",
+            )
+            .await;
+        }
+
+        Ok(())
+    }
+
+    // ── On-chain supply ───────────────────────────────────────────────────────
+
+    async fn fetch_on_chain_supply(&self) -> anyhow::Result<BigDecimal> {
+        let stats = self
+            .stellar_client
+            .get_asset_stats(&self.cngn_asset_code, &self.cngn_issuer)
+            .await?;
+
+        let amount_str = stats
+            .get("amount")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+
+        Ok(BigDecimal::from_str(amount_str).unwrap_or_else(|_| BigDecimal::from(0)))
+    }
+
+    // ── Bank balances ─────────────────────────────────────────────────────────
+
+    /// Fetch settled balances from all configured custodian banks.
+    /// Uses read-only credentials — cannot initiate transfers.
+    /// Failures are logged but do not abort the cycle; a missing bank simply
+    /// contributes 0 to the total (which will trigger an under-collateral alert).
+    async fn fetch_bank_balances(&self) -> Vec<BankBalance> {
+        let mut results = Vec::new();
+
+        for bank in &self.banks {
+            match self.fetch_single_bank_balance(bank).await {
+                Ok(balance) => results.push(balance),
+                Err(e) => {
+                    error!(
+                        bank = %bank.label,
+                        error = %e,
+                        "Failed to fetch bank balance — treating as 0"
+                    );
+                    // A missing bank balance is treated as 0, which will
+                    // naturally trigger an under-collateral alert.
+                    results.push(BankBalance {
+                        label: bank.label.clone(),
+                        settled_balance: BigDecimal::from(0),
+                        currency: "NGN".to_string(),
+                        balance_as_of: Utc::now(),
+                    });
+                }
+            }
+        }
+
+        // If no banks are configured, log a warning.
+        if results.is_empty() {
+            warn!("No custodian bank credentials configured (RESERVE_BANK_1_* env vars). PoR bank total will be 0.");
+        }
+
+        results
+    }
+
+    /// Fetch a single bank's settled balance via its read-only API.
+    ///
+    /// Expected JSON response shape:
+    /// ```json
+    /// {
+    ///   "settled_balance": "1234567890.00",
+    ///   "currency": "NGN",
+    ///   "balance_as_of": "2026-04-23T12:00:00Z"
+    /// }
+    /// ```
+    async fn fetch_single_bank_balance(&self, bank: &BankCredential) -> anyhow::Result<BankBalance> {
+        let url = format!(
+            "{}/accounts/{}/settled-balance",
+            bank.api_base_url.trim_end_matches('/'),
+            bank.account_id
+        );
+
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&bank.api_key)
+            .header("X-Read-Only", "true")
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<serde_json::Value>()
+            .await?;
+
+        let balance_str = resp
+            .get("settled_balance")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let currency = resp
+            .get("currency")
+            .and_then(|v| v.as_str())
+            .unwrap_or("NGN")
+            .to_string();
+        let balance_as_of_str = resp
+            .get("balance_as_of")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let balance_as_of = chrono::DateTime::parse_from_rfc3339(balance_as_of_str)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now());
+
+        Ok(BankBalance {
+            label: bank.label.clone(),
+            settled_balance: BigDecimal::from_str(balance_str)
+                .unwrap_or_else(|_| BigDecimal::from(0)),
+            currency,
+            balance_as_of,
+        })
+    }
+
+    // ── Persistence ───────────────────────────────────────────────────────────
+
+    #[allow(clippy::too_many_arguments)]
+    async fn persist_snapshot(
+        &self,
+        total_on_chain_supply: &BigDecimal,
+        total_bank_assets: &BigDecimal,
+        collateralization_ratio: &BigDecimal,
+        is_fully_collateralized: bool,
+        custodian_solvency_ts: chrono::DateTime<Utc>,
+        signature: &str,
+        signing_key: &str,
+        bank_balances: &[BankBalance],
+    ) -> anyhow::Result<uuid::Uuid> {
+        let mut tx = self.pool.begin().await?;
+
+        let snapshot_id = sqlx::query_scalar::<_, uuid::Uuid>(
+            r#"
+            INSERT INTO por_snapshots
+                (total_on_chain_supply, total_bank_assets, collateralization_ratio,
+                 is_fully_collateralized, custodian_solvency_ts, signature, signing_key)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING id
+            "#,
+        )
+        .bind(total_on_chain_supply)
+        .bind(total_bank_assets)
+        .bind(collateralization_ratio)
+        .bind(is_fully_collateralized)
+        .bind(custodian_solvency_ts)
+        .bind(signature)
+        .bind(signing_key)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        for bank in bank_balances {
+            sqlx::query(
+                r#"
+                INSERT INTO por_bank_balances
+                    (snapshot_id, bank_label, settled_balance, currency, balance_as_of)
+                VALUES ($1, $2, $3, $4, $5)
+                "#,
+            )
+            .bind(snapshot_id)
+            .bind(&bank.label)
+            .bind(&bank.settled_balance)
+            .bind(&bank.currency)
+            .bind(bank.balance_as_of)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(snapshot_id)
+    }
+
+    // ── Discrepancy alert ─────────────────────────────────────────────────────
+
+    async fn raise_discrepancy_alert(
+        &self,
+        snapshot_id: uuid::Uuid,
+        ratio: &BigDecimal,
+        supply: &BigDecimal,
+        bank_assets: &BigDecimal,
+        alert_level: &str,
+    ) {
+        let shortfall = supply - bank_assets;
+        let deviation_pct = (ratio.to_string().parse::<f64>().unwrap_or(0.0) - 100.0_f64).abs();
+        let deviation_bd = BigDecimal::from_str(&format!("{deviation_pct:.6}"))
+            .unwrap_or_else(|_| BigDecimal::from(0));
+
+        let db_result = sqlx::query(
+            r#"
+            INSERT INTO por_discrepancy_alerts
+                (snapshot_id, collateralization_ratio, total_on_chain_supply,
+                 total_bank_assets, shortfall, deviation_pct, alert_level)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            "#,
+        )
+        .bind(snapshot_id)
+        .bind(ratio)
+        .bind(supply)
+        .bind(bank_assets)
+        .bind(&shortfall)
+        .bind(&deviation_bd)
+        .bind(alert_level)
+        .execute(&self.pool)
+        .await;
+
+        if let Err(e) = db_result {
+            error!(error = %e, "Failed to persist PoR discrepancy alert");
+        }
+
+        // Write to Audit Trail (Issue #117)
+        if let Some(writer) = &self.audit_writer {
+            let entry = PendingAuditEntry {
+                event_type: "por.discrepancy_alert".to_string(),
+                event_category: AuditEventCategory::FinancialTransaction,
+                actor_type: AuditActorType::System,
+                actor_id: Some("por_worker".to_string()),
+                actor_ip: None,
+                actor_consumer_type: Some("proof_of_reserves_worker".to_string()),
+                session_id: None,
+                target_resource_type: Some("por_snapshot".to_string()),
+                target_resource_id: Some(snapshot_id.to_string()),
+                request_method: "INTERNAL".to_string(),
+                request_path: "/internal/por/discrepancy".to_string(),
+                request_body_hash: None,
+                response_status: 200,
+                response_latency_ms: 0,
+                outcome: AuditOutcome::Failure,
+                failure_reason: Some(format!(
+                    "PoR {alert_level}: ratio={ratio:.6}% supply={supply} bank_assets={bank_assets} \
+                     shortfall={shortfall} deviation={deviation_pct:.4}%"
+                )),
+                environment: std::env::var("APP_ENV").unwrap_or_else(|_| "production".to_string()),
+            };
+            writer.write(entry).await;
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ratio_calculation_fully_backed() {
+        let supply = BigDecimal::from_str("1000000").unwrap();
+        let bank = BigDecimal::from_str("1001000").unwrap();
+        let ratio = (&bank / &supply) * BigDecimal::from(100);
+        let ratio_f64: f64 = ratio.to_string().parse().unwrap();
+        assert!(ratio_f64 >= UNDER_COLLATERAL_THRESHOLD);
+    }
+
+    #[test]
+    fn ratio_calculation_under_collateralized() {
+        let supply = BigDecimal::from_str("1000000").unwrap();
+        let bank = BigDecimal::from_str("999000").unwrap();
+        let ratio = (&bank / &supply) * BigDecimal::from(100);
+        let ratio_f64: f64 = ratio.to_string().parse().unwrap();
+        assert!(ratio_f64 < UNDER_COLLATERAL_THRESHOLD);
+    }
+
+    #[test]
+    fn discrepancy_threshold_triggers_at_0_05_pct() {
+        // 0.06% deviation should trigger
+        let ratio_f64 = 99.94_f64;
+        let deviation = (ratio_f64 - 100.0_f64).abs();
+        assert!(deviation > DISCREPANCY_ALERT_THRESHOLD_PCT);
+    }
+
+    #[test]
+    fn discrepancy_threshold_does_not_trigger_below_0_05_pct() {
+        // 0.04% deviation should NOT trigger
+        let ratio_f64 = 99.96_f64;
+        let deviation = (ratio_f64 - 100.0_f64).abs();
+        assert!(deviation <= DISCREPANCY_ALERT_THRESHOLD_PCT);
+    }
+
+    #[test]
+    fn zero_supply_yields_100_pct_ratio() {
+        let supply = BigDecimal::from(0);
+        let bank = BigDecimal::from_str("1000000").unwrap();
+        let ratio = if supply == BigDecimal::from(0) {
+            BigDecimal::from(100)
+        } else {
+            (&bank / &supply) * BigDecimal::from(100)
+        };
+        let ratio_f64: f64 = ratio.to_string().parse().unwrap();
+        assert!((ratio_f64 - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bank_credentials_load_from_env_skips_incomplete_entries() {
+        // No env vars set → empty list
+        let banks = BankCredential::load_from_env();
+        // In a clean test environment there are no RESERVE_BANK_* vars
+        // so the list should be empty (or contain only fully-configured entries).
+        for bank in &banks {
+            assert!(!bank.label.is_empty());
+            assert!(!bank.api_base_url.is_empty());
+            assert!(!bank.api_key.is_empty());
+            assert!(!bank.account_id.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
…f-Reserves (PoR)

Implements Issue #297 — Stablecoin Reserve Management & Proof-of-Reserves.

## What was changed

### New files
- migrations/20260423000000_proof_of_reserves_por.sql Three new tables:
  * por_snapshots — hourly signed PoR snapshots (supply, bank assets, ratio, custodian solvency timestamp, Ed25519 signature)
  * por_bank_balances — per-bank settled NGN balances per snapshot
  * por_discrepancy_alerts — investigation/critical alerts when ratio deviates

- src/workers/por_worker.rs — ProofOfReservesWorker
  * Runs every 60 minutes (POR_INTERVAL_SECS env override)
  * Fetches cNGN circulating supply from Stellar Horizon (on-chain tracker)
  * Aggregates settled NGN balances from custodian banks via read-only API credentials (RESERVE_BANK_N_* env vars; cannot move funds)
  * Calculates collateralization ratio: (bank_assets / supply) × 100
  * Persists signed snapshot to por_snapshots + per-bank rows
  * Raises CRITICAL alert if ratio < 100.01% (under-collateralized)
  * Raises INVESTIGATION alert if deviation from 100.00% exceeds 0.05%
  * Writes all alerts to the Audit Trail (Issue #117) via AuditWriter
  * Signs canonical payload with platform Ed25519 key (reuses transparency key)
  * Unit tests for ratio calculation, threshold logic, and env loading

- src/api/por.rs — public GET /v1/transparency/por handler
  * Unauthenticated public endpoint
  * Returns most-recent signed PoR snapshot with per-bank breakdown
  * Includes custodian_solvency_timestamp (Proof of Solvency)
  * Cache-Control: public, max-age=60 for CDN caching
  * Returns 503 with descriptive message when no snapshot exists yet

### Modified files
- src/api/mod.rs — registers new por module
- src/workers/mod.rs — registers por_worker module; fixes pre-existing duplicate pub mod reconciliation_worker declaration
- src/main.rs — wires up PoR worker (after reconciliation worker) and PoR routes (alongside transparency routes)

## Why it was needed

Issue #297 requires a Trust Anchor service that cryptographically links cNGN on-chain supply to physical NGN held in custodian bank accounts, providing a public Proof-of-Reserves guarantee for users and regulators.

## Assumptions

- Bank APIs follow a standard settled-balance response shape ({settled_balance, currency, balance_as_of}); real integrations will need provider-specific adapters once bank credentials are available.
- The platform Ed25519 signing key (TRANSPARENCY_SIGNING_KEY_HEX) is reused for PoR signatures to avoid key proliferation.
- POR_WORKER_ENABLED=false disables the worker without code changes.

Closes #297