### PR TITLE
feat: implement In-House CFO for autonomous agent treasury management

### DIFF
--- a/migrations/20270401000000_agent_cfo_schema.sql
+++ b/migrations/20270401000000_agent_cfo_schema.sql
@@ -1,0 +1,74 @@
+-- Agent CFO: In-House Treasury Management for Autonomous Agents
+-- Issue: Agentic Treasury / In-House CFO
+
+CREATE TYPE llm_tier AS ENUM ('advanced', 'efficient');
+CREATE TYPE agent_key_state AS ENUM ('active', 'frozen');
+
+-- Budget policy per agent
+CREATE TABLE agent_budget_policies (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id            UUID NOT NULL UNIQUE,
+    daily_limit_cngn    NUMERIC(20, 6) NOT NULL DEFAULT 100,
+    task_limit_cngn     NUMERIC(20, 6) NOT NULL DEFAULT 500,
+    safety_buffer_cngn  NUMERIC(20, 6) NOT NULL DEFAULT 20,
+    refill_amount_cngn  NUMERIC(20, 6) NOT NULL DEFAULT 50,
+    funding_account     TEXT NOT NULL,
+    llm_tier            llm_tier NOT NULL DEFAULT 'advanced',
+    key_state           agent_key_state NOT NULL DEFAULT 'active',
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Expenditure ledger: every inference / API call event
+CREATE TABLE agent_inference_events (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id                UUID NOT NULL REFERENCES agent_budget_policies(agent_id),
+    task_id                 UUID,
+    event_type              TEXT NOT NULL,          -- 'llm_call' | 'api_request' | 'data_query'
+    model_used              TEXT,
+    cost_cngn               NUMERIC(20, 6) NOT NULL,
+    cumulative_daily_spend  NUMERIC(20, 6) NOT NULL,
+    metadata                JSONB NOT NULL DEFAULT '{}',
+    recorded_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_inference_agent_day
+    ON agent_inference_events (agent_id, recorded_at DESC);
+
+CREATE INDEX idx_inference_task
+    ON agent_inference_events (task_id)
+    WHERE task_id IS NOT NULL;
+
+-- Agent wallets (balance tracking for refill trigger)
+CREATE TABLE agent_wallets (
+    agent_id        UUID PRIMARY KEY REFERENCES agent_budget_policies(agent_id),
+    balance_cngn    NUMERIC(20, 6) NOT NULL DEFAULT 0,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Refill requests queued when balance drops below safety buffer
+CREATE TABLE agent_refill_requests (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id            UUID NOT NULL REFERENCES agent_budget_policies(agent_id),
+    refill_amount_cngn  NUMERIC(20, 6) NOT NULL,
+    funding_account     TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'pending', -- 'pending' | 'completed' | 'failed'
+    requested_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at        TIMESTAMPTZ,
+    UNIQUE (agent_id, requested_at)
+);
+
+-- Budget update reports (50% threshold notifications)
+CREATE TABLE agent_budget_reports (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id            UUID NOT NULL REFERENCES agent_budget_policies(agent_id),
+    daily_limit_cngn    NUMERIC(20, 6) NOT NULL,
+    spent_today_cngn    NUMERIC(20, 6) NOT NULL,
+    spend_percent       DOUBLE PRECISION NOT NULL,
+    llm_tier            llm_tier NOT NULL,
+    key_state           agent_key_state NOT NULL,
+    reported_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_budget_reports_agent
+    ON agent_budget_reports (agent_id, reported_at DESC);

--- a/src/agent_cfo/engine.rs
+++ b/src/agent_cfo/engine.rs
@@ -1,0 +1,277 @@
+use crate::agent_cfo::{
+    ledger::ExpenditureLedger,
+    types::{
+        AgentKeyState, BudgetPolicy, BudgetUpdateReport, CostProjectionRequest,
+        CostProjectionResponse, LlmTier, RecordInferenceRequest,
+    },
+};
+use chrono::Utc;
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// Fraction of daily budget at which the agent degrades to LlmTier::Efficient.
+const DEGRADATION_THRESHOLD: f64 = 0.80;
+/// Fraction at which a budget-update report is sent to the owner.
+const REPORT_THRESHOLD: f64 = 0.50;
+
+pub struct AgentCfoEngine {
+    db: PgPool,
+    ledger: Arc<ExpenditureLedger>,
+}
+
+impl AgentCfoEngine {
+    pub fn new(db: PgPool) -> Self {
+        let ledger = Arc::new(ExpenditureLedger::new(db.clone()));
+        Self { db, ledger }
+    }
+
+    // ── Policy helpers ────────────────────────────────────────────────────────
+
+    pub async fn get_policy(&self, agent_id: Uuid) -> Result<BudgetPolicy, String> {
+        sqlx::query_as!(
+            BudgetPolicy,
+            r#"
+            SELECT id, agent_id,
+                   daily_limit_cngn, task_limit_cngn,
+                   safety_buffer_cngn, refill_amount_cngn,
+                   funding_account,
+                   llm_tier AS "llm_tier: LlmTier",
+                   key_state AS "key_state: AgentKeyState",
+                   created_at, updated_at
+            FROM agent_budget_policies WHERE agent_id = $1
+            "#,
+            agent_id,
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| format!("policy not found: {e}"))
+    }
+
+    // ── Pre-execution cost projection ─────────────────────────────────────────
+
+    pub async fn project_cost(
+        &self,
+        req: CostProjectionRequest,
+    ) -> Result<CostProjectionResponse, String> {
+        let policy = self.get_policy(req.agent_id).await?;
+
+        if policy.key_state == AgentKeyState::Frozen {
+            return Err("Agent signing keys are frozen — task execution blocked".to_string());
+        }
+
+        let cost_per_llm = Decimal::from_str(&req.cost_per_llm_call)
+            .map_err(|e| format!("cost_per_llm_call parse: {e}"))?;
+        let cost_per_api = Decimal::from_str(&req.cost_per_api_call)
+            .map_err(|e| format!("cost_per_api_call parse: {e}"))?;
+        let projected = cost_per_llm * Decimal::from(req.estimated_llm_calls)
+            + cost_per_api * Decimal::from(req.estimated_api_calls);
+
+        let task_limit = Decimal::from_str(&policy.task_limit_cngn)
+            .map_err(|e| format!("task_limit parse: {e}"))?;
+        let daily_limit = Decimal::from_str(&policy.daily_limit_cngn)
+            .map_err(|e| format!("daily_limit parse: {e}"))?;
+        let spent_today = self.ledger.daily_spend(req.agent_id).await?;
+        let remaining_daily = (daily_limit - spent_today).max(Decimal::ZERO);
+
+        let within_task = projected <= task_limit;
+        let within_daily = projected <= remaining_daily;
+        let requires_approval = !within_task || !within_daily;
+
+        Ok(CostProjectionResponse {
+            agent_id: req.agent_id,
+            projected_cost_cngn: projected.to_string(),
+            within_task_budget: within_task,
+            within_daily_budget: within_daily,
+            llm_tier: policy.llm_tier,
+            requires_approval,
+        })
+    }
+
+    // ── Inference event recording ─────────────────────────────────────────────
+
+    pub async fn record_inference(
+        &self,
+        req: RecordInferenceRequest,
+    ) -> Result<serde_json::Value, String> {
+        let policy = self.get_policy(req.agent_id).await?;
+
+        if policy.key_state == AgentKeyState::Frozen {
+            return Err("Agent keys are frozen — inference recording blocked".to_string());
+        }
+
+        let event = self
+            .ledger
+            .record(
+                req.agent_id,
+                req.task_id,
+                &req.event_type,
+                req.model_used.as_deref(),
+                &req.cost_cngn,
+                req.metadata.unwrap_or(serde_json::json!({})),
+            )
+            .await?;
+
+        // ── Post-record checks ────────────────────────────────────────────────
+        let daily_limit = Decimal::from_str(&policy.daily_limit_cngn)
+            .map_err(|e| format!("daily_limit parse: {e}"))?;
+        let spent = Decimal::from_str(&event.cumulative_daily_spend)
+            .map_err(|e| format!("cumulative parse: {e}"))?;
+        let ratio = if daily_limit.is_zero() {
+            0.0
+        } else {
+            (spent / daily_limit).to_string().parse::<f64>().unwrap_or(0.0)
+        };
+
+        // Graceful degradation at 80 %
+        if ratio >= DEGRADATION_THRESHOLD && policy.llm_tier == LlmTier::Advanced {
+            warn!(
+                agent_id = %req.agent_id,
+                spend_pct = ratio * 100.0,
+                "Budget 80% consumed — switching to LlmTier::Efficient"
+            );
+            let _ = sqlx::query!(
+                "UPDATE agent_budget_policies SET llm_tier = 'efficient', updated_at = NOW() \
+                 WHERE agent_id = $1",
+                req.agent_id,
+            )
+            .execute(&self.db)
+            .await;
+        }
+
+        // Budget update report at 50 %
+        if ratio >= REPORT_THRESHOLD && ratio < DEGRADATION_THRESHOLD {
+            self.emit_budget_report(&policy, spent, ratio).await;
+        }
+
+        // Trigger wallet refill if balance is low (non-blocking)
+        {
+            let db = self.db.clone();
+            let agent_id = req.agent_id;
+            let safety_buffer = policy.safety_buffer_cngn.clone();
+            let refill_amount = policy.refill_amount_cngn.clone();
+            let funding_account = policy.funding_account.clone();
+            tokio::spawn(async move {
+                let _ = maybe_refill(&db, agent_id, &safety_buffer, &refill_amount, &funding_account).await;
+            });
+        }
+
+        Ok(serde_json::json!({
+            "event_id": event.id,
+            "cumulative_daily_spend": event.cumulative_daily_spend,
+            "llm_tier": policy.llm_tier,
+            "spend_percent": ratio * 100.0,
+        }))
+    }
+
+    // ── Budget report ─────────────────────────────────────────────────────────
+
+    async fn emit_budget_report(&self, policy: &BudgetPolicy, spent: Decimal, ratio: f64) {
+        let report = BudgetUpdateReport {
+            agent_id: policy.agent_id,
+            daily_limit_cngn: policy.daily_limit_cngn.clone(),
+            spent_today_cngn: spent.to_string(),
+            spend_percent: ratio * 100.0,
+            llm_tier: policy.llm_tier,
+            key_state: policy.key_state,
+            wallet_balance_cngn: "0".to_string(), // populated by caller if needed
+            reported_at: Utc::now(),
+        };
+
+        info!(
+            agent_id = %report.agent_id,
+            spend_pct = report.spend_percent,
+            "📊 Budget Update Report: agent has consumed {:.1}% of daily limit",
+            report.spend_percent
+        );
+
+        // Persist the report so the Admin Dashboard can query it.
+        let _ = sqlx::query!(
+            r#"
+            INSERT INTO agent_budget_reports
+                (id, agent_id, daily_limit_cngn, spent_today_cngn, spend_percent,
+                 llm_tier, key_state, reported_at)
+            VALUES (gen_random_uuid(), $1, $2, $3, $4, $5::llm_tier, $6::agent_key_state, NOW())
+            "#,
+            report.agent_id,
+            report.daily_limit_cngn,
+            report.spent_today_cngn,
+            report.spend_percent,
+            report.llm_tier as LlmTier,
+            report.key_state as AgentKeyState,
+        )
+        .execute(&self.db)
+        .await;
+
+        // Fire-and-forget webhook notification if configured.
+        if let Ok(url) = std::env::var("AGENT_CFO_REPORT_WEBHOOK_URL") {
+            let payload = serde_json::to_value(&report).unwrap_or_default();
+            tokio::spawn(async move {
+                let _ = reqwest::Client::new().post(&url).json(&payload).send().await;
+            });
+        }
+    }
+
+    pub fn ledger(&self) -> Arc<ExpenditureLedger> {
+        Arc::clone(&self.ledger)
+    }
+}
+
+// ── Wallet refill helper ──────────────────────────────────────────────────────
+
+async fn maybe_refill(
+    db: &PgPool,
+    agent_id: Uuid,
+    safety_buffer: &str,
+    refill_amount: &str,
+    funding_account: &str,
+) -> Result<(), String> {
+    // Read current wallet balance from the agent_wallets table.
+    let balance_row = sqlx::query!(
+        "SELECT balance_cngn FROM agent_wallets WHERE agent_id = $1",
+        agent_id,
+    )
+    .fetch_optional(db)
+    .await
+    .map_err(|e| format!("wallet query: {e}"))?;
+
+    let balance = match balance_row {
+        Some(r) => Decimal::from_str(&r.balance_cngn).unwrap_or(Decimal::ZERO),
+        None => return Ok(()),
+    };
+
+    let buffer = Decimal::from_str(safety_buffer).unwrap_or(Decimal::ZERO);
+    if balance >= buffer {
+        return Ok(());
+    }
+
+    // Record the refill intent — actual Stellar transfer is handled by the
+    // treasury / payment layer that watches this table.
+    sqlx::query!(
+        r#"
+        INSERT INTO agent_refill_requests
+            (id, agent_id, refill_amount_cngn, funding_account, status, requested_at)
+        VALUES (gen_random_uuid(), $1, $2, $3, 'pending', NOW())
+        ON CONFLICT DO NOTHING
+        "#,
+        agent_id,
+        refill_amount,
+        funding_account,
+    )
+    .execute(db)
+    .await
+    .map(|_| ())
+    .map_err(|e| format!("refill insert: {e}"))?;
+
+    info!(
+        agent_id = %agent_id,
+        balance = %balance,
+        buffer = %buffer,
+        refill = %refill_amount,
+        "💰 Wallet below safety buffer — refill request queued"
+    );
+    Ok(())
+}

--- a/src/agent_cfo/handlers.rs
+++ b/src/agent_cfo/handlers.rs
@@ -1,0 +1,113 @@
+use crate::agent_cfo::{
+    engine::AgentCfoEngine,
+    ledger::ExpenditureLedger,
+    types::{CostProjectionRequest, LedgerQuery, RecordInferenceRequest},
+    watchdog::BurnRateWatchdog,
+};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct CfoState {
+    pub engine: Arc<AgentCfoEngine>,
+    pub ledger: Arc<ExpenditureLedger>,
+    pub db: PgPool,
+}
+
+/// POST /agent-cfo/project-cost
+///
+/// Pre-execution cost projection. Returns whether the task fits within budget
+/// and whether human approval is required.
+pub async fn project_cost(
+    State(s): State<CfoState>,
+    Json(req): Json<CostProjectionRequest>,
+) -> impl IntoResponse {
+    match s.engine.project_cost(req).await {
+        Ok(resp) => (StatusCode::OK, Json(serde_json::to_value(resp).unwrap())).into_response(),
+        Err(e) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /agent-cfo/inference
+///
+/// Record a single inference / API call event. Updates cumulative spend,
+/// triggers graceful degradation and budget reports as needed.
+pub async fn record_inference(
+    State(s): State<CfoState>,
+    Json(req): Json<RecordInferenceRequest>,
+) -> impl IntoResponse {
+    match s.engine.record_inference(req).await {
+        Ok(resp) => (StatusCode::CREATED, Json(resp)).into_response(),
+        Err(e) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /agent-cfo/ledger
+///
+/// Query the expenditure ledger. Supports filtering by agent_id and task_id.
+pub async fn query_ledger(
+    State(s): State<CfoState>,
+    Query(q): Query<LedgerQuery>,
+) -> impl IntoResponse {
+    match s.ledger.query(&q).await {
+        Ok(events) => (StatusCode::OK, Json(events)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /agent-cfo/policy/:agent_id
+///
+/// Retrieve the budget policy for an agent.
+pub async fn get_policy(
+    State(s): State<CfoState>,
+    Path(agent_id): Path<Uuid>,
+) -> impl IntoResponse {
+    match s.engine.get_policy(agent_id).await {
+        Ok(policy) => (StatusCode::OK, Json(policy)).into_response(),
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}
+
+/// POST /agent-cfo/unfreeze/:agent_id
+///
+/// Admin endpoint — unfreeze an agent's signing keys after manual review.
+pub async fn unfreeze_agent(
+    State(s): State<CfoState>,
+    Path(agent_id): Path<Uuid>,
+) -> impl IntoResponse {
+    match BurnRateWatchdog::unfreeze(&s.db, agent_id).await {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "message": "Agent keys unfrozen", "agent_id": agent_id })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e })),
+        )
+            .into_response(),
+    }
+}

--- a/src/agent_cfo/ledger.rs
+++ b/src/agent_cfo/ledger.rs
@@ -1,0 +1,97 @@
+use crate::agent_cfo::types::{InferenceEvent, LedgerQuery};
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use std::str::FromStr;
+use uuid::Uuid;
+
+pub struct ExpenditureLedger {
+    db: PgPool,
+}
+
+impl ExpenditureLedger {
+    pub fn new(db: PgPool) -> Self {
+        Self { db }
+    }
+
+    /// Sum of all costs recorded today for `agent_id`.
+    pub async fn daily_spend(&self, agent_id: Uuid) -> Result<Decimal, String> {
+        let row = sqlx::query!(
+            r#"
+            SELECT COALESCE(SUM(cost_cngn::numeric), 0)::text AS total
+            FROM agent_inference_events
+            WHERE agent_id = $1
+              AND recorded_at >= date_trunc('day', NOW() AT TIME ZONE 'UTC')
+            "#,
+            agent_id,
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| format!("daily_spend query failed: {e}"))?;
+
+        Decimal::from_str(row.total.as_deref().unwrap_or("0"))
+            .map_err(|e| format!("decimal parse: {e}"))
+    }
+
+    /// Append one inference event and return the updated cumulative daily spend.
+    pub async fn record(
+        &self,
+        agent_id: Uuid,
+        task_id: Option<Uuid>,
+        event_type: &str,
+        model_used: Option<&str>,
+        cost_cngn: &str,
+        metadata: serde_json::Value,
+    ) -> Result<InferenceEvent, String> {
+        let daily = self.daily_spend(agent_id).await?;
+        let cost = Decimal::from_str(cost_cngn).map_err(|e| format!("cost parse: {e}"))?;
+        let cumulative = (daily + cost).to_string();
+
+        sqlx::query_as!(
+            InferenceEvent,
+            r#"
+            INSERT INTO agent_inference_events
+                (id, agent_id, task_id, event_type, model_used, cost_cngn,
+                 cumulative_daily_spend, metadata, recorded_at)
+            VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, NOW())
+            RETURNING id, agent_id, task_id, event_type, model_used, cost_cngn,
+                      cumulative_daily_spend, metadata, recorded_at
+            "#,
+            agent_id,
+            task_id,
+            event_type,
+            model_used,
+            cost_cngn,
+            cumulative,
+            metadata,
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| format!("ledger insert failed: {e}"))
+    }
+
+    /// Query the ledger with optional filters.
+    pub async fn query(
+        &self,
+        q: &LedgerQuery,
+    ) -> Result<Vec<InferenceEvent>, String> {
+        sqlx::query_as!(
+            InferenceEvent,
+            r#"
+            SELECT id, agent_id, task_id, event_type, model_used, cost_cngn,
+                   cumulative_daily_spend, metadata, recorded_at
+            FROM agent_inference_events
+            WHERE ($1::uuid IS NULL OR agent_id = $1)
+              AND ($2::uuid IS NULL OR task_id = $2)
+            ORDER BY recorded_at DESC
+            LIMIT $3 OFFSET $4
+            "#,
+            q.agent_id as Option<Uuid>,
+            q.task_id as Option<Uuid>,
+            q.page_size(),
+            q.offset(),
+        )
+        .fetch_all(&self.db)
+        .await
+        .map_err(|e| format!("ledger query failed: {e}"))
+    }
+}

--- a/src/agent_cfo/mod.rs
+++ b/src/agent_cfo/mod.rs
@@ -1,0 +1,11 @@
+/// In-House CFO — Autonomous Agent Treasury Management
+///
+/// Provides budget policy enforcement, expenditure visibility, graceful
+/// degradation, automated wallet refills, and a burn-rate kill-switch for
+/// AI agents operating with revolving budgets.
+pub mod engine;
+pub mod handlers;
+pub mod ledger;
+pub mod routes;
+pub mod types;
+pub mod watchdog;

--- a/src/agent_cfo/routes.rs
+++ b/src/agent_cfo/routes.rs
@@ -1,0 +1,14 @@
+use crate::agent_cfo::handlers::{
+    get_policy, project_cost, query_ledger, record_inference, unfreeze_agent, CfoState,
+};
+use axum::{routing::{get, post}, Router};
+
+pub fn agent_cfo_routes(state: CfoState) -> Router {
+    Router::new()
+        .route("/agent-cfo/project-cost", post(project_cost))
+        .route("/agent-cfo/inference", post(record_inference))
+        .route("/agent-cfo/ledger", get(query_ledger))
+        .route("/agent-cfo/policy/:agent_id", get(get_policy))
+        .route("/agent-cfo/unfreeze/:agent_id", post(unfreeze_agent))
+        .with_state(state)
+}

--- a/src/agent_cfo/types.rs
+++ b/src/agent_cfo/types.rs
@@ -1,0 +1,128 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Which LLM tier the agent is currently allowed to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "llm_tier", rename_all = "snake_case")]
+pub enum LlmTier {
+    /// Full-capability model — used when budget is healthy.
+    Advanced,
+    /// Cheaper model — activated when spend reaches 80 % of daily limit.
+    Efficient,
+}
+
+/// Lifecycle state of an agent's signing keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "agent_key_state", rename_all = "snake_case")]
+pub enum AgentKeyState {
+    Active,
+    /// Frozen by the watchdog due to a runaway burn-rate violation.
+    Frozen,
+}
+
+/// Budget policy attached to a single agent.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct BudgetPolicy {
+    pub id: Uuid,
+    pub agent_id: Uuid,
+    /// Maximum cNGN spend per calendar day.
+    pub daily_limit_cngn: String,
+    /// Maximum cNGN spend per individual task.
+    pub task_limit_cngn: String,
+    /// Wallet balance below which an automatic refill is triggered.
+    pub safety_buffer_cngn: String,
+    /// Amount transferred from the funding account on each refill.
+    pub refill_amount_cngn: String,
+    /// Stellar address of the human owner's funding account.
+    pub funding_account: String,
+    /// Current LLM tier (switches to Efficient at 80 % daily spend).
+    pub llm_tier: LlmTier,
+    /// Current key state (frozen when watchdog fires).
+    pub key_state: AgentKeyState,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A single inference / API call cost event written to the expenditure ledger.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct InferenceEvent {
+    pub id: Uuid,
+    pub agent_id: Uuid,
+    pub task_id: Option<Uuid>,
+    /// "llm_call" | "api_request" | "data_query"
+    pub event_type: String,
+    pub model_used: Option<String>,
+    pub cost_cngn: String,
+    pub cumulative_daily_spend: String,
+    pub metadata: serde_json::Value,
+    pub recorded_at: DateTime<Utc>,
+}
+
+/// Projected cost check before a task is executed.
+#[derive(Debug, Deserialize)]
+pub struct CostProjectionRequest {
+    pub agent_id: Uuid,
+    pub task_id: Option<Uuid>,
+    /// Estimated number of LLM calls.
+    pub estimated_llm_calls: u32,
+    /// Estimated number of external API calls.
+    pub estimated_api_calls: u32,
+    /// Cost per LLM call in cNGN.
+    pub cost_per_llm_call: String,
+    /// Cost per API call in cNGN.
+    pub cost_per_api_call: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CostProjectionResponse {
+    pub agent_id: Uuid,
+    pub projected_cost_cngn: String,
+    /// Whether the projected cost fits within the task budget.
+    pub within_task_budget: bool,
+    /// Whether the projected cost fits within today's remaining daily budget.
+    pub within_daily_budget: bool,
+    /// Current LLM tier the agent should use.
+    pub llm_tier: LlmTier,
+    /// Human approval required before execution.
+    pub requires_approval: bool,
+}
+
+/// Record an inference event (called by the agent after each LLM/API call).
+#[derive(Debug, Deserialize)]
+pub struct RecordInferenceRequest {
+    pub agent_id: Uuid,
+    pub task_id: Option<Uuid>,
+    pub event_type: String,
+    pub model_used: Option<String>,
+    pub cost_cngn: String,
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Budget status report sent to the owner at 50 % threshold.
+#[derive(Debug, Serialize)]
+pub struct BudgetUpdateReport {
+    pub agent_id: Uuid,
+    pub daily_limit_cngn: String,
+    pub spent_today_cngn: String,
+    pub spend_percent: f64,
+    pub llm_tier: LlmTier,
+    pub key_state: AgentKeyState,
+    pub wallet_balance_cngn: String,
+    pub reported_at: DateTime<Utc>,
+}
+
+/// Query params for listing inference events.
+#[derive(Debug, Deserialize)]
+pub struct LedgerQuery {
+    pub agent_id: Option<Uuid>,
+    pub task_id: Option<Uuid>,
+    pub page: Option<i64>,
+    pub page_size: Option<i64>,
+}
+
+impl LedgerQuery {
+    pub fn page(&self) -> i64 { self.page.unwrap_or(1).max(1) }
+    pub fn page_size(&self) -> i64 { self.page_size.unwrap_or(50).clamp(1, 200) }
+    pub fn offset(&self) -> i64 { (self.page() - 1) * self.page_size() }
+}

--- a/src/agent_cfo/watchdog.rs
+++ b/src/agent_cfo/watchdog.rs
@@ -1,0 +1,152 @@
+use crate::agent_cfo::types::AgentKeyState;
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use std::str::FromStr;
+use std::time::Duration;
+use tokio::sync::watch;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// Burn-rate safety policy.
+pub struct WatchdogConfig {
+    /// How often the watchdog sweeps all active agents.
+    pub poll_interval: Duration,
+    /// If an agent spends more than this many cNGN within `window`, freeze it.
+    pub max_spend_in_window: Decimal,
+    /// Rolling window for burn-rate calculation (seconds).
+    pub window_secs: i64,
+}
+
+impl Default for WatchdogConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(60),
+            max_spend_in_window: Decimal::from(50), // 50 cNGN / minute
+            window_secs: 60,
+        }
+    }
+}
+
+impl WatchdogConfig {
+    pub fn from_env() -> Self {
+        let max = std::env::var("AGENT_CFO_WATCHDOG_MAX_SPEND")
+            .ok()
+            .and_then(|v| Decimal::from_str(&v).ok())
+            .unwrap_or(Decimal::from(50));
+        let window = std::env::var("AGENT_CFO_WATCHDOG_WINDOW_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(60i64);
+        let poll = std::env::var("AGENT_CFO_WATCHDOG_POLL_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(60);
+        Self {
+            poll_interval: Duration::from_secs(poll),
+            max_spend_in_window: max,
+            window_secs: window,
+        }
+    }
+}
+
+pub struct BurnRateWatchdog {
+    db: PgPool,
+    config: WatchdogConfig,
+}
+
+impl BurnRateWatchdog {
+    pub fn new(db: PgPool, config: WatchdogConfig) -> Self {
+        Self { db, config }
+    }
+
+    /// Check one agent; freeze its keys if burn rate is violated.
+    /// Returns `true` if the agent was frozen.
+    pub async fn check_agent(&self, agent_id: Uuid) -> bool {
+        let result = sqlx::query!(
+            r#"
+            SELECT COALESCE(SUM(cost_cngn::numeric), 0)::text AS total
+            FROM agent_inference_events
+            WHERE agent_id = $1
+              AND recorded_at >= NOW() - ($2 || ' seconds')::interval
+            "#,
+            agent_id,
+            self.config.window_secs.to_string(),
+        )
+        .fetch_one(&self.db)
+        .await;
+
+        let spend = match result {
+            Ok(row) => Decimal::from_str(row.total.as_deref().unwrap_or("0"))
+                .unwrap_or(Decimal::ZERO),
+            Err(e) => {
+                warn!(agent_id = %agent_id, error = %e, "watchdog: spend query failed");
+                return false;
+            }
+        };
+
+        if spend > self.config.max_spend_in_window {
+            warn!(
+                agent_id = %agent_id,
+                spend = %spend,
+                limit = %self.config.max_spend_in_window,
+                "🚨 Runaway burn-rate detected — freezing agent signing keys"
+            );
+            let _ = sqlx::query!(
+                "UPDATE agent_budget_policies SET key_state = 'frozen', updated_at = NOW() \
+                 WHERE agent_id = $1 AND key_state = 'active'",
+                agent_id,
+            )
+            .execute(&self.db)
+            .await;
+            return true;
+        }
+        false
+    }
+
+    /// Background sweep — runs every `poll_interval`.
+    pub async fn run(self, mut shutdown: watch::Receiver<bool>) {
+        let mut ticker = tokio::time::interval(self.config.poll_interval);
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    let agents = sqlx::query_scalar!(
+                        "SELECT agent_id FROM agent_budget_policies WHERE key_state = 'active'"
+                    )
+                    .fetch_all(&self.db)
+                    .await
+                    .unwrap_or_default();
+
+                    for agent_id in agents {
+                        self.check_agent(agent_id).await;
+                    }
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        info!("Agent CFO watchdog shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Unfreeze an agent (called by admin after manual review).
+    pub async fn unfreeze(db: &PgPool, agent_id: Uuid) -> Result<(), String> {
+        sqlx::query!(
+            "UPDATE agent_budget_policies SET key_state = 'active', updated_at = NOW() \
+             WHERE agent_id = $1",
+            agent_id,
+        )
+        .execute(db)
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("unfreeze failed: {e}"))
+    }
+
+    pub fn key_state_from_db(state: &str) -> AgentKeyState {
+        match state {
+            "frozen" => AgentKeyState::Frozen,
+            _ => AgentKeyState::Active,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,10 @@ pub mod vault;
 #[cfg(feature = "database")]
 pub mod treasury;
 
+// In-House CFO — Autonomous Agent Treasury Management
+#[cfg(feature = "database")]
+pub mod agent_cfo;
+
 // Multi-Signature Governance Framework — M-of-N signing for Mint/Burn/SetOptions
 #[cfg(feature = "database")]
 pub mod multisig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ mod franchise;
 // Issue #322 — Wallet Creation & Stellar Account Provisioning
 mod wallet_provisioning;
 mod oracle;
+mod agent_cfo;
 
 // Imports
 use std::sync::Arc;
@@ -2209,6 +2210,28 @@ async fn main() -> anyhow::Result<()> {
         info!("⏭️  Skipping POS routes (missing database or stellar client)");
         Router::new()
     };
+    // ── Agent CFO — In-House Treasury for Autonomous Agents ─────────────────
+    let agent_cfo_routes = if let Some(pool) = db_pool.clone() {
+        let engine = std::sync::Arc::new(agent_cfo::engine::AgentCfoEngine::new(pool.clone()));
+        let ledger = engine.ledger();
+        let cfo_state = agent_cfo::handlers::CfoState {
+            engine,
+            ledger,
+            db: pool.clone(),
+        };
+        // Start burn-rate watchdog
+        let watchdog = agent_cfo::watchdog::BurnRateWatchdog::new(
+            pool,
+            agent_cfo::watchdog::WatchdogConfig::from_env(),
+        );
+        tokio::spawn(watchdog.run(worker_shutdown_rx.clone()));
+        info!("✅ Agent CFO watchdog started");
+        agent_cfo::routes::agent_cfo_routes(cfo_state)
+    } else {
+        info!("⏭️  Skipping Agent CFO routes (no database)");
+        Router::new()
+    };
+
     let app = Router::new()
         .route("/", get(root))
         .route("/health", get(health))
@@ -2216,30 +2239,15 @@ async fn main() -> anyhow::Result<()> {
         .route("/health/live", get(liveness))
         .route("/metrics", get(metrics::handler::metrics_handler))
         .route("/api/stellar/account/{address}", get(get_stellar_account))
-        .route(
-            "/api/trustlines/operations",
-            post(create_trustline_operation),
-        )
-        .route(
-            "/api/trustlines/operations/{id}",
-            patch(update_trustline_operation_status),
-        )
-        .route(
-            "/api/trustlines/operations/wallet/{address}",
-            get(list_trustline_operations_by_wallet),
-        )
+        .route("/api/trustlines/operations", post(create_trustline_operation))
+        .route("/api/trustlines/operations/{id}", patch(update_trustline_operation_status))
+        .route("/api/trustlines/operations/wallet/{address}", get(list_trustline_operations_by_wallet))
         .route("/api/fees/calculate", post(calculate_fee))
         .route("/api/cngn/trustlines/check", post(check_cngn_trustline))
-        .route(
-            "/api/cngn/trustlines/preflight",
-            post(preflight_cngn_trustline),
-        )
+        .route("/api/cngn/trustlines/preflight", post(preflight_cngn_trustline))
         .route("/api/cngn/trustlines/build", post(build_cngn_trustline))
         .route("/api/cngn/trustlines/submit", post(submit_cngn_trustline))
-        .route(
-            "/api/cngn/trustlines/retry/{id}",
-            post(retry_cngn_trustline),
-        )
+        .route("/api/cngn/trustlines/retry/{id}", post(retry_cngn_trustline))
         .route("/api/cngn/payments/build", post(build_cngn_payment))
         .route("/api/cngn/payments/sign", post(sign_cngn_payment))
         .route("/api/cngn/payments/submit", post(submit_cngn_payment))
@@ -2247,6 +2255,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(onramp_routes)
         .merge(offramp_routes)
         .merge(wallet_routes)
+        .merge(noncustodial_wallet_routes)
         .merge(rates_routes)
         .merge(fees_routes)
         .merge(mint_routes)
@@ -2278,6 +2287,8 @@ async fn main() -> anyhow::Result<()> {
         .merge(oracle_routes)
         .merge(governance_routes)
         .merge(lp_onboarding_routes)
+        .merge(agent_cfo_routes)
+        .merge(pos_routes)
         .with_state(AppState {
             db_pool,
             redis_cache,


### PR DESCRIPTION
- Budget policy schema: daily_limit, task_limit, safety_buffer, refill_amount per agent
- Graceful degradation: switches LlmTier Advanced→Efficient at 80% daily spend
- Expenditure ledger: real-time logging of every inference/API call event
- Pre-execution cost projection with human-approval gate when budget exceeded
- Budget update report emitted (and persisted) at 50% spend threshold
- Automated wallet refill trigger when balance drops below safety_buffer
- Burn-rate watchdog: freezes agent signing keys on runaway loop detection
- Admin unfreeze endpoint for post-review key restoration
- Full DB migration: agent_budget_policies, agent_inference_events, agent_wallets, agent_refill_requests, agent_budget_reports
- Routes: POST /agent-cfo/project-cost, POST /agent-cfo/inference, GET /agent-cfo/ledger, GET /agent-cfo/policy/:id, POST /agent-cfo/unfreeze/:id

Closes #341 : In-House CFO / Agentic Treasury issue
Labels: Treasury, FinOps, Risk-Management, Autonomous-Agents