### PR TITLE
feat: add async webhook delivery queues (#346)

### DIFF
--- a/migrations/20260424020000_async_webhook_delivery.sql
+++ b/migrations/20260424020000_async_webhook_delivery.sql
@@ -1,0 +1,91 @@
+-- ============================================================================
+-- Async Webhook Delivery & Retry Queues
+-- Issue #346
+-- ============================================================================
+-- Adds explicit queue metadata, deterministic idempotency keys, dead-letter
+-- capture, and endpoint circuit breakers to merchant webhook delivery.
+-- ============================================================================
+
+ALTER TABLE merchant_webhook_deliveries
+    ADD COLUMN IF NOT EXISTS idempotency_key TEXT,
+    ADD COLUMN IF NOT EXISTS queue_name TEXT NOT NULL DEFAULT 'primary',
+    ADD COLUMN IF NOT EXISTS locked_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS locked_by TEXT,
+    ADD COLUMN IF NOT EXISTS dead_lettered_at TIMESTAMPTZ;
+
+UPDATE merchant_webhook_deliveries
+SET idempotency_key = CONCAT('legacy-webhook:', id::text)
+WHERE idempotency_key IS NULL;
+
+ALTER TABLE merchant_webhook_deliveries
+    ALTER COLUMN idempotency_key SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_merchant_webhook_deliveries_idempotency
+    ON merchant_webhook_deliveries (idempotency_key);
+
+ALTER TABLE merchant_webhook_deliveries
+    DROP CONSTRAINT IF EXISTS merchant_webhook_deliveries_status_check;
+
+ALTER TABLE merchant_webhook_deliveries
+    ADD CONSTRAINT merchant_webhook_deliveries_status_check
+    CHECK (status IN ('pending', 'retrying', 'delivered', 'failed', 'abandoned', 'dead_lettered'));
+
+ALTER TABLE merchant_webhook_deliveries
+    DROP CONSTRAINT IF EXISTS merchant_webhook_deliveries_queue_name_check;
+
+ALTER TABLE merchant_webhook_deliveries
+    ADD CONSTRAINT merchant_webhook_deliveries_queue_name_check
+    CHECK (queue_name IN ('primary', 'retry', 'dead_letter'));
+
+CREATE INDEX IF NOT EXISTS idx_merchant_webhook_deliveries_retry_queue
+    ON merchant_webhook_deliveries (queue_name, next_retry_at)
+    WHERE status IN ('pending', 'retrying');
+
+CREATE INDEX IF NOT EXISTS idx_merchant_webhook_deliveries_dead_letter
+    ON merchant_webhook_deliveries (dead_lettered_at DESC)
+    WHERE status = 'dead_lettered';
+
+CREATE TABLE IF NOT EXISTS merchant_webhook_dead_letters (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    webhook_delivery_id UUID NOT NULL UNIQUE REFERENCES merchant_webhook_deliveries(id) ON DELETE CASCADE,
+    merchant_id UUID NOT NULL REFERENCES merchants(id) ON DELETE CASCADE,
+    webhook_url TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    last_error_message TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    operator_alert_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (operator_alert_status IN ('pending', 'sent', 'acknowledged')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_merchant_webhook_dead_letters_alert
+    ON merchant_webhook_dead_letters (operator_alert_status, created_at);
+
+CREATE TABLE IF NOT EXISTS merchant_webhook_endpoint_circuits (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id UUID NOT NULL REFERENCES merchants(id) ON DELETE CASCADE,
+    webhook_url TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'closed'
+        CHECK (state IN ('closed', 'open', 'half_open')),
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    opened_until TIMESTAMPTZ,
+    last_failure_at TIMESTAMPTZ,
+    last_success_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (merchant_id, webhook_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_merchant_webhook_endpoint_circuits_open
+    ON merchant_webhook_endpoint_circuits (opened_until)
+    WHERE state = 'open';
+
+CREATE TRIGGER set_updated_at_merchant_webhook_dead_letters
+    BEFORE UPDATE ON merchant_webhook_dead_letters
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_updated_at_merchant_webhook_endpoint_circuits
+    BEFORE UPDATE ON merchant_webhook_endpoint_circuits
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/src/api/webhooks.rs
+++ b/src/api/webhooks.rs
@@ -50,15 +50,24 @@ pub async fn handle_webhook(
         }
     };
 
-    // Process webhook
+    // Queue webhook for asynchronous processing. This keeps provider callback
+    // latency independent of downstream database, payment, or merchant systems.
     match state
         .processor
-        .process_webhook(&provider, signature.as_deref(), &payload)
+        .enqueue_webhook(&provider, signature.as_deref(), &payload)
         .await
     {
-        Ok(_) => {
-            info!(provider = %provider, "Webhook processed successfully");
-            (StatusCode::OK, Json(serde_json::json!({"status": "ok"}))).into_response()
+        Ok(event_id) => {
+            info!(provider = %provider, event_id = %event_id, "Webhook queued successfully");
+            (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({
+                    "status": "accepted",
+                    "event_id": event_id,
+                    "delivery": "queued"
+                })),
+            )
+                .into_response()
         }
         Err(WebhookProcessorError::InvalidSignature) => {
             warn!(provider = %provider, "Invalid webhook signature");
@@ -66,11 +75,19 @@ pub async fn handle_webhook(
         }
         Err(WebhookProcessorError::AlreadyProcessed) => {
             info!(provider = %provider, "Webhook already processed");
-            (StatusCode::OK, Json(serde_json::json!({"status": "ok"}))).into_response()
+            (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({"status": "accepted"})),
+            )
+                .into_response()
         }
         Err(e) => {
             error!(provider = %provider, error = %e, "Webhook processing failed");
-            (StatusCode::OK, Json(serde_json::json!({"status": "ok"}))).into_response()
+            (
+                StatusCode::ACCEPTED,
+                Json(serde_json::json!({"status": "accepted"})),
+            )
+                .into_response()
         }
     }
 }

--- a/src/merchant_gateway/mod.rs
+++ b/src/merchant_gateway/mod.rs
@@ -9,6 +9,7 @@ pub mod routes;
 pub mod webhook_engine;
 pub mod api_key_service;
 pub mod metrics;
+pub mod webhook_queue;
 
 #[cfg(test)]
 mod tests;

--- a/src/merchant_gateway/models.rs
+++ b/src/merchant_gateway/models.rs
@@ -144,41 +144,66 @@ pub struct WebhookDelivery {
     pub event_type: String,
     pub payload: serde_json::Value,
     pub signature: String,
+    pub idempotency_key: String,
+    pub queue_name: String,
     pub status: WebhookStatus,
     pub http_status_code: Option<i32>,
     pub response_body: Option<String>,
     pub error_message: Option<String>,
     pub retry_count: i32,
     pub next_retry_at: Option<DateTime<Utc>>,
+    pub locked_at: Option<DateTime<Utc>>,
+    pub locked_by: Option<String>,
     pub last_attempt_at: Option<DateTime<Utc>>,
     pub delivered_at: Option<DateTime<Utc>>,
+    pub dead_lettered_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, sqlx::Type)]
 #[sqlx(type_name = "text")]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum WebhookStatus {
     #[sqlx(rename = "pending")]
     Pending,
+    #[sqlx(rename = "retrying")]
+    Retrying,
     #[sqlx(rename = "delivered")]
     Delivered,
     #[sqlx(rename = "failed")]
     Failed,
     #[sqlx(rename = "abandoned")]
     Abandoned,
+    #[sqlx(rename = "dead_lettered")]
+    DeadLettered,
 }
 
 impl std::fmt::Display for WebhookStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             WebhookStatus::Pending => write!(f, "pending"),
+            WebhookStatus::Retrying => write!(f, "retrying"),
             WebhookStatus::Delivered => write!(f, "delivered"),
             WebhookStatus::Failed => write!(f, "failed"),
             WebhookStatus::Abandoned => write!(f, "abandoned"),
+            WebhookStatus::DeadLettered => write!(f, "dead_lettered"),
         }
     }
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct WebhookEndpointCircuitBreaker {
+    pub id: Uuid,
+    pub merchant_id: Uuid,
+    pub webhook_url: String,
+    pub state: String,
+    pub consecutive_failures: i32,
+    pub opened_until: Option<DateTime<Utc>>,
+    pub last_failure_at: Option<DateTime<Utc>>,
+    pub last_success_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize)]
@@ -270,15 +295,15 @@ impl MerchantApiKeyScope {
             MerchantApiKeyScope::RefundOnly => "refund_only",
         }
     }
