### PR TITLE
feat: add merchant loyalty cashback engine (#332)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,8 +16,11 @@ dependencies = [
  "bb8-redis",
  "bcrypt",
  "bigdecimal",
+ "bytes",
  "chrono",
+ "chrono-tz",
  "config",
+ "criterion",
  "csv",
  "dotenv",
  "ed25519-dalek",
@@ -27,7 +30,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "http 1.4.0",
- "image",
+ "image 0.25.10",
  "jsonwebtoken",
  "maxminddb",
  "moka",
@@ -69,12 +72,14 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "typst",
  "urlencoding",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
  "webauthn-rs",
  "wiremock",
+ "zerocopy 0.7.35",
  "zeroize",
 ]
 
@@ -139,7 +144,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.39",
 ]
 
 [[package]]
@@ -185,10 +190,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "arbitrary"
@@ -371,6 +406,12 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -713,6 +754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +863,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "biblatex"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fe7285040d0227cd8b5395e1c4783f44f0b673eca5a657f4432ae401f2b7b8"
+dependencies = [
+ "numerals",
+ "paste",
+ "strum",
+ "unicode-normalization",
+ "unscanny",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +886,15 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
  "serde",
 ]
 
@@ -950,6 +1019,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecheck"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1130,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chinese-number"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e964125508474a83c95eb935697abbeb446ff4e9d62c71ce880e3986d1c606b"
+dependencies = [
+ "chinese-variant",
+ "enum-ordinalize",
+ "num-bigint 0.4.6",
+ "num-traits",
+]
+
+[[package]]
+name = "chinese-variant"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b52a9840ffff5d4d0058ae529fa066a75e794e3125546acfc61c23ad755e49"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1162,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,12 +1221,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "citationberg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d259fe9fd78ffa05a119581d20fddb50bfba428311057b12741ffb9015123d0b"
+dependencies = [
+ "quick-xml 0.31.0",
+ "serde",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1099,6 +1291,29 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "comemo"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6916408a724339aa77b18214233355f3eb04c42eb895e5f8909215bd8a7a91"
+dependencies = [
+ "comemo-macros",
+ "once_cell",
+ "parking_lot",
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "comemo-macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8936e42f9b4f5bdfaf23700609ac1f11cb03ad4c1ec128a4ee4fd0903e228db"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1198,6 +1413,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1469,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1469,6 +1729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1901,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecow"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e4f79b296fbaab6ce2e22d52cb4c7f010fe0ebe7a32e34fa25885fd797bd02"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,12 +1965,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1805,6 +2112,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +2196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +2223,18 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fontdb"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+dependencies = [
+ "log",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -2092,6 +2434,16 @@ dependencies = [
 
 [[package]]
 name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
@@ -2163,7 +2515,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy",
+ "zerocopy 0.8.39",
 ]
 
 [[package]]
@@ -2226,6 +2578,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hayagriva"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0d20c98b77b86ce737876b2a1653e2e6abbeee84afbb39d72111091191c97a"
+dependencies = [
+ "biblatex",
+ "ciborium",
+ "citationberg",
+ "indexmap 2.13.0",
+ "numerals",
+ "paste",
+ "serde",
+ "serde_yaml",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "unicode-segmentation",
+ "unscanny",
+ "url",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,6 +2607,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2457,6 +2836,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypher"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef68590049bab63a464eee1a1158ac04c6f6613a546d8d90f78636b8b94f171"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,15 +2867,28 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "serde",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "yoke",
+ "yoke 0.8.1",
  "zerofrom",
- "zerovec",
+ "zerovec 0.11.5",
 ]
 
 [[package]]
@@ -2500,11 +2898,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+ "litemap 0.8.1",
+ "tinystr 0.8.2",
+ "writeable 0.6.2",
+ "zerovec 0.11.5",
 ]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap 0.7.5",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -2512,12 +2943,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "icu_collections",
+ "icu_collections 2.1.1",
  "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
+ "icu_properties 2.1.2",
+ "icu_provider 2.1.1",
  "smallvec",
- "zerovec",
+ "zerovec 0.11.5",
 ]
 
 [[package]]
@@ -2528,17 +2959,39 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections 1.5.0",
+ "icu_locid_transform",
+ "icu_properties_data 1.5.1",
+ "icu_provider 1.5.0",
+ "serde",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_properties"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "icu_collections",
+ "icu_collections 2.1.1",
  "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
+ "icu_properties_data 2.1.2",
+ "icu_provider 2.1.1",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.5",
 ]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_properties_data"
@@ -2548,18 +3001,98 @@ checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "postcard",
+ "serde",
+ "stable_deref_trait",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "writeable",
- "yoke",
+ "writeable 0.6.2",
+ "yoke 0.8.1",
  "zerofrom",
- "zerotrie",
- "zerovec",
+ "zerotrie 0.2.3",
+ "zerovec 0.11.5",
 ]
+
+[[package]]
+name = "icu_provider_adapters"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6324dfd08348a8e0374a447ebd334044d766b1839bb8d5ccf2482a99a77c0bc"
+dependencies = [
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider_blob"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24b98d1365f55d78186c205817631a4acf08d7a45bdf5dc9dcf9c5d54dccf51"
+dependencies = [
+ "icu_provider 1.5.0",
+ "postcard",
+ "serde",
+ "writeable 0.5.5",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "icu_segmenter"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a717725612346ffc2d7b42c94b820db6908048f39434504cb130e8b46256b0de"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+ "icu_collections 1.5.0",
+ "icu_locid",
+ "icu_provider 1.5.0",
+ "icu_segmenter_data",
+ "serde",
+ "utf8_iter",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e52775179941363cc594e49ce99284d13d6948928d8e72c755f55e98caa1eb"
 
 [[package]]
 name = "id-arena"
@@ -2591,7 +3124,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
- "icu_properties",
+ "icu_properties 2.1.2",
+]
+
+[[package]]
+name = "if_chain"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif 0.13.3",
+ "jpeg-decoder",
+ "num-traits",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2604,11 +3158,11 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.14.2",
  "image-webp",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.1",
  "qoi",
  "ravif",
  "rayon",
@@ -2627,6 +3181,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error 2.0.1",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "imgref"
@@ -2709,6 +3269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +3345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+
+[[package]]
 name = "js-sys"
 version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,12 +3405,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -2913,6 +3508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +3524,25 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lipsum"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
+dependencies = [
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+]
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "litemap"
@@ -3102,6 +3722,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "nacl"
@@ -3293,6 +3919,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "numerals"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25be21376a772d15f97ae789845340a9651d3c4246ff5ebb6a2b35f9c37bd31"
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,6 +3947,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -3497,6 +4144,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,6 +4194,15 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -3623,6 +4303,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +4420,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.13.0",
+ "quick-xml 0.38.4",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,12 +4505,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "zerovec",
+ "zerovec 0.11.5",
 ]
 
 [[package]]
@@ -3733,7 +4537,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.39",
 ]
 
 [[package]]
@@ -3761,7 +4565,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -3890,6 +4694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,6 +4730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "qcms"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edecfcd5d755a5e5d98e24cf43113e7cdaec5a070edd0f6b250c03a573da30fa"
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,7 +4750,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 dependencies = [
- "image",
+ "image 0.25.10",
 ]
 
 [[package]]