-    
+
     pub fn can_create_payment(&self) -> bool {
         matches!(self, MerchantApiKeyScope::Full | MerchantApiKeyScope::WriteOnly)
     }
-    
+
     pub fn can_read_payment(&self) -> bool {
         matches!(self, MerchantApiKeyScope::Full | MerchantApiKeyScope::ReadOnly)
     }
-    
+
     pub fn can_refund(&self) -> bool {
         matches!(self, MerchantApiKeyScope::Full | MerchantApiKeyScope::RefundOnly)
     }

--- a/src/merchant_gateway/repository.rs
+++ b/src/merchant_gateway/repository.rs
@@ -2,6 +2,10 @@
 
 use crate::database::error::{DatabaseError, DatabaseErrorKind};
 use crate::merchant_gateway::models::*;
+use crate::merchant_gateway::webhook_queue::{
+    circuit_decision_after_failure, is_circuit_breaker_failure, next_retry_at, should_dead_letter,
+    CircuitDecision, DEFAULT_CIRCUIT_COOLDOWN_SECS, DEFAULT_CIRCUIT_FAILURE_THRESHOLD,
+};
 use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
@@ -350,13 +354,17 @@ impl WebhookDeliveryRepository {
         event_type: &str,
         payload: serde_json::Value,
         signature: &str,
+        idempotency_key: &str,
     ) -> Result<WebhookDelivery, DatabaseError> {
         sqlx::query_as::<_, WebhookDelivery>(
             r#"
             INSERT INTO merchant_webhook_deliveries (
-                payment_intent_id, merchant_id, webhook_url, event_type, payload, signature
+                payment_intent_id, merchant_id, webhook_url, event_type, payload,
+                signature, idempotency_key, queue_name, status
             )
-            VALUES ($1, $2, $3, $4, $5, $6)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, 'primary', 'pending')
+            ON CONFLICT (idempotency_key) DO UPDATE
+                SET updated_at = merchant_webhook_deliveries.updated_at
             RETURNING *
             "#,
         )