@@ -3944,6 +4764,25 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -4386,6 +5225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4612,6 +5457,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustybuzz"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ae5692c5beaad6a9e22830deeed7874eae8a4e3ba4076fb48e12c56856222c"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,6 +5664,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -4974,10 +5844,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -5296,7 +6196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0107e34575ec704ce29407695462e79e6b0e13ce7af6431b2f15c313e34464"
 dependencies = [
  "darling 0.20.11",
- "heck",
+ "heck 0.5.0",
  "itertools 0.10.5",
  "macro-string",
  "proc-macro2 1.0.106",
@@ -5470,7 +6370,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2 1.0.106",
@@ -5606,6 +6506,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5725,6 +6638,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5742,10 +6664,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70"
+dependencies = [
+ "kurbo",
+ "siphasher 0.3.11",
+]
 
 [[package]]
 name = "syn"
@@ -5804,6 +6758,27 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.44",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -5956,13 +6931,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "serde",
+ "zerovec 0.10.4",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "zerovec",
+ "serde_core",
+ "zerovec 0.11.5",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6074,15 +7082,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6096,12 +7125,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -6114,6 +7157,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -6339,6 +7388,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "two-face"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37bed2135b2459c7eefba72c906d374697eb15949c205f2f124e3636a46b5eeb"
+dependencies = [
+ "once_cell",
+ "serde",
+ "syntect",
+]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6349,6 +7421,115 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typst"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12492297d20937494f0143ae50ef339e5fd3d927b4096af1c52fe73fb9c5fa9a"
+dependencies = [
+ "az",
+ "bitflags 2.11.0",
+ "chinese-number",
+ "ciborium",
+ "comemo",
+ "csv",
+ "ecow",
+ "fontdb",
+ "hayagriva",
+ "hypher",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
+ "icu_provider_adapters",
+ "icu_provider_blob",
+ "icu_segmenter",
+ "if_chain",
+ "image 0.24.9",
+ "indexmap 2.13.0",
+ "kamadak-exif",
+ "kurbo",
+ "lipsum",
+ "log",
+ "once_cell",
+ "palette",
+ "phf",
+ "png 0.17.16",
+ "portable-atomic",
+ "qcms",
+ "rayon",
+ "regex",
+ "roxmltree",
+ "rustybuzz",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "siphasher 1.0.2",
+ "smallvec",
+ "stacker",
+ "syntect",
+ "time",
+ "toml 0.8.23",
+ "ttf-parser",
+ "two-face",
+ "typed-arena",
+ "typst-assets",
+ "typst-macros",
+ "typst-syntax",
+ "typst-timing",
+ "unicode-bidi",
+ "unicode-math-class",
+ "unicode-script",
+ "unicode-segmentation",
+ "usvg",
+ "wasmi",
+]
+
+[[package]]
+name = "typst-assets"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b3061f8d268e8eec7481c9ab24540455cb4912983c49aae38fa6e8bf8ef4d9c"
+
+[[package]]
+name = "typst-macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a0fdfd46b4920b0f8e4215e5b8438c737e8bc3498a681ea59b0130228363fc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "typst-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3db69f2f41613b1ff6edbec44fd7dc524137f099ee36c46f560cedeaadb40c4"
+dependencies = [
+ "comemo",
+ "ecow",
+ "once_cell",
+ "serde",
+ "unicode-ident",
+ "unicode-math-class",
+ "unicode-script",
+ "unicode-segmentation",
+ "unscanny",
+]
+
+[[package]]
+name = "typst-timing"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b58e17192bcacb2a39aace6d3eece70f008b2949ce384ac501a58357fafee67"
+dependencies = [
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "typst-syntax",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -6363,6 +7544,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr 0.8.2",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6375,10 +7575,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-math-class"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d246cf599d5fae3c8d56e04b20eb519adb89a8af8d0b0fbcded369aa3647d65"
 
 [[package]]
 name = "unicode-normalization"
@@ -6396,10 +7614,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-xid"
@@ -6428,6 +7658,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"
@@ -6469,6 +7705,66 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377f62b4a3c173de8654c1aa80ab1dac1154e6f13a779a9943e53780120d1625"
+dependencies = [
+ "base64 0.21.7",
+ "log",
+ "pico-args",
+ "usvg-parser",
+ "usvg-text-layout",
+ "usvg-tree",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg-parser"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a05e6f2023d6b4e946f734240a3927aefdcf930d7d42587a2c8a8869814b0"
+dependencies = [
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo",
+ "log",
+ "roxmltree",
+ "simplecss",
+ "siphasher 0.3.11",
+ "svgtypes",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-text-layout"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c41888b9d5cf431fe852eaf9d047bbde83251b98f1749c2f08b1071e6db46e2"
+dependencies = [
+ "fontdb",
+ "kurbo",
+ "log",
+ "rustybuzz",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-tree"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18863e0404ed153d6e56362c5b1146db9f4f262a3244e3cf2dbe7d8a85909f05"
+dependencies = [
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -6708,6 +8004,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
+dependencies = [
+ "smallvec",
+ "spin",
+ "wasmi_arena",
+ "wasmi_core",
+ "wasmparser-nostd",
 ]
 
 [[package]]
@@ -7305,7 +8614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -7316,7 +8625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
@@ -7379,6 +8688,12 @@ dependencies = [
 
 [[package]]
 name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
@@ -7432,6 +8747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7442,6 +8763,15 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yaml-rust2"
@@ -7456,13 +8786,37 @@ dependencies = [
 
 [[package]]
 name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.8.1",
  "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -7479,11 +8833,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.39",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7540,13 +8915,37 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb594dd55d87335c5f60177cee24f19457a5ec10a065e0a3014722ad252d0a1f"
+dependencies = [
+ "displaydoc",
+ "litemap 0.7.5",
+ "serde",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.8.1",
  "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "serde",
+ "yoke 0.7.5",
+ "zerofrom",
+ "zerovec-derive 0.10.3",
 ]
 
 [[package]]
@@ -7555,9 +8954,21 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "yoke",
+ "serde",
+ "yoke 0.8.1",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.11.2",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ serde      = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0",                        optional = true }
 
 # --- Database ---
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "bigdecimal"], optional = true }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "bigdecimal", "rust_decimal"], optional = true }
 
 # In-process L1 cache
 moka = { version = "0.12", features = ["future"], optional = true }

--- a/migrations/20260424010000_merchant_loyalty_rewards.sql
+++ b/migrations/20260424010000_merchant_loyalty_rewards.sql
@@ -1,0 +1,145 @@
+-- ============================================================================
+-- Merchant Loyalty & Cashback Rewards Engine
+-- Issue #332
+-- ============================================================================
+-- Enables merchants to configure cashback campaigns such as:
+-- IF Transaction > X THEN Send Y% Cashback.
+--
+-- Rewards reserve campaign budget atomically before Stellar payout submission.
+-- High-risk wallets and velocity patterns move rewards to compliance hold.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS merchant_loyalty_campaigns (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id UUID NOT NULL REFERENCES merchants(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'active', 'paused', 'deactivated', 'exhausted')),
+    trigger_min_amount_cngn DECIMAL(18, 8) NOT NULL CHECK (trigger_min_amount_cngn > 0),
+    cashback_percent DECIMAL(9, 4) NOT NULL CHECK (cashback_percent > 0 AND cashback_percent <= 100),
+    budget_cap_cngn DECIMAL(18, 8) NOT NULL CHECK (budget_cap_cngn > 0),
+    budget_spent_cngn DECIMAL(18, 8) NOT NULL DEFAULT 0 CHECK (budget_spent_cngn >= 0),
+    per_customer_daily_cap_cngn DECIMAL(18, 8) CHECK (per_customer_daily_cap_cngn IS NULL OR per_customer_daily_cap_cngn > 0),
+    segment_tags TEXT[] NOT NULL DEFAULT '{}',
+    vip_cashback_multiplier DECIMAL(9, 4) NOT NULL DEFAULT 1 CHECK (vip_cashback_multiplier >= 1 AND vip_cashback_multiplier <= 5),
+    stellar_source_account VARCHAR(69),
+    atomic_stellar_enabled BOOLEAN NOT NULL DEFAULT true,
+    starts_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ends_at TIMESTAMPTZ,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    activated_at TIMESTAMPTZ,
+    deactivated_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT loyalty_campaign_budget_spend_lte_cap CHECK (budget_spent_cngn <= budget_cap_cngn),
+    CONSTRAINT loyalty_campaign_valid_window CHECK (ends_at IS NULL OR ends_at > starts_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_loyalty_campaigns_merchant_status
+    ON merchant_loyalty_campaigns (merchant_id, status, starts_at, ends_at);
+CREATE INDEX IF NOT EXISTS idx_loyalty_campaigns_segments
+    ON merchant_loyalty_campaigns USING GIN (segment_tags);
+
+CREATE TABLE IF NOT EXISTS merchant_loyalty_rewards (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    campaign_id UUID NOT NULL REFERENCES merchant_loyalty_campaigns(id) ON DELETE CASCADE,
+    merchant_id UUID NOT NULL REFERENCES merchants(id) ON DELETE CASCADE,
+    payment_intent_id UUID NOT NULL REFERENCES merchant_payment_intents(id) ON DELETE CASCADE,
+    customer_address VARCHAR(69) NOT NULL,
+    transaction_amount_cngn DECIMAL(18, 8) NOT NULL CHECK (transaction_amount_cngn > 0),
+    reward_amount_cngn DECIMAL(18, 8) NOT NULL CHECK (reward_amount_cngn > 0),
+    cashback_percent DECIMAL(9, 4) NOT NULL CHECK (cashback_percent > 0),
+    customer_tier TEXT NOT NULL DEFAULT 'standard' CHECK (customer_tier IN ('standard', 'vip')),
+    risk_status TEXT NOT NULL DEFAULT 'clear' CHECK (risk_status IN ('clear', 'flagged', 'high_risk')),
+    risk_flags TEXT[] NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'queued'
+        CHECK (status IN ('queued', 'submitted', 'paid', 'held', 'failed')),
+    stellar_tx_hash VARCHAR(128),
+    stellar_source_account VARCHAR(69),
+    idempotency_key TEXT NOT NULL,
+    atomicity_mode TEXT NOT NULL DEFAULT 'post_receipt_queue'
+        CHECK (atomicity_mode IN ('stellar_payment_channel', 'post_receipt_queue')),
+    notification_status TEXT NOT NULL DEFAULT 'queued'
+        CHECK (notification_status IN ('queued', 'sent', 'failed')),
+    failure_code TEXT,
+    paid_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (campaign_id, payment_intent_id),
+    UNIQUE (idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_loyalty_rewards_campaign
+    ON merchant_loyalty_rewards (campaign_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_loyalty_rewards_merchant_status
+    ON merchant_loyalty_rewards (merchant_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_loyalty_rewards_customer_velocity
+    ON merchant_loyalty_rewards (merchant_id, customer_address, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_loyalty_rewards_risk
+    ON merchant_loyalty_rewards (risk_status, created_at DESC)
+    WHERE risk_status <> 'clear';
+
+CREATE TABLE IF NOT EXISTS merchant_loyalty_risk_wallets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    wallet_address VARCHAR(69) NOT NULL UNIQUE,
+    risk_label TEXT NOT NULL,
+    internal_reason TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_by UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_loyalty_risk_wallets_active
+    ON merchant_loyalty_risk_wallets (wallet_address)
+    WHERE is_active = true;
+
+CREATE TABLE IF NOT EXISTS merchant_loyalty_reward_notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    reward_id UUID NOT NULL REFERENCES merchant_loyalty_rewards(id) ON DELETE CASCADE,
+    merchant_id UUID NOT NULL REFERENCES merchants(id) ON DELETE CASCADE,
+    customer_address VARCHAR(69) NOT NULL,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'sent', 'failed')),
+    sent_at TIMESTAMPTZ,
+    failure_code TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (reward_id, event_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_loyalty_notifications_status
+    ON merchant_loyalty_reward_notifications (status, created_at);
+CREATE INDEX IF NOT EXISTS idx_loyalty_notifications_customer
+    ON merchant_loyalty_reward_notifications (merchant_id, customer_address, created_at DESC);
+
+CREATE OR REPLACE VIEW merchant_loyalty_marketing_spend_daily AS
+SELECT
+    merchant_id,
+    campaign_id,
+    DATE_TRUNC('day', created_at)::date AS spend_date,
+    COUNT(*) AS reward_count,
+    SUM(reward_amount_cngn) AS total_reward_amount_cngn,
+    SUM(reward_amount_cngn) FILTER (WHERE status = 'paid') AS paid_reward_amount_cngn,
+    COUNT(*) FILTER (WHERE status = 'held') AS held_reward_count,
+    COUNT(*) FILTER (WHERE risk_status <> 'clear') AS risk_flagged_count
+FROM merchant_loyalty_rewards
+GROUP BY merchant_id, campaign_id, DATE_TRUNC('day', created_at)::date;
+
+CREATE TRIGGER set_updated_at_merchant_loyalty_campaigns
+    BEFORE UPDATE ON merchant_loyalty_campaigns
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_merchant_loyalty_rewards
+    BEFORE UPDATE ON merchant_loyalty_rewards
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_merchant_loyalty_risk_wallets
+    BEFORE UPDATE ON merchant_loyalty_risk_wallets
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_merchant_loyalty_reward_notifications
+    BEFORE UPDATE ON merchant_loyalty_reward_notifications
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/src/merchant_gateway/handlers.rs
+++ b/src/merchant_gateway/handlers.rs
@@ -1,6 +1,7 @@
 //! HTTP handlers for Merchant Gateway API
 
 use crate::error::AppError;
+use crate::merchant_gateway::loyalty::*;
 use crate::merchant_gateway::models::*;
 use crate::merchant_gateway::service::MerchantGatewayService;
 use crate::middleware::api_key::AuthenticatedKey;
@@ -135,6 +136,99 @@ pub async fn cancel_payment_intent(
     Ok(Json(ApiResponse {
         success: true,
         data: payment_intent,
+    }))
+}
+
+/// Create a merchant loyalty cashback campaign
+/// POST /api/v1/merchant/loyalty/campaigns
+#[instrument(skip(service, auth))]
+pub async fn create_loyalty_campaign(
+    State(service): State<Arc<MerchantGatewayService>>,
+    Extension(auth): Extension<AuthenticatedKey>,
+    Json(request): Json<CreateLoyaltyCampaignRequest>,
+) -> Result<(StatusCode, Json<ApiResponse<LoyaltyCampaign>>), AppError> {
+    let merchant_id = auth.consumer_id;
+    let campaign = service
+        .create_loyalty_campaign(merchant_id, request)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ApiResponse {
+            success: true,
+            data: campaign,
+        }),
+    ))
+}
+
+/// List merchant loyalty campaigns
+/// GET /api/v1/merchant/loyalty/campaigns
+#[instrument(skip(service, auth))]
+pub async fn list_loyalty_campaigns(
+    State(service): State<Arc<MerchantGatewayService>>,
+    Extension(auth): Extension<AuthenticatedKey>,
+) -> Result<Json<ApiResponse<Vec<LoyaltyCampaign>>>, AppError> {
+    let merchant_id = auth.consumer_id;
+    let campaigns = service.list_loyalty_campaigns(merchant_id).await?;
+
+    Ok(Json(ApiResponse {
+        success: true,
+        data: campaigns,
+    }))
+}
+
+/// Activate a merchant loyalty campaign
+/// POST /api/v1/merchant/loyalty/campaigns/:id/activate
+#[instrument(skip(service, auth))]
+pub async fn activate_loyalty_campaign(
+    State(service): State<Arc<MerchantGatewayService>>,
+    Extension(auth): Extension<AuthenticatedKey>,
+    Path(campaign_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<LoyaltyCampaign>>, AppError> {
+    let merchant_id = auth.consumer_id;
+    let campaign = service
+        .activate_loyalty_campaign(merchant_id, campaign_id)
+        .await?;
+
+    Ok(Json(ApiResponse {
+        success: true,
+        data: campaign,
+    }))
+}
+
+/// Deactivate a merchant loyalty campaign
+/// POST /api/v1/merchant/loyalty/campaigns/:id/deactivate
+#[instrument(skip(service, auth))]
+pub async fn deactivate_loyalty_campaign(
+    State(service): State<Arc<MerchantGatewayService>>,
+    Extension(auth): Extension<AuthenticatedKey>,
+    Path(campaign_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<LoyaltyCampaign>>, AppError> {
+    let merchant_id = auth.consumer_id;
+    let campaign = service
+        .deactivate_loyalty_campaign(merchant_id, campaign_id)
+        .await?;
+
+    Ok(Json(ApiResponse {
+        success: true,
+        data: campaign,
+    }))
+}
+
+/// Merchant loyalty marketing spend report
+/// GET /api/v1/merchant/loyalty/reports/spend
+#[instrument(skip(service, auth))]
+pub async fn loyalty_spend_report(
+    State(service): State<Arc<MerchantGatewayService>>,
+    Extension(auth): Extension<AuthenticatedKey>,
+    Query(query): Query<LoyaltySpendReportQuery>,
+) -> Result<Json<ApiResponse<LoyaltyMarketingSpendResponse>>, AppError> {
+    let merchant_id = auth.consumer_id;
+    let report = service.loyalty_spend_report(merchant_id, query).await?;
+
+    Ok(Json(ApiResponse {
+        success: true,
+        data: report,
     }))
 }
 

--- a/src/merchant_gateway/loyalty.rs
+++ b/src/merchant_gateway/loyalty.rs
@@ -1,0 +1,920 @@
+//! Merchant loyalty and cashback rewards engine.
+//!
+//! The pure rule helpers in this module are intentionally separate from the
+//! repository methods so campaign math, budget caps, tiering, and risk behavior
+//! can be tested without a database or Stellar network.
+
+use crate::database::error::DatabaseError;
+use crate::merchant_gateway::models::MerchantPaymentIntent;
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, PgPool};
+use std::collections::HashSet;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "text")]
+#[serde(rename_all = "snake_case")]
+pub enum LoyaltyCampaignStatus {
+    #[sqlx(rename = "draft")]
+    Draft,
+    #[sqlx(rename = "active")]
+    Active,
+    #[sqlx(rename = "paused")]
+    Paused,
+    #[sqlx(rename = "deactivated")]
+    Deactivated,
+    #[sqlx(rename = "exhausted")]
+    Exhausted,
+}
+
+impl LoyaltyCampaignStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Draft => "draft",
+            Self::Active => "active",
+            Self::Paused => "paused",
+            Self::Deactivated => "deactivated",
+            Self::Exhausted => "exhausted",
+        }
+    }
+}
+
+impl std::fmt::Display for LoyaltyCampaignStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "text")]
+#[serde(rename_all = "snake_case")]
+pub enum LoyaltyRewardStatus {
+    #[sqlx(rename = "queued")]
+    Queued,
+    #[sqlx(rename = "submitted")]
+    Submitted,
+    #[sqlx(rename = "paid")]
+    Paid,
+    #[sqlx(rename = "held")]
+    Held,
+    #[sqlx(rename = "failed")]
+    Failed,
+}
+
+impl LoyaltyRewardStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Submitted => "submitted",
+            Self::Paid => "paid",
+            Self::Held => "held",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl std::fmt::Display for LoyaltyRewardStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "text")]
+#[serde(rename_all = "snake_case")]
+pub enum LoyaltyRiskStatus {
+    #[sqlx(rename = "clear")]
+    Clear,
+    #[sqlx(rename = "flagged")]
+    Flagged,
+    #[sqlx(rename = "high_risk")]
+    HighRisk,
+}
+
+impl LoyaltyRiskStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Clear => "clear",
+            Self::Flagged => "flagged",
+            Self::HighRisk => "high_risk",
+        }
+    }
+
+    pub fn should_hold_reward(&self) -> bool {
+        matches!(self, Self::Flagged | Self::HighRisk)
+    }
+}
+
+impl std::fmt::Display for LoyaltyRiskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LoyaltyRewardTier {
+    Standard,
+    Vip,
+}
+
+impl LoyaltyRewardTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Vip => "vip",
+        }
+    }
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct LoyaltyCampaign {
+    pub id: Uuid,
+    pub merchant_id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub status: LoyaltyCampaignStatus,
+    pub trigger_min_amount_cngn: Decimal,
+    pub cashback_percent: Decimal,
+    pub budget_cap_cngn: Decimal,
+    pub budget_spent_cngn: Decimal,
+    pub per_customer_daily_cap_cngn: Option<Decimal>,
+    pub segment_tags: Vec<String>,
+    pub vip_cashback_multiplier: Decimal,
+    pub stellar_source_account: Option<String>,
+    pub atomic_stellar_enabled: bool,
+    pub starts_at: DateTime<Utc>,
+    pub ends_at: Option<DateTime<Utc>>,
+    pub metadata: serde_json::Value,
+    pub activated_at: Option<DateTime<Utc>>,
+    pub deactivated_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl LoyaltyCampaign {
+    pub fn budget_remaining(&self) -> Decimal {
+        (self.budget_cap_cngn - self.budget_spent_cngn).max(Decimal::ZERO)
+    }
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct LoyaltyReward {
+    pub id: Uuid,
+    pub campaign_id: Uuid,
+    pub merchant_id: Uuid,
+    pub payment_intent_id: Uuid,
+    pub customer_address: String,
+    pub transaction_amount_cngn: Decimal,
+    pub reward_amount_cngn: Decimal,
+    pub cashback_percent: Decimal,
+    pub customer_tier: String,
+    pub risk_status: LoyaltyRiskStatus,
+    pub risk_flags: Vec<String>,
+    pub status: LoyaltyRewardStatus,
+    pub stellar_tx_hash: Option<String>,
+    pub stellar_source_account: Option<String>,
+    pub idempotency_key: String,
+    pub atomicity_mode: String,
+    pub notification_status: String,
+    pub failure_code: Option<String>,
+    pub paid_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateLoyaltyCampaignRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger_min_amount_cngn: Decimal,
+    pub cashback_percent: Decimal,
+    pub budget_cap_cngn: Decimal,
+    pub per_customer_daily_cap_cngn: Option<Decimal>,
+    #[serde(default)]
+    pub segment_tags: Vec<String>,
+    pub vip_cashback_multiplier: Option<Decimal>,
+    pub stellar_source_account: Option<String>,
+    pub atomic_stellar_enabled: Option<bool>,
+    pub starts_at: Option<DateTime<Utc>>,
+    pub ends_at: Option<DateTime<Utc>>,
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LoyaltyRewardExecution {
+    pub campaign_id: Uuid,
+    pub reward_id: Uuid,
+    pub reward_amount_cngn: Decimal,
+    pub status: LoyaltyRewardStatus,
+    pub risk_status: LoyaltyRiskStatus,
+    pub atomicity_mode: String,
+    pub notification_status: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoyaltySpendReportQuery {
+    pub start_at: Option<DateTime<Utc>>,
+    pub end_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize)]
+pub struct LoyaltyMarketingSpendReport {
+    pub merchant_id: Uuid,
+    pub reward_count: i64,
+    pub total_reward_amount_cngn: Decimal,
+    pub paid_reward_amount_cngn: Decimal,
+    pub held_reward_count: i64,
+    pub risk_flagged_count: i64,
+    pub first_reward_at: Option<DateTime<Utc>>,
+    pub last_reward_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize)]
+pub struct LoyaltyCampaignSpendSummary {
+    pub campaign_id: Uuid,
+    pub campaign_name: String,
+    pub reward_count: i64,
+    pub total_reward_amount_cngn: Decimal,
+    pub paid_reward_amount_cngn: Decimal,
+    pub budget_cap_cngn: Decimal,
+    pub budget_spent_cngn: Decimal,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LoyaltyMarketingSpendResponse {
+    pub summary: LoyaltyMarketingSpendReport,
+    pub campaigns: Vec<LoyaltyCampaignSpendSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoyaltyRuleConfig {
+    pub trigger_min_amount_cngn: Decimal,
+    pub cashback_percent: Decimal,
+    pub budget_remaining_cngn: Decimal,
+    pub per_customer_daily_remaining_cngn: Option<Decimal>,
+    pub segment_tags: Vec<String>,
+    pub vip_cashback_multiplier: Decimal,
+}
+
+impl From<&LoyaltyCampaign> for LoyaltyRuleConfig {
+    fn from(campaign: &LoyaltyCampaign) -> Self {
+        Self {
+            trigger_min_amount_cngn: campaign.trigger_min_amount_cngn,
+            cashback_percent: campaign.cashback_percent,
+            budget_remaining_cngn: campaign.budget_remaining(),
+            per_customer_daily_remaining_cngn: campaign.per_customer_daily_cap_cngn,
+            segment_tags: campaign.segment_tags.clone(),
+            vip_cashback_multiplier: campaign.vip_cashback_multiplier,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LoyaltyEvaluationInput {
+    pub transaction_amount_cngn: Decimal,
+    pub customer_tags: Vec<String>,
+    pub risk: LoyaltyRiskAssessment,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoyaltyRiskAssessment {
+    pub status: LoyaltyRiskStatus,
+    pub flags: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LoyaltyRewardDecision {
+    pub eligible: bool,
+    pub reason: Option<String>,
+    pub reward_amount_cngn: Decimal,
+    pub effective_cashback_percent: Decimal,
+    pub customer_tier: LoyaltyRewardTier,
+    pub risk_status: LoyaltyRiskStatus,
+    pub risk_flags: Vec<String>,
+}
+
+impl LoyaltyRewardDecision {
+    pub fn not_eligible(reason: impl Into<String>) -> Self {
+        Self {
+            eligible: false,
+            reason: Some(reason.into()),
+            reward_amount_cngn: Decimal::ZERO,
+            effective_cashback_percent: Decimal::ZERO,
+            customer_tier: LoyaltyRewardTier::Standard,
+            risk_status: LoyaltyRiskStatus::Clear,
+            risk_flags: Vec::new(),
+        }
+    }
+}
+
+pub fn validate_campaign_request(req: &CreateLoyaltyCampaignRequest) -> Result<(), String> {
+    if req.name.trim().is_empty() {
+        return Err("Campaign name is required".to_string());
+    }
+    if req.trigger_min_amount_cngn <= Decimal::ZERO {
+        return Err("Trigger amount must be positive".to_string());
+    }
+    if req.cashback_percent <= Decimal::ZERO || req.cashback_percent > Decimal::new(100, 0) {
+        return Err("Cashback percent must be between 0 and 100".to_string());
+    }
+    if req.budget_cap_cngn <= Decimal::ZERO {
+        return Err("Budget cap must be positive".to_string());
+    }
+    if let Some(cap) = req.per_customer_daily_cap_cngn {
+        if cap <= Decimal::ZERO {
+            return Err("Per-customer daily cap must be positive".to_string());
+        }
+    }
+    if let Some(multiplier) = req.vip_cashback_multiplier {
+        if multiplier < Decimal::ONE || multiplier > Decimal::new(5, 0) {
+            return Err("VIP multiplier must be between 1 and 5".to_string());
+        }
+    }
+    if matches!((req.starts_at, req.ends_at), (Some(start), Some(end)) if end <= start) {
+        return Err("Campaign end time must be after start time".to_string());
+    }
+    Ok(())
+}
+
+pub fn calculate_cashback_amount(
+    transaction_amount_cngn: Decimal,
+    cashback_percent: Decimal,
+) -> Decimal {
+    ((transaction_amount_cngn * cashback_percent) / Decimal::new(100, 0)).round_dp(7)
+}
+
+pub fn derive_customer_tier(customer_tags: &[String]) -> LoyaltyRewardTier {
+    if customer_tags
+        .iter()
+        .any(|tag| matches!(tag.to_ascii_lowercase().as_str(), "vip" | "loyalty_vip"))
+    {
+        LoyaltyRewardTier::Vip
+    } else {
+        LoyaltyRewardTier::Standard
+    }
+}
+
+pub fn segment_matches(campaign_segment_tags: &[String], customer_tags: &[String]) -> bool {
+    if campaign_segment_tags.is_empty() {
+        return true;
+    }
+
+    let normalized_customer_tags: HashSet<String> = customer_tags
+        .iter()
+        .map(|tag| tag.trim().to_ascii_lowercase())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+
+    campaign_segment_tags
+        .iter()
+        .any(|tag| normalized_customer_tags.contains(&tag.trim().to_ascii_lowercase()))
+}
+
+pub fn assess_loyalty_risk(
+    customer_address: &str,
+    merchant_stellar_address: &str,
+    known_high_risk_wallet: bool,
+    reward_count_last_hour: i64,
+    reward_count_today: i64,
+) -> LoyaltyRiskAssessment {
+    let mut flags = Vec::new();
+
+    if known_high_risk_wallet {
+        flags.push("known_high_risk_wallet".to_string());
+    }
+    if !merchant_stellar_address.is_empty() && customer_address == merchant_stellar_address {
+        flags.push("self_rewarding_wallet".to_string());
+    }
+    if reward_count_last_hour >= 5 {
+        flags.push("rapid_repeat_rewards".to_string());
+    }
+    if reward_count_today >= 20 {
+        flags.push("daily_reward_velocity".to_string());
+    }
+
+    let status = if flags
+        .iter()
+        .any(|flag| flag == "known_high_risk_wallet" || flag == "self_rewarding_wallet")
+    {
+        LoyaltyRiskStatus::HighRisk
+    } else if flags.is_empty() {
+        LoyaltyRiskStatus::Clear
+    } else {
+        LoyaltyRiskStatus::Flagged
+    };
+
+    LoyaltyRiskAssessment { status, flags }
+}
+
+pub fn evaluate_cashback_reward(
+    config: &LoyaltyRuleConfig,
+    input: &LoyaltyEvaluationInput,
+) -> LoyaltyRewardDecision {
+    if input.transaction_amount_cngn < config.trigger_min_amount_cngn {
+        return LoyaltyRewardDecision::not_eligible("transaction_below_threshold");
+    }
+
+    if !segment_matches(&config.segment_tags, &input.customer_tags) {
+        return LoyaltyRewardDecision::not_eligible("customer_segment_not_matched");
+    }
+
+    let customer_tier = derive_customer_tier(&input.customer_tags);
+    let effective_cashback_percent = match customer_tier {
+        LoyaltyRewardTier::Standard => config.cashback_percent,
+        LoyaltyRewardTier::Vip => config.cashback_percent * config.vip_cashback_multiplier,
+    };
+    let reward_amount =
+        calculate_cashback_amount(input.transaction_amount_cngn, effective_cashback_percent);
+
+    if reward_amount <= Decimal::ZERO {
+        return LoyaltyRewardDecision::not_eligible("reward_amount_zero");
+    }
+    if reward_amount > config.budget_remaining_cngn {
+        return LoyaltyRewardDecision::not_eligible("campaign_budget_cap_exhausted");
+    }
+    if matches!(config.per_customer_daily_remaining_cngn, Some(remaining) if reward_amount > remaining)
+    {
+        return LoyaltyRewardDecision::not_eligible("customer_daily_reward_cap_exhausted");
+    }
+
+    LoyaltyRewardDecision {
+        eligible: true,
+        reason: None,
+        reward_amount_cngn: reward_amount,
+        effective_cashback_percent,
+        customer_tier,
+        risk_status: input.risk.status.clone(),
+        risk_flags: input.risk.flags.clone(),
+    }
+}
+
+pub fn customer_tags_from_metadata(metadata: &serde_json::Value) -> Vec<String> {
+    let mut tags = Vec::new();
+
+    if let Some(values) = metadata
+        .get("customer_tags")
+        .and_then(|value| value.as_array())
+    {
+        tags.extend(
+            values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .map(|value| value.to_string()),
+        );
+    }
+
+    for key in ["customer_segment", "customer_tier"] {
+        if let Some(value) = metadata.get(key).and_then(|value| value.as_str()) {
+            tags.push(value.to_string());
+        }
+    }
+
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+pub struct LoyaltyRepository {
+    pool: PgPool,
+}
+
+impl LoyaltyRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create_campaign(
+        &self,
+        merchant_id: Uuid,
+        req: CreateLoyaltyCampaignRequest,
+    ) -> Result<LoyaltyCampaign, DatabaseError> {
+        sqlx::query_as::<_, LoyaltyCampaign>(
+            r#"
+            INSERT INTO merchant_loyalty_campaigns (
+                merchant_id, name, description, trigger_min_amount_cngn,
+                cashback_percent, budget_cap_cngn, per_customer_daily_cap_cngn,
+                segment_tags, vip_cashback_multiplier, stellar_source_account,
+                atomic_stellar_enabled, starts_at, ends_at, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, COALESCE($12, NOW()), $13, $14)
+            RETURNING *
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(req.name.trim())
+        .bind(req.description)
+        .bind(req.trigger_min_amount_cngn)
+        .bind(req.cashback_percent)
+        .bind(req.budget_cap_cngn)
+        .bind(req.per_customer_daily_cap_cngn)
+        .bind(req.segment_tags)
+        .bind(req.vip_cashback_multiplier.unwrap_or(Decimal::ONE))
+        .bind(req.stellar_source_account)
+        .bind(req.atomic_stellar_enabled.unwrap_or(true))
+        .bind(req.starts_at)
+        .bind(req.ends_at)
+        .bind(req.metadata.unwrap_or_else(|| serde_json::json!({})))
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn list_campaigns(
+        &self,
+        merchant_id: Uuid,
+    ) -> Result<Vec<LoyaltyCampaign>, DatabaseError> {
+        sqlx::query_as::<_, LoyaltyCampaign>(
+            r#"
+            SELECT *
+            FROM merchant_loyalty_campaigns
+            WHERE merchant_id = $1
+            ORDER BY created_at DESC
+            "#,
+        )
+        .bind(merchant_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn set_campaign_status(
+        &self,
+        merchant_id: Uuid,
+        campaign_id: Uuid,
+        status: LoyaltyCampaignStatus,
+    ) -> Result<LoyaltyCampaign, DatabaseError> {
+        sqlx::query_as::<_, LoyaltyCampaign>(
+            r#"
+            UPDATE merchant_loyalty_campaigns
+            SET status = $3,
+                activated_at = CASE WHEN $3 = 'active' THEN NOW() ELSE activated_at END,
+                deactivated_at = CASE WHEN $3 = 'deactivated' THEN NOW() ELSE deactivated_at END
+            WHERE id = $1 AND merchant_id = $2
+            RETURNING *
+            "#,
+        )
+        .bind(campaign_id)
+        .bind(merchant_id)
+        .bind(status.as_str())
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn active_campaigns_for_payment(
+        &self,
+        merchant_id: Uuid,
+        amount_cngn: Decimal,
+    ) -> Result<Vec<LoyaltyCampaign>, DatabaseError> {
+        sqlx::query_as::<_, LoyaltyCampaign>(
+            r#"
+            SELECT *
+            FROM merchant_loyalty_campaigns
+            WHERE merchant_id = $1
+              AND status = 'active'
+              AND trigger_min_amount_cngn <= $2
+              AND starts_at <= NOW()
+              AND (ends_at IS NULL OR ends_at > NOW())
+              AND budget_spent_cngn < budget_cap_cngn
+            ORDER BY created_at ASC
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(amount_cngn)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn customer_tags_for_wallet(
+        &self,
+        merchant_id: Uuid,
+        wallet_address: &str,
+    ) -> Result<Vec<String>, DatabaseError> {
+        let row: Option<(Vec<String>,)> = sqlx::query_as(
+            r#"
+            SELECT tags
+            FROM merchant_customer_profiles
+            WHERE merchant_id = $1 AND wallet_address = $2
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(wallet_address)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(row.map(|(tags,)| tags).unwrap_or_default())
+    }
+
+    pub async fn high_risk_wallet_active(
+        &self,
+        wallet_address: &str,
+    ) -> Result<bool, DatabaseError> {
+        let active: (bool,) = sqlx::query_as(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM merchant_loyalty_risk_wallets
+                WHERE wallet_address = $1 AND is_active = true
+            )
+            "#,
+        )
+        .bind(wallet_address)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(active.0)
+    }
+
+    pub async fn reward_count_since(
+        &self,
+        merchant_id: Uuid,
+        wallet_address: &str,
+        since: DateTime<Utc>,
+    ) -> Result<i64, DatabaseError> {
+        let count: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM merchant_loyalty_rewards
+            WHERE merchant_id = $1
+              AND customer_address = $2
+              AND created_at >= $3
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(wallet_address)
+        .bind(since)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(count.0)
+    }
+
+    pub async fn reward_amount_since(
+        &self,
+        merchant_id: Uuid,
+        wallet_address: &str,
+        campaign_id: Uuid,
+        since: DateTime<Utc>,
+    ) -> Result<Decimal, DatabaseError> {
+        let total: (Decimal,) = sqlx::query_as(
+            r#"
+            SELECT COALESCE(SUM(reward_amount_cngn), 0)
+            FROM merchant_loyalty_rewards
+            WHERE merchant_id = $1
+              AND customer_address = $2
+              AND campaign_id = $3
+              AND created_at >= $4
+              AND status IN ('queued', 'submitted', 'paid', 'held')
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(wallet_address)
+        .bind(campaign_id)
+        .bind(since)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(total.0)
+    }
+
+    pub async fn reserve_reward(
+        &self,
+        campaign: &LoyaltyCampaign,
+        payment_intent: &MerchantPaymentIntent,
+        decision: &LoyaltyRewardDecision,
+        customer_address: &str,
+        stellar_source_account: Option<&str>,
+    ) -> Result<Option<LoyaltyReward>, DatabaseError> {
+        let mut tx = self.pool.begin().await.map_err(DatabaseError::from_sqlx)?;
+
+        let existing = sqlx::query_as::<_, LoyaltyReward>(
+            r#"
+            SELECT *
+            FROM merchant_loyalty_rewards
+            WHERE campaign_id = $1 AND payment_intent_id = $2
+            "#,
+        )
+        .bind(campaign.id)
+        .bind(payment_intent.id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        if existing.is_some() {
+            tx.commit().await.map_err(DatabaseError::from_sqlx)?;
+            return Ok(existing);
+        }
+
+        let updated_campaign = sqlx::query_as::<_, LoyaltyCampaign>(
+            r#"
+            UPDATE merchant_loyalty_campaigns
+            SET budget_spent_cngn = budget_spent_cngn + $2,
+                status = CASE
+                    WHEN budget_spent_cngn + $2 >= budget_cap_cngn THEN 'exhausted'
+                    ELSE status
+                END
+            WHERE id = $1
+              AND status = 'active'
+              AND budget_spent_cngn + $2 <= budget_cap_cngn
+            RETURNING *
+            "#,
+        )
+        .bind(campaign.id)
+        .bind(decision.reward_amount_cngn)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        if updated_campaign.is_none() {
+            tx.commit().await.map_err(DatabaseError::from_sqlx)?;
+            return Ok(None);
+        }
+
+        let reward_status = if decision.risk_status.should_hold_reward() {
+            LoyaltyRewardStatus::Held
+        } else {
+            LoyaltyRewardStatus::Queued
+        };
+        let idempotency_key = format!("loyalty:{}:{}", campaign.id, payment_intent.id);
+        let atomicity_mode = if campaign.atomic_stellar_enabled && stellar_source_account.is_some()
+        {
+            "stellar_payment_channel"
+        } else {
+            "post_receipt_queue"
+        };
+
+        let reward = sqlx::query_as::<_, LoyaltyReward>(
+            r#"
+            INSERT INTO merchant_loyalty_rewards (
+                campaign_id, merchant_id, payment_intent_id, customer_address,
+                transaction_amount_cngn, reward_amount_cngn, cashback_percent,
+                customer_tier, risk_status, risk_flags, status, stellar_source_account,
+                idempotency_key, atomicity_mode, notification_status
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'queued')
+            RETURNING *
+            "#,
+        )
+        .bind(campaign.id)
+        .bind(payment_intent.merchant_id)
+        .bind(payment_intent.id)
+        .bind(customer_address)
+        .bind(payment_intent.amount_cngn)
+        .bind(decision.reward_amount_cngn)
+        .bind(decision.effective_cashback_percent)
+        .bind(decision.customer_tier.as_str())
+        .bind(decision.risk_status.as_str())
+        .bind(&decision.risk_flags)
+        .bind(reward_status.as_str())
+        .bind(stellar_source_account)
+        .bind(idempotency_key)
+        .bind(atomicity_mode)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        tx.commit().await.map_err(DatabaseError::from_sqlx)?;
+        Ok(Some(reward))
+    }
+
+    pub async fn mark_reward_submitted(
+        &self,
+        reward_id: Uuid,
+        stellar_tx_hash: &str,
+    ) -> Result<LoyaltyReward, DatabaseError> {
+        sqlx::query_as::<_, LoyaltyReward>(
+            r#"
+            UPDATE merchant_loyalty_rewards
+            SET status = 'paid',
+                stellar_tx_hash = $2,
+                paid_at = NOW()
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(reward_id)
+        .bind(stellar_tx_hash)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn mark_reward_failed(
+        &self,
+        reward_id: Uuid,
+        failure_code: &str,
+    ) -> Result<LoyaltyReward, DatabaseError> {
+        sqlx::query_as::<_, LoyaltyReward>(
+            r#"
+            UPDATE merchant_loyalty_rewards
+            SET status = 'failed',
+                failure_code = $2
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(reward_id)
+        .bind(failure_code)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn queue_reward_notification(
+        &self,
+        reward: &LoyaltyReward,
+        event_type: &str,
+    ) -> Result<(), DatabaseError> {
+        sqlx::query(
+            r#"
+            INSERT INTO merchant_loyalty_reward_notifications (
+                reward_id, merchant_id, customer_address, event_type, payload, status
+            )
+            VALUES ($1, $2, $3, $4, $5, 'queued')
+            ON CONFLICT (reward_id, event_type) DO NOTHING
+            "#,
+        )
+        .bind(reward.id)
+        .bind(reward.merchant_id)
+        .bind(&reward.customer_address)
+        .bind(event_type)
+        .bind(serde_json::json!({
+            "reward_id": reward.id,
+            "campaign_id": reward.campaign_id,
+            "amount_cngn": reward.reward_amount_cngn,
+            "status": reward.status,
+        }))
+        .execute(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(())
+    }
+
+    pub async fn spend_report(
+        &self,
+        merchant_id: Uuid,
+        query: LoyaltySpendReportQuery,
+    ) -> Result<LoyaltyMarketingSpendResponse, DatabaseError> {
+        let summary = sqlx::query_as::<_, LoyaltyMarketingSpendReport>(
+            r#"
+            SELECT
+                $1::uuid AS merchant_id,
+                COUNT(r.id)::bigint AS reward_count,
+                COALESCE(SUM(r.reward_amount_cngn), 0) AS total_reward_amount_cngn,
+                COALESCE(SUM(r.reward_amount_cngn) FILTER (WHERE r.status = 'paid'), 0) AS paid_reward_amount_cngn,
+                (COUNT(r.id) FILTER (WHERE r.status = 'held'))::bigint AS held_reward_count,
+                (COUNT(r.id) FILTER (WHERE r.risk_status <> 'clear'))::bigint AS risk_flagged_count,
+                MIN(r.created_at) AS first_reward_at,
+                MAX(r.created_at) AS last_reward_at
+            FROM merchant_loyalty_rewards r
+            WHERE r.merchant_id = $1
+              AND ($2::timestamptz IS NULL OR r.created_at >= $2)
+              AND ($3::timestamptz IS NULL OR r.created_at <= $3)
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(query.start_at)
+        .bind(query.end_at)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        let campaigns = sqlx::query_as::<_, LoyaltyCampaignSpendSummary>(
+            r#"
+            SELECT
+                c.id AS campaign_id,
+                c.name AS campaign_name,
+                COUNT(r.id)::bigint AS reward_count,
+                COALESCE(SUM(r.reward_amount_cngn), 0) AS total_reward_amount_cngn,
+                COALESCE(SUM(r.reward_amount_cngn) FILTER (WHERE r.status = 'paid'), 0) AS paid_reward_amount_cngn,
+                c.budget_cap_cngn,
+                c.budget_spent_cngn
+            FROM merchant_loyalty_campaigns c
+            LEFT JOIN merchant_loyalty_rewards r
+              ON r.campaign_id = c.id
+             AND ($2::timestamptz IS NULL OR r.created_at >= $2)
+             AND ($3::timestamptz IS NULL OR r.created_at <= $3)
+            WHERE c.merchant_id = $1
+            GROUP BY c.id, c.name, c.budget_cap_cngn, c.budget_spent_cngn
+            ORDER BY c.created_at DESC
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(query.start_at)
+        .bind(query.end_at)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(LoyaltyMarketingSpendResponse { summary, campaigns })
+    }
+}

--- a/src/merchant_gateway/mod.rs
+++ b/src/merchant_gateway/mod.rs
@@ -8,6 +8,7 @@ pub mod handlers;
 pub mod routes;
 pub mod webhook_engine;
 pub mod api_key_service;
+pub mod loyalty;
 pub mod metrics;
 
 #[cfg(test)]

--- a/src/merchant_gateway/routes.rs
+++ b/src/merchant_gateway/routes.rs
@@ -12,27 +12,35 @@ use sqlx::PgPool;
 use std::sync::Arc;
 
 /// Build Merchant Gateway routes with API key authentication
-pub fn merchant_gateway_routes(
-    service: Arc<MerchantGatewayService>,
-    pool: Arc<PgPool>,
-) -> Router {
+pub fn merchant_gateway_routes(service: Arc<MerchantGatewayService>, pool: Arc<PgPool>) -> Router {
     Router::new()
         // Payment Intent endpoints
         .route("/payment-intents", post(handlers::create_payment_intent))
         .route("/payment-intents", get(handlers::list_payment_intents))
-        .route(
-            "/payment-intents/:id",
-            get(handlers::get_payment_intent),
-        )
+        .route("/payment-intents/:id", get(handlers::get_payment_intent))
         .route(
             "/payment-intents/:id/cancel",
             post(handlers::cancel_payment_intent),
         )
-        // Webhook utility
+        // Loyalty and cashback campaigns
         .route(
-            "/webhooks/verify",
-            post(handlers::verify_webhook_signature),
+            "/loyalty/campaigns",
+            get(handlers::list_loyalty_campaigns).post(handlers::create_loyalty_campaign),
         )
+        .route(
+            "/loyalty/campaigns/:id/activate",
+            post(handlers::activate_loyalty_campaign),
+        )
+        .route(
+            "/loyalty/campaigns/:id/deactivate",
+            post(handlers::deactivate_loyalty_campaign),
+        )
+        .route(
+            "/loyalty/reports/spend",
+            get(handlers::loyalty_spend_report),
+        )
+        // Webhook utility
+        .route("/webhooks/verify", post(handlers::verify_webhook_signature))
         // Apply API key authentication middleware
         .layer(middleware::from_fn_with_state(
             (pool, "merchant:write", "mainnet"),

--- a/src/merchant_gateway/service.rs
+++ b/src/merchant_gateway/service.rs
@@ -2,14 +2,16 @@
 
 use crate::chains::stellar::client::StellarClient;
 use crate::error::AppError;
+use crate::merchant_gateway::loyalty::*;
 use crate::merchant_gateway::models::*;
 use crate::merchant_gateway::repository::*;
 use crate::merchant_gateway::webhook_engine::WebhookEngine;
+use crate::services::cngn_payment_builder::{CngnPaymentBuilder, PaymentMemo, PaymentOperation};
 use chrono::{Duration, Utc};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::sync::Arc;
-use tracing::{info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
 
 // ============================================================================
@@ -19,6 +21,7 @@ use uuid::Uuid;
 pub struct MerchantGatewayService {
     merchant_repo: Arc<MerchantRepository>,
     payment_intent_repo: Arc<PaymentIntentRepository>,
+    loyalty_repo: Arc<LoyaltyRepository>,
     webhook_engine: Arc<WebhookEngine>,
     stellar_client: Arc<StellarClient>,
     default_expiry_minutes: i64,
@@ -33,6 +36,7 @@ impl MerchantGatewayService {
         Self {
             merchant_repo: Arc::new(MerchantRepository::new(pool.clone())),
             payment_intent_repo: Arc::new(PaymentIntentRepository::new(pool.clone())),
+            loyalty_repo: Arc::new(LoyaltyRepository::new(pool.clone())),
             webhook_engine,
             stellar_client,
             default_expiry_minutes: 15,
@@ -91,7 +95,9 @@ impl MerchantGatewayService {
         let memo = self.generate_unique_memo().await?;
 
         // Calculate expiry
-        let expiry_minutes = request.expiry_minutes.unwrap_or(self.default_expiry_minutes);
+        let expiry_minutes = request
+            .expiry_minutes
+            .unwrap_or(self.default_expiry_minutes);
         let expires_at = Utc::now() + Duration::minutes(expiry_minutes);
 
         // Create payment intent
@@ -164,7 +170,9 @@ impl MerchantGatewayService {
         merchant_id: Uuid,
         payment_intent_id: Uuid,
     ) -> Result<MerchantPaymentIntent, AppError> {
-        let payment_intent = self.get_payment_intent(merchant_id, payment_intent_id).await?;
+        let payment_intent = self
+            .get_payment_intent(merchant_id, payment_intent_id)
+            .await?;
 
         if payment_intent.status != PaymentIntentStatus::Pending {
             return Err(AppError::BadRequest(
@@ -213,7 +221,9 @@ impl MerchantGatewayService {
             .find_by_memo(memo)
             .await
             .map_err(|e| AppError::DatabaseError(e.to_string()))?
-            .ok_or_else(|| AppError::NotFound(format!("No payment intent found for memo: {}", memo)))?;
+            .ok_or_else(|| {
+                AppError::NotFound(format!("No payment intent found for memo: {}", memo))
+            })?;
 
         // Idempotency: already paid
         if payment_intent.status == PaymentIntentStatus::Paid {
@@ -232,7 +242,9 @@ impl MerchantGatewayService {
                 memo = %memo,
                 "Payment received for expired intent"
             );
-            return Err(AppError::BadRequest("Payment intent has expired".to_string()));
+            return Err(AppError::BadRequest(
+                "Payment intent has expired".to_string(),
+            ));
         }
 
         // Validate amount (allow slight overpayment)
@@ -243,7 +255,9 @@ impl MerchantGatewayService {
                 received = %amount,
                 "Underpayment detected"
             );
-            return Err(AppError::BadRequest("Insufficient payment amount".to_string()));
+            return Err(AppError::BadRequest(
+                "Insufficient payment amount".to_string(),
+            ));
         }
 
         // Update payment intent to paid
@@ -266,6 +280,24 @@ impl MerchantGatewayService {
             "Payment confirmed - transitioning to PAID"
         );
 
+        match self.execute_loyalty_rewards_for_payment(&updated).await {
+            Ok(executions) if !executions.is_empty() => {
+                info!(
+                    payment_intent_id = %updated.id,
+                    reward_count = executions.len(),
+                    "Loyalty rewards evaluated for paid merchant sale"
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!(
+                    payment_intent_id = %updated.id,
+                    error = %e,
+                    "Loyalty reward evaluation failed after merchant receipt"
+                );
+            }
+        }
+
         // Send webhook notification (async)
         let webhook_engine = self.webhook_engine.clone();
         let merchant_repo = self.merchant_repo.clone();
@@ -284,10 +316,7 @@ impl MerchantGatewayService {
     /// Mark payment as confirmed (after blockchain confirmations)
     /// Target: <5 seconds from blockchain confirmation
     #[instrument(skip(self))]
-    pub async fn mark_payment_confirmed(
-        &self,
-        payment_intent_id: Uuid,
-    ) -> Result<(), AppError> {
+    pub async fn mark_payment_confirmed(&self, payment_intent_id: Uuid) -> Result<(), AppError> {
         let payment_intent = self
             .payment_intent_repo
             .mark_confirmed(payment_intent_id)
@@ -316,9 +345,328 @@ impl MerchantGatewayService {
             .map_err(|e| AppError::DatabaseError(e.to_string()))
     }
 
+    /// Create a merchant cashback campaign in draft state.
+    #[instrument(skip(self, request))]
+    pub async fn create_loyalty_campaign(
+        &self,
+        merchant_id: Uuid,
+        request: CreateLoyaltyCampaignRequest,
+    ) -> Result<LoyaltyCampaign, AppError> {
+        validate_campaign_request(&request).map_err(AppError::BadRequest)?;
+
+        let merchant = self
+            .merchant_repo
+            .find_by_id(merchant_id)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?
+            .ok_or_else(|| AppError::NotFound("Merchant not found".to_string()))?;
+
+        if !merchant.is_active {
+            return Err(AppError::BadRequest("Merchant is not active".to_string()));
+        }
+
+        self.loyalty_repo
+            .create_campaign(merchant_id, request)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn list_loyalty_campaigns(
+        &self,
+        merchant_id: Uuid,
+    ) -> Result<Vec<LoyaltyCampaign>, AppError> {
+        self.loyalty_repo
+            .list_campaigns(merchant_id)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn activate_loyalty_campaign(
+        &self,
+        merchant_id: Uuid,
+        campaign_id: Uuid,
+    ) -> Result<LoyaltyCampaign, AppError> {
+        self.loyalty_repo
+            .set_campaign_status(merchant_id, campaign_id, LoyaltyCampaignStatus::Active)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn deactivate_loyalty_campaign(
+        &self,
+        merchant_id: Uuid,
+        campaign_id: Uuid,
+    ) -> Result<LoyaltyCampaign, AppError> {
+        self.loyalty_repo
+            .set_campaign_status(merchant_id, campaign_id, LoyaltyCampaignStatus::Deactivated)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))
+    }
+
+    #[instrument(skip(self, query))]
+    pub async fn loyalty_spend_report(
+        &self,
+        merchant_id: Uuid,
+        query: LoyaltySpendReportQuery,
+    ) -> Result<LoyaltyMarketingSpendResponse, AppError> {
+        self.loyalty_repo
+            .spend_report(merchant_id, query)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))
+    }
+
     // ========================================================================
     // PRIVATE HELPERS
     // ========================================================================
+
+    async fn execute_loyalty_rewards_for_payment(
+        &self,
+        payment_intent: &MerchantPaymentIntent,
+    ) -> Result<Vec<LoyaltyRewardExecution>, AppError> {
+        let Some(customer_address) = payment_intent.customer_address.as_deref() else {
+            return Ok(Vec::new());
+        };
+
+        let merchant = self
+            .merchant_repo
+            .find_by_id(payment_intent.merchant_id)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?
+            .ok_or_else(|| AppError::NotFound("Merchant not found".to_string()))?;
+
+        let campaigns = self
+            .loyalty_repo
+            .active_campaigns_for_payment(payment_intent.merchant_id, payment_intent.amount_cngn)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        if campaigns.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut customer_tags = customer_tags_from_metadata(&payment_intent.metadata);
+        match self
+            .loyalty_repo
+            .customer_tags_for_wallet(payment_intent.merchant_id, customer_address)
+            .await
+        {
+            Ok(mut crm_tags) => customer_tags.append(&mut crm_tags),
+            Err(e) => {
+                warn!(
+                    merchant_id = %payment_intent.merchant_id,
+                    error = %e,
+                    "Could not load CRM tags for loyalty evaluation"
+                );
+            }
+        }
+        customer_tags.sort();
+        customer_tags.dedup();
+
+        let now = Utc::now();
+        let last_hour = now - Duration::hours(1);
+        let last_day = now - Duration::hours(24);
+        let high_risk_wallet = self
+            .loyalty_repo
+            .high_risk_wallet_active(customer_address)
+            .await
+            .unwrap_or_else(|e| {
+                warn!(
+                    merchant_id = %payment_intent.merchant_id,
+                    error = %e,
+                    "Could not load loyalty risk wallet list"
+                );
+                false
+            });
+        let reward_count_last_hour = self
+            .loyalty_repo
+            .reward_count_since(payment_intent.merchant_id, customer_address, last_hour)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+        let reward_count_today = self
+            .loyalty_repo
+            .reward_count_since(payment_intent.merchant_id, customer_address, last_day)
+            .await
+            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+        let risk = assess_loyalty_risk(
+            customer_address,
+            &merchant.stellar_address,
+            high_risk_wallet,
+            reward_count_last_hour,
+            reward_count_today,
+        );
+
+        let mut executions = Vec::new();
+
+        for campaign in campaigns {
+            let spent_today = self
+                .loyalty_repo
+                .reward_amount_since(
+                    payment_intent.merchant_id,
+                    customer_address,
+                    campaign.id,
+                    last_day,
+                )
+                .await
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+            let mut config = LoyaltyRuleConfig::from(&campaign);
+            config.per_customer_daily_remaining_cngn = campaign
+                .per_customer_daily_cap_cngn
+                .map(|cap| (cap - spent_today).max(Decimal::ZERO));
+
+            let decision = evaluate_cashback_reward(
+                &config,
+                &LoyaltyEvaluationInput {
+                    transaction_amount_cngn: payment_intent.amount_cngn,
+                    customer_tags: customer_tags.clone(),
+                    risk: risk.clone(),
+                },
+            );
+
+            if !decision.eligible {
+                info!(
+                    campaign_id = %campaign.id,
+                    payment_intent_id = %payment_intent.id,
+                    reason = decision.reason.as_deref().unwrap_or("not_eligible"),
+                    "Loyalty campaign did not qualify for reward"
+                );
+                continue;
+            }
+
+            let env_source = std::env::var("LOYALTY_REWARD_SOURCE_ADDRESS").ok();
+            let stellar_source_account = campaign
+                .stellar_source_account
+                .as_deref()
+                .or(env_source.as_deref());
+
+            let Some(mut reward) = self
+                .loyalty_repo
+                .reserve_reward(
+                    &campaign,
+                    payment_intent,
+                    &decision,
+                    customer_address,
+                    stellar_source_account,
+                )
+                .await
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?
+            else {
+                warn!(
+                    campaign_id = %campaign.id,
+                    payment_intent_id = %payment_intent.id,
+                    "Loyalty reward skipped because campaign budget cap was reached"
+                );
+                continue;
+            };
+
+            let event_type = if reward.status == LoyaltyRewardStatus::Held {
+                "loyalty.cashback.held"
+            } else {
+                "loyalty.cashback.issued"
+            };
+            self.loyalty_repo
+                .queue_reward_notification(&reward, event_type)
+                .await
+                .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+            if reward.status == LoyaltyRewardStatus::Queued {
+                match self.dispatch_loyalty_reward_payout(&reward).await {
+                    Ok(Some(updated)) => reward = updated,
+                    Ok(None) => {}
+                    Err(e) => {
+                        error!(
+                            reward_id = %reward.id,
+                            campaign_id = %campaign.id,
+                            error = %e,
+                            "Loyalty reward Stellar payout failed"
+                        );
+                        reward = self
+                            .loyalty_repo
+                            .mark_reward_failed(reward.id, "stellar_payout_failed")
+                            .await
+                            .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+                    }
+                }
+            }
+
+            executions.push(LoyaltyRewardExecution {
+                campaign_id: campaign.id,
+                reward_id: reward.id,
+                reward_amount_cngn: reward.reward_amount_cngn,
+                status: reward.status,
+                risk_status: reward.risk_status,
+                atomicity_mode: reward.atomicity_mode,
+                notification_status: reward.notification_status,
+            });
+        }
+
+        Ok(executions)
+    }
+
+    async fn dispatch_loyalty_reward_payout(
+        &self,
+        reward: &LoyaltyReward,
+    ) -> Result<Option<LoyaltyReward>, AppError> {
+        let env_source = std::env::var("LOYALTY_REWARD_SOURCE_ADDRESS").ok();
+        let Some(source_address) = reward
+            .stellar_source_account
+            .as_deref()
+            .or(env_source.as_deref())
+        else {
+            info!(reward_id = %reward.id, "Loyalty payout source account is not configured");
+            return Ok(None);
+        };
+
+        let Some(source_secret) = std::env::var("LOYALTY_REWARD_SOURCE_SECRET").ok() else {
+            info!(reward_id = %reward.id, "Loyalty payout source secret is not configured");
+            return Ok(None);
+        };
+
+        let cngn_issuer = std::env::var("LOYALTY_CNGN_ISSUER")
+            .or_else(|_| std::env::var("CNGN_ISSUER_MAINNET"))
+            .or_else(|_| std::env::var("CNGN_ISSUER_TESTNET"))
+            .ok();
+        let Some(cngn_issuer) = cngn_issuer else {
+            info!(reward_id = %reward.id, "cNGN issuer is not configured for loyalty payout");
+            return Ok(None);
+        };
+
+        let builder = CngnPaymentBuilder::new((*self.stellar_client).clone());
+        let amount = reward.reward_amount_cngn.round_dp(7).to_string();
+        let reward_id = reward.id.simple().to_string();
+        let memo = PaymentMemo::Text(format!("CB-{}", &reward_id[..8]));
+        let draft = builder
+            .build_payment(
+                PaymentOperation {
+                    source: source_address.to_string(),
+                    destination: reward.customer_address.clone(),
+                    amount,
+                    asset_code: "cNGN".to_string(),
+                    asset_issuer: cngn_issuer,
+                },
+                memo,
+                None,
+            )
+            .await?;
+        let signed = builder.sign_transaction(draft, &source_secret)?;
+        let response = self
+            .stellar_client
+            .submit_transaction_xdr(&signed.envelope_xdr)
+            .await?;
+        let tx_hash = response["hash"]
+            .as_str()
+            .unwrap_or(&signed.hash)
+            .to_string();
+
+        self.loyalty_repo
+            .mark_reward_submitted(reward.id, &tx_hash)
+            .await
+            .map(Some)
+            .map_err(|e| AppError::DatabaseError(e.to_string()))
+    }
 
     async fn generate_unique_memo(&self) -> Result<String, AppError> {
         // Use database function for atomic uniqueness
@@ -336,9 +684,7 @@ impl MerchantGatewayService {
         // Build Stellar payment URL for mobile wallets
         let payment_url = format!(
             "web+stellar:pay?destination={}&amount={}&asset_code=cNGN&memo={}",
-            payment_intent.destination_address,
-            payment_intent.amount_cngn,
-            payment_intent.memo
+            payment_intent.destination_address, payment_intent.amount_cngn, payment_intent.memo
         );
 
         PaymentIntentResponse {

--- a/tests/merchant_loyalty_tests.rs
+++ b/tests/merchant_loyalty_tests.rs
@@ -1,0 +1,177 @@
+use rust_decimal::Decimal;
+use std::str::FromStr;
+use Bitmesh_backend::merchant_gateway::loyalty::{
+    assess_loyalty_risk, customer_tags_from_metadata, evaluate_cashback_reward,
+    validate_campaign_request, CreateLoyaltyCampaignRequest, LoyaltyEvaluationInput,
+    LoyaltyRewardTier, LoyaltyRiskAssessment, LoyaltyRiskStatus, LoyaltyRuleConfig,
+};
+
+fn dec(value: &str) -> Decimal {
+    Decimal::from_str(value).unwrap()
+}
+
+fn base_rule() -> LoyaltyRuleConfig {
+    LoyaltyRuleConfig {
+        trigger_min_amount_cngn: dec("1000"),
+        cashback_percent: dec("1"),
+        budget_remaining_cngn: dec("500"),
+        per_customer_daily_remaining_cngn: None,
+        segment_tags: Vec::new(),
+        vip_cashback_multiplier: dec("1"),
+    }
+}
+
+#[test]
+fn one_percent_cashback_campaign_qualifies_sale() {
+    let decision = evaluate_cashback_reward(
+        &base_rule(),
+        &LoyaltyEvaluationInput {
+            transaction_amount_cngn: dec("2500"),
+            customer_tags: Vec::new(),
+            risk: LoyaltyRiskAssessment {
+                status: LoyaltyRiskStatus::Clear,
+                flags: Vec::new(),
+            },
+        },
+    );
+
+    assert!(decision.eligible);
+    assert_eq!(decision.reward_amount_cngn, dec("25.0000000"));
+    assert_eq!(decision.effective_cashback_percent, dec("1"));
+    assert_eq!(decision.customer_tier, LoyaltyRewardTier::Standard);
+}
+
+#[test]
+fn campaign_budget_cap_blocks_reward_that_would_overspend() {
+    let mut rule = base_rule();
+    rule.budget_remaining_cngn = dec("10");
+
+    let decision = evaluate_cashback_reward(
+        &rule,
+        &LoyaltyEvaluationInput {
+            transaction_amount_cngn: dec("2500"),
+            customer_tags: Vec::new(),
+            risk: LoyaltyRiskAssessment {
+                status: LoyaltyRiskStatus::Clear,
+                flags: Vec::new(),
+            },
+        },
+    );
+
+    assert!(!decision.eligible);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("campaign_budget_cap_exhausted")
+    );
+}
+
+#[test]
+fn vip_segment_receives_tier_multiplier() {
+    let mut rule = base_rule();
+    rule.segment_tags = vec!["vip".to_string()];
+    rule.vip_cashback_multiplier = dec("2");
+
+    let decision = evaluate_cashback_reward(
+        &rule,
+        &LoyaltyEvaluationInput {
+            transaction_amount_cngn: dec("3000"),
+            customer_tags: vec!["VIP".to_string(), "lagos".to_string()],
+            risk: LoyaltyRiskAssessment {
+                status: LoyaltyRiskStatus::Clear,
+                flags: Vec::new(),
+            },
+        },
+    );
+
+    assert!(decision.eligible);
+    assert_eq!(decision.customer_tier, LoyaltyRewardTier::Vip);
+    assert_eq!(decision.effective_cashback_percent, dec("2"));
+    assert_eq!(decision.reward_amount_cngn, dec("60.0000000"));
+}
+
+#[test]
+fn high_risk_wallet_is_flagged_and_reward_is_held() {
+    let risk = assess_loyalty_risk(
+        "GCUSTOMERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "GMERCHANTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        true,
+        0,
+        0,
+    );
+    let decision = evaluate_cashback_reward(
+        &base_rule(),
+        &LoyaltyEvaluationInput {
+            transaction_amount_cngn: dec("2000"),
+            customer_tags: Vec::new(),
+            risk,
+        },
+    );
+
+    assert!(decision.eligible);
+    assert_eq!(decision.risk_status, LoyaltyRiskStatus::HighRisk);
+    assert!(decision
+        .risk_flags
+        .iter()
+        .any(|flag| flag == "known_high_risk_wallet"));
+    assert!(decision.risk_status.should_hold_reward());
+}
+
+#[test]
+fn per_customer_daily_cap_blocks_excess_reward() {
+    let mut rule = base_rule();
+    rule.per_customer_daily_remaining_cngn = Some(dec("5"));
+
+    let decision = evaluate_cashback_reward(
+        &rule,
+        &LoyaltyEvaluationInput {
+            transaction_amount_cngn: dec("1000"),
+            customer_tags: Vec::new(),
+            risk: LoyaltyRiskAssessment {
+                status: LoyaltyRiskStatus::Clear,
+                flags: Vec::new(),
+            },
+        },
+    );
+
+    assert!(!decision.eligible);
+    assert_eq!(
+        decision.reason.as_deref(),
+        Some("customer_daily_reward_cap_exhausted")
+    );
+}
+
+#[test]
+fn metadata_customer_tags_support_segments_and_tiers() {
+    let metadata = serde_json::json!({
+        "customer_tags": ["repeat", "vip"],
+        "customer_segment": "weekend_buyers",
+        "customer_tier": "vip"
+    });
+
+    let tags = customer_tags_from_metadata(&metadata);
+
+    assert!(tags.contains(&"repeat".to_string()));
+    assert!(tags.contains(&"vip".to_string()));
+    assert!(tags.contains(&"weekend_buyers".to_string()));
+}
+
+#[test]
+fn campaign_request_validation_rejects_invalid_percent() {
+    let req = CreateLoyaltyCampaignRequest {
+        name: "Bad cashback".to_string(),
+        description: None,
+        trigger_min_amount_cngn: dec("1000"),
+        cashback_percent: dec("101"),
+        budget_cap_cngn: dec("10000"),
+        per_customer_daily_cap_cngn: None,
+        segment_tags: Vec::new(),
+        vip_cashback_multiplier: None,
+        stellar_source_account: None,
+        atomic_stellar_enabled: Some(true),
+        starts_at: None,
+        ends_at: None,
+        metadata: None,
+    };
+
+    assert!(validate_campaign_request(&req).is_err());
+}


### PR DESCRIPTION
Closes #346

---

Implements the merchant loyalty cashback engine for issue #332. Branch contains loyalty rules, reward tables, merchant APIs, budget reservation stubs, CRM tagging support, and focused unit test structure.