@@ -366,7 +374,18 @@ impl WebhookDeliveryRepository {
         .bind(event_type)
         .bind(payload)
         .bind(signature)
+        .bind(idempotency_key)
         .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn find_by_id(&self, id: Uuid) -> Result<Option<WebhookDelivery>, DatabaseError> {
+        sqlx::query_as::<_, WebhookDelivery>(
+            "SELECT * FROM merchant_webhook_deliveries WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
         .await
         .map_err(DatabaseError::from_sqlx)
     }
@@ -381,8 +400,12 @@ impl WebhookDeliveryRepository {
             r#"
             UPDATE merchant_webhook_deliveries
             SET status = 'delivered',
+                queue_name = 'primary',
                 http_status_code = $2,
                 response_body = $3,
+                error_message = NULL,
+                locked_at = NULL,
+                locked_by = NULL,
                 delivered_at = NOW(),
                 last_attempt_at = NOW()
             WHERE id = $1
@@ -427,6 +450,250 @@ impl WebhookDeliveryRepository {
         .map_err(DatabaseError::from_sqlx)
     }
 
+    pub async fn record_delivery_failure(
+        &self,
+        webhook: &WebhookDelivery,
+        http_status: Option<i32>,
+        error_message: &str,
+        max_retries: u32,
+    ) -> Result<WebhookDelivery, DatabaseError> {
+        let now = Utc::now();
+        let next_attempt = webhook.retry_count + 1;
+        let exhausted = should_dead_letter(next_attempt, max_retries);
+        let retry_at = next_retry_at(now, next_attempt);
+        let next_status = if exhausted {
+            "dead_lettered"
+        } else {
+            "retrying"
+        };
+        let queue_name = if exhausted { "dead_letter" } else { "retry" };
+
+        let delivery = sqlx::query_as::<_, WebhookDelivery>(
+            r#"
+            UPDATE merchant_webhook_deliveries
+            SET retry_count = retry_count + 1,
+                http_status_code = $2,
+                error_message = $3,
+                last_attempt_at = NOW(),
+                next_retry_at = CASE WHEN $4 THEN NULL ELSE $5 END,
+                status = $6,
+                queue_name = $7,
+                locked_at = NULL,
+                locked_by = NULL,
+                dead_lettered_at = CASE WHEN $4 THEN NOW() ELSE dead_lettered_at END
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(webhook.id)
+        .bind(http_status)
+        .bind(error_message)
+        .bind(exhausted)
+        .bind(retry_at)
+        .bind(next_status)
+        .bind(queue_name)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        if exhausted {
+            self.record_dead_letter(&delivery).await?;
+        }
+
+        let circuit = self
+            .record_circuit_failure(
+                delivery.merchant_id,
+                &delivery.webhook_url,
+                http_status,
+                DEFAULT_CIRCUIT_FAILURE_THRESHOLD,
+                DEFAULT_CIRCUIT_COOLDOWN_SECS,
+            )
+            .await?;
+
+        if let Some(opened_until) = circuit.opened_until {
+            self.pause_endpoint_retry_until(
+                delivery.merchant_id,
+                &delivery.webhook_url,
+                opened_until,
+            )
+            .await?;
+        }
+
+        Ok(delivery)
+    }
+
+    pub async fn record_dead_letter(
+        &self,
+        delivery: &WebhookDelivery,
+    ) -> Result<(), DatabaseError> {
+        sqlx::query(
+            r#"
+            INSERT INTO merchant_webhook_dead_letters (
+                webhook_delivery_id, merchant_id, webhook_url, event_type,
+                payload, last_error_message, retry_count
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (webhook_delivery_id) DO UPDATE
+                SET last_error_message = EXCLUDED.last_error_message,
+                    retry_count = EXCLUDED.retry_count
+            "#,
+        )
+        .bind(delivery.id)
+        .bind(delivery.merchant_id)
+        .bind(&delivery.webhook_url)
+        .bind(&delivery.event_type)
+        .bind(&delivery.payload)
+        .bind(delivery.error_message.as_deref())
+        .bind(delivery.retry_count)
+        .execute(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(())
+    }
+
+    pub async fn active_circuit_for_endpoint(
+        &self,
+        merchant_id: Uuid,
+        webhook_url: &str,
+    ) -> Result<Option<WebhookEndpointCircuitBreaker>, DatabaseError> {
+        sqlx::query_as::<_, WebhookEndpointCircuitBreaker>(
+            r#"
+            SELECT *
+            FROM merchant_webhook_endpoint_circuits
+            WHERE merchant_id = $1
+              AND webhook_url = $2
+              AND state = 'open'
+              AND opened_until > NOW()
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(webhook_url)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn record_circuit_success(
+        &self,
+        merchant_id: Uuid,
+        webhook_url: &str,
+    ) -> Result<(), DatabaseError> {
+        sqlx::query(
+            r#"
+            INSERT INTO merchant_webhook_endpoint_circuits (
+                merchant_id, webhook_url, state, consecutive_failures, last_success_at
+            )
+            VALUES ($1, $2, 'closed', 0, NOW())
+            ON CONFLICT (merchant_id, webhook_url) DO UPDATE
+            SET state = 'closed',
+                consecutive_failures = 0,
+                opened_until = NULL,
+                last_success_at = NOW()
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(webhook_url)
+        .execute(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(())
+    }
+
+    async fn record_circuit_failure(
+        &self,
+        merchant_id: Uuid,
+        webhook_url: &str,
+        http_status: Option<i32>,
+        failure_threshold: i32,
+        cooldown_secs: i64,
+    ) -> Result<WebhookEndpointCircuitBreaker, DatabaseError> {
+        let current = sqlx::query_as::<_, WebhookEndpointCircuitBreaker>(
+            r#"
+            SELECT *
+            FROM merchant_webhook_endpoint_circuits
+            WHERE merchant_id = $1 AND webhook_url = $2
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(webhook_url)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        let next_failures = if is_circuit_breaker_failure(http_status) {
+            current
+                .as_ref()
+                .map(|circuit| circuit.consecutive_failures + 1)
+                .unwrap_or(1)
+        } else {
+            0
+        };
+        let decision = circuit_decision_after_failure(
+            Utc::now(),
+            next_failures,
+            http_status,
+            failure_threshold,
+            cooldown_secs,
+        );
+        let (state, opened_until) = match decision {
+            CircuitDecision::Closed => ("closed", None),
+            CircuitDecision::OpenUntil(until) => ("open", Some(until)),
+        };
+
+        sqlx::query_as::<_, WebhookEndpointCircuitBreaker>(
+            r#"
+            INSERT INTO merchant_webhook_endpoint_circuits (
+                merchant_id, webhook_url, state, consecutive_failures,
+                opened_until, last_failure_at
+            )
+            VALUES ($1, $2, $3, $4, $5, NOW())
+            ON CONFLICT (merchant_id, webhook_url) DO UPDATE
+            SET state = EXCLUDED.state,
+                consecutive_failures = EXCLUDED.consecutive_failures,
+                opened_until = EXCLUDED.opened_until,
+                last_failure_at = NOW()
+            RETURNING *
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(webhook_url)
+        .bind(state)
+        .bind(next_failures)
+        .bind(opened_until)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)
+    }
+
+    pub async fn pause_endpoint_retry_until(
+        &self,
+        merchant_id: Uuid,
+        webhook_url: &str,
+        opened_until: DateTime<Utc>,
+    ) -> Result<(), DatabaseError> {
+        sqlx::query(
+            r#"
+            UPDATE merchant_webhook_deliveries
+            SET next_retry_at = GREATEST(COALESCE(next_retry_at, $3), $3),
+                status = CASE WHEN status = 'pending' THEN 'retrying' ELSE status END,
+                queue_name = CASE WHEN queue_name = 'primary' THEN 'retry' ELSE queue_name END
+            WHERE merchant_id = $1
+              AND webhook_url = $2
+              AND status IN ('pending', 'retrying')
+            "#,
+        )
+        .bind(merchant_id)
+        .bind(webhook_url)
+        .bind(opened_until)
+        .execute(&self.pool)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        Ok(())
+    }
+
     pub async fn find_pending_for_retry(
         &self,
         limit: i64,
@@ -434,7 +701,7 @@ impl WebhookDeliveryRepository {
         sqlx::query_as::<_, WebhookDelivery>(
             r#"
             SELECT * FROM merchant_webhook_deliveries
-            WHERE status = 'pending'
+            WHERE status IN ('pending', 'retrying')
               AND (next_retry_at IS NULL OR next_retry_at <= NOW())
               AND retry_count < 5
             ORDER BY created_at ASC

--- a/src/merchant_gateway/webhook_engine.rs
+++ b/src/merchant_gateway/webhook_engine.rs
@@ -3,6 +3,7 @@
 
 use crate::merchant_gateway::models::*;
 use crate::merchant_gateway::repository::WebhookDeliveryRepository;
+use crate::merchant_gateway::webhook_queue::{webhook_idempotency_key, worker_pool_size};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use reqwest::Client;
@@ -11,6 +12,7 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;
+use tokio::sync::Semaphore;
 use tokio::time::interval;
 use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
@@ -26,6 +28,7 @@ pub struct WebhookEngine {
     http_client: Client,
     max_retries: u32,
     timeout_secs: u64,
+    delivery_worker_id: String,
 }
 
 impl WebhookEngine {
@@ -45,6 +48,7 @@ impl WebhookEngine {
             http_client,
             max_retries: 5,
             timeout_secs,
+            delivery_worker_id: format!("webhook-worker-{}", Uuid::new_v4()),
         }
     }
 
@@ -84,7 +88,10 @@ impl WebhookEngine {
         // Generate HMAC signature
         let signature = self.generate_signature(&merchant.webhook_secret, &payload_json)?;
 
-        // Queue webhook delivery
+        let idempotency_key = webhook_idempotency_key(merchant.id, payment_intent.id, event_type);
+
+        // Queue webhook delivery. The worker pool handles actual network I/O,
+        // so callers can return immediately after this durable write.
         let webhook_delivery = self
             .webhook_repo
             .create(
@@ -94,6 +101,7 @@ impl WebhookEngine {
                 event_type,
                 payload_json,
                 &signature,
+                &idempotency_key,
             )
             .await
             .map_err(|e| format!("Failed to queue webhook: {}", e))?;
@@ -103,17 +111,9 @@ impl WebhookEngine {
             payment_intent_id = %payment_intent.id,
             merchant_id = %merchant.id,
             event_type = %event_type,
+            idempotency_key = %webhook_delivery.idempotency_key,
             "Webhook queued for delivery"
         );
-
-        // Trigger immediate delivery attempt (async)
-        let engine = self.clone_for_delivery();
-        let webhook_id = webhook_delivery.id;
-        tokio::spawn(async move {
-            if let Err(e) = engine.deliver_webhook(webhook_id).await {
-                warn!(webhook_id = %webhook_id, error = %e, "Initial webhook delivery failed");
-            }
-        });
 
         Ok(webhook_delivery.id)
     }
@@ -129,13 +129,49 @@ impl WebhookEngine {
             .map_err(|e| format!("Failed to fetch webhook: {}", e))?
             .ok_or_else(|| "Webhook not found".to_string())?;
 
-        if webhook.status == WebhookStatus::Delivered {
+        if matches!(
+            webhook.status,
+            WebhookStatus::Delivered | WebhookStatus::DeadLettered | WebhookStatus::Abandoned
+        ) {
             return Ok(()); // Already delivered
         }
 
         if webhook.retry_count >= self.max_retries as i32 {
-            warn!(webhook_id = %webhook_id, "Webhook abandoned after max retries");
+            self.webhook_repo
+                .record_delivery_failure(
+                    &webhook,
+                    None,
+                    "Max retries exceeded before delivery attempt",
+                    self.max_retries,
+                )
+                .await
+                .map_err(|e| format!("Failed to dead-letter webhook: {}", e))?;
             return Err("Max retries exceeded".to_string());
+        }
+
+        if let Some(circuit) = self
+            .webhook_repo
+            .active_circuit_for_endpoint(webhook.merchant_id, &webhook.webhook_url)
+            .await
+            .map_err(|e| format!("Failed to read webhook circuit breaker: {}", e))?
+        {
+            if let Some(opened_until) = circuit.opened_until {
+                self.webhook_repo
+                    .pause_endpoint_retry_until(
+                        webhook.merchant_id,
+                        &webhook.webhook_url,
+                        opened_until,
+                    )
+                    .await
+                    .map_err(|e| format!("Failed to pause webhook delivery: {}", e))?;
+                warn!(
+                    webhook_id = %webhook_id,
+                    merchant_id = %webhook.merchant_id,
+                    opened_until = %opened_until,
+                    "Webhook endpoint circuit is open; delivery paused"
+                );
+                return Ok(());
+            }
         }
 
         // Prepare HTTP request
@@ -150,6 +186,7 @@ impl WebhookEngine {
             .header("X-Webhook-Event", &webhook.event_type)
             .header("X-Webhook-Id", webhook_id.to_string())
             .header("X-Webhook-Timestamp", Utc::now().to_rfc3339())
+            .header("x-aframp-idempotency-key", &webhook.idempotency_key)
             .body(payload_str)
             .send()
             .await;
@@ -168,6 +205,10 @@ impl WebhookEngine {
                         .mark_delivered(webhook_id, status.as_u16() as i32, Some(&response_body))
                         .await
                         .map_err(|e| format!("Failed to mark webhook delivered: {}", e))?;
+                    self.webhook_repo
+                        .record_circuit_success(webhook.merchant_id, &webhook.webhook_url)
+                        .await
+                        .map_err(|e| format!("Failed to close webhook circuit: {}", e))?;
 
                     info!(
                         webhook_id = %webhook_id,
@@ -179,7 +220,12 @@ impl WebhookEngine {
                     // HTTP error - schedule retry
                     let error_msg = format!("HTTP {}: {}", status.as_u16(), response_body);
                     self.webhook_repo
-                        .mark_failed(webhook_id, Some(status.as_u16() as i32), &error_msg)
+                        .record_delivery_failure(
+                            &webhook,
+                            Some(status.as_u16() as i32),
+                            &error_msg,
+                            self.max_retries,
+                        )
                         .await
                         .map_err(|e| format!("Failed to mark webhook failed: {}", e))?;
 
@@ -196,7 +242,7 @@ impl WebhookEngine {
                 // Network error - schedule retry
                 let error_msg = format!("Network error: {}", e);
                 self.webhook_repo
-                    .mark_failed(webhook_id, None, &error_msg)
+                    .record_delivery_failure(&webhook, None, &error_msg, self.max_retries)
                     .await
                     .map_err(|e| format!("Failed to mark webhook failed: {}", e))?;
 
@@ -251,35 +297,8 @@ impl WebhookEngine {
             http_client: self.http_client.clone(),
             max_retries: self.max_retries,
             timeout_secs: self.timeout_secs,
+            delivery_worker_id: self.delivery_worker_id.clone(),
         }
-    }
-}
-
-// Extension trait for repository
-trait WebhookRepositoryExt {
-    async fn find_by_id(&self, id: Uuid) -> Result<Option<WebhookDelivery>, crate::database::error::DatabaseError>;
-}
-
-impl WebhookRepositoryExt for WebhookDeliveryRepository {
-    async fn find_by_id(&self, id: Uuid) -> Result<Option<WebhookDelivery>, crate::database::error::DatabaseError> {
-        sqlx::query_as::<_, WebhookDelivery>(
-            "SELECT * FROM merchant_webhook_deliveries WHERE id = $1"
-        )
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(crate::database::error::DatabaseError::from_sqlx)
-    }
-}
-
-// Access to pool
-trait RepositoryPool {
-    fn pool(&self) -> &PgPool;
-}
-
-impl RepositoryPool for WebhookDeliveryRepository {
-    fn pool(&self) -> &PgPool {
-        &self.pool
     }
 }
 
@@ -292,6 +311,7 @@ pub struct WebhookRetryWorker {
     webhook_engine: Arc<WebhookEngine>,
     poll_interval_secs: u64,
     batch_size: i64,
+    max_concurrency: usize,
 }
 
 impl WebhookRetryWorker {
@@ -305,12 +325,17 @@ impl WebhookRetryWorker {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(50);
+        let max_concurrency = std::env::var("WEBHOOK_WORKER_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(16);
 
         Self {
             webhook_repo: Arc::new(WebhookDeliveryRepository::new(pool)),
             webhook_engine,
             poll_interval_secs,
             batch_size,
+            max_concurrency,
         }
     }
 
@@ -318,6 +343,7 @@ impl WebhookRetryWorker {
         info!(
             poll_interval_secs = self.poll_interval_secs,
             batch_size = self.batch_size,
+            max_concurrency = self.max_concurrency,
             "Webhook retry worker started"
         );
 
@@ -354,16 +380,35 @@ impl WebhookRetryWorker {
             return Ok(());
         }
 
-        info!(count = pending.len(), "Processing pending webhooks");
+        let pool_size = worker_pool_size(pending.len(), self.max_concurrency);
+        info!(
+            count = pending.len(),
+            pool_size, "Processing queued webhooks"
+        );
+
+        let permits = Arc::new(Semaphore::new(pool_size));
+        let mut tasks = Vec::with_capacity(pending.len());
 
         for webhook in pending {
             let engine = self.webhook_engine.clone();
             let webhook_id = webhook.id;
-            tokio::spawn(async move {
+            let permit = permits
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| format!("Webhook worker semaphore closed: {}", e))?;
+            tasks.push(tokio::spawn(async move {
+                let _permit = permit;
                 if let Err(e) = engine.deliver_webhook(webhook_id).await {
                     warn!(webhook_id = %webhook_id, error = %e, "Webhook retry failed");
                 }
-            });
+            }));
+        }
+
+        for task in tasks {
+            if let Err(e) = task.await {
+                warn!(error = %e, "Webhook worker task join failed");
+            }
         }
 
         Ok(())

--- a/src/merchant_gateway/webhook_queue.rs
+++ b/src/merchant_gateway/webhook_queue.rs
@@ -1,0 +1,63 @@
+//! Queue policy helpers for asynchronous merchant webhook delivery.
+
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use uuid::Uuid;
+
+pub const WEBHOOK_RETRY_BACKOFF_SECS: [i64; 5] = [60, 300, 900, 3_600, 14_400];
+pub const DEFAULT_CIRCUIT_FAILURE_THRESHOLD: i32 = 5;
+pub const DEFAULT_CIRCUIT_COOLDOWN_SECS: i64 = 900;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitDecision {
+    Closed,
+    OpenUntil(DateTime<Utc>),
+}
+
+pub fn webhook_idempotency_key(merchant_id: Uuid, subject_id: Uuid, event_type: &str) -> String {
+    format!(
+        "merchant-webhook:{}:{}:{}",
+        merchant_id,
+        event_type.trim().to_ascii_lowercase(),
+        subject_id
+    )
+}
+
+pub fn backoff_for_retry_attempt(attempt: i32) -> ChronoDuration {
+    let index = attempt.saturating_sub(1) as usize;
+    let secs = WEBHOOK_RETRY_BACKOFF_SECS
+        .get(index)
+        .copied()
+        .unwrap_or(*WEBHOOK_RETRY_BACKOFF_SECS.last().unwrap());
+
+    ChronoDuration::seconds(secs)
+}
+
+pub fn next_retry_at(now: DateTime<Utc>, next_attempt: i32) -> DateTime<Utc> {
+    now + backoff_for_retry_attempt(next_attempt)
+}
+
+pub fn should_dead_letter(next_attempt: i32, max_retries: u32) -> bool {
+    next_attempt >= max_retries as i32
+}
+
+pub fn is_circuit_breaker_failure(http_status: Option<i32>) -> bool {
+    matches!(http_status, Some(status) if status >= 500)
+}
+
+pub fn circuit_decision_after_failure(
+    now: DateTime<Utc>,
+    consecutive_failures: i32,
+    http_status: Option<i32>,
+    failure_threshold: i32,
+    cooldown_secs: i64,
+) -> CircuitDecision {
+    if is_circuit_breaker_failure(http_status) && consecutive_failures >= failure_threshold {
+        CircuitDecision::OpenUntil(now + ChronoDuration::seconds(cooldown_secs))
+    } else {
+        CircuitDecision::Closed
+    }
+}
+
+pub fn worker_pool_size(queue_depth: usize, configured_max: usize) -> usize {
+    queue_depth.clamp(1, configured_max.max(1))
+}

--- a/src/services/webhook_processor.rs
+++ b/src/services/webhook_processor.rs
@@ -117,6 +117,59 @@ impl WebhookProcessor {
         }
     }
 
+    pub async fn enqueue_webhook(
+        &self,
+        provider_name: &str,
+        signature: Option<&str>,
+        payload: &JsonValue,
+    ) -> Result<String, WebhookProcessorError> {
+        let provider = self.parse_provider(provider_name)?;
+        let signature = signature.ok_or(WebhookProcessorError::InvalidSignature)?;
+
+        let provider_impl = self
+            .provider_factory
+            .get_provider(provider)
+            .map_err(|e| WebhookProcessorError::ProcessingError(e.to_string()))?;
+
+        let payload_bytes = serde_json::to_vec(payload)
+            .map_err(|e| WebhookProcessorError::ProcessingError(e.to_string()))?;
+        let verification = provider_impl
+            .verify_webhook(&payload_bytes, signature)
+            .map_err(|e| WebhookProcessorError::ProcessingError(e.to_string()))?;
+
+        if !verification.valid {
+            error!(provider = %provider_name, "Invalid webhook signature");
+            return Err(WebhookProcessorError::InvalidSignature);
+        }
+
+        let event = provider_impl
+            .parse_webhook_event(&payload_bytes)
+            .map_err(|e| WebhookProcessorError::ProcessingError(e.to_string()))?;
+        let event_id = self.extract_event_id(&event.payload, provider_name);
+
+        let webhook_event = self
+            .webhook_repo
+            .log_event(
+                &event_id,
+                provider_name,
+                &event.event_type,
+                payload.clone(),
+                Some(signature),
+                None,
+            )
+            .await
+            .map_err(|e| WebhookProcessorError::DatabaseError(e.to_string()))?;
+
+        info!(
+            event_id = %webhook_event.event_id,
+            provider = %provider_name,
+            event_type = %webhook_event.event_type,
+            "Webhook accepted into durable queue"
+        );
+
+        Ok(webhook_event.event_id)
+    }
+
     async fn process_event(
         &self,
         _webhook_event: &crate::database::webhook_repository::WebhookEvent,

--- a/tests/merchant_webhook_queue_tests.rs
+++ b/tests/merchant_webhook_queue_tests.rs
@@ -1,0 +1,67 @@
+use chrono::Utc;
+use uuid::Uuid;
+
+use Bitmesh_backend::merchant_gateway::webhook_queue::{
+    backoff_for_retry_attempt, circuit_decision_after_failure, is_circuit_breaker_failure,
+    next_retry_at, should_dead_letter, webhook_idempotency_key, worker_pool_size, CircuitDecision,
+};
+
+#[test]
+fn retry_backoff_uses_required_schedule() {
+    assert_eq!(backoff_for_retry_attempt(1).num_seconds(), 60);
+    assert_eq!(backoff_for_retry_attempt(2).num_seconds(), 300);
+    assert_eq!(backoff_for_retry_attempt(3).num_seconds(), 900);
+    assert_eq!(backoff_for_retry_attempt(4).num_seconds(), 3_600);
+    assert_eq!(backoff_for_retry_attempt(5).num_seconds(), 14_400);
+    assert_eq!(backoff_for_retry_attempt(99).num_seconds(), 14_400);
+}
+
+#[test]
+fn retry_dead_letters_after_max_attempts() {
+    assert!(!should_dead_letter(4, 5));
+    assert!(should_dead_letter(5, 5));
+    assert!(should_dead_letter(6, 5));
+}
+
+#[test]
+fn idempotency_key_is_stable_for_same_event() {
+    let merchant_id = Uuid::new_v4();
+    let payment_id = Uuid::new_v4();
+
+    assert_eq!(
+        webhook_idempotency_key(merchant_id, payment_id, "Payment.Confirmed"),
+        webhook_idempotency_key(merchant_id, payment_id, "payment.confirmed")
+    );
+}
+
+#[test]
+fn next_retry_at_applies_exponential_backoff() {
+    let now = Utc::now();
+    assert_eq!((next_retry_at(now, 3) - now).num_seconds(), 900);
+}
+
+#[test]
+fn circuit_breaker_opens_only_for_repeated_5xx_failures() {
+    let now = Utc::now();
+
+    assert!(is_circuit_breaker_failure(Some(503)));
+    assert!(!is_circuit_breaker_failure(Some(429)));
+    assert!(!is_circuit_breaker_failure(None));
+
+    assert_eq!(
+        circuit_decision_after_failure(now, 4, Some(503), 5, 900),
+        CircuitDecision::Closed
+    );
+
+    match circuit_decision_after_failure(now, 5, Some(503), 5, 900) {
+        CircuitDecision::OpenUntil(until) => assert_eq!((until - now).num_seconds(), 900),
+        CircuitDecision::Closed => panic!("expected circuit to open"),
+    }
+}
+
+#[test]
+fn worker_pool_size_tracks_queue_depth_without_exceeding_max() {
+    assert_eq!(worker_pool_size(0, 16), 1);
+    assert_eq!(worker_pool_size(3, 16), 3);
+    assert_eq!(worker_pool_size(99, 16), 16);
+}


### PR DESCRIPTION
Closes #346

---

Adds async webhook delivery processing for issue #346. This branch includes webhook enqueueing, retry/DLQ metadata, circuit breaker state, idempotency key handling, and worker concurrency controls.