### PR TITLE
feat(sla): Performance SLA Management & Breach Response (#405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
+ "hostname",
  "http 1.4.0",
  "image 0.25.10",
  "jsonwebtoken",
@@ -2666,6 +2667,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -6335,6 +6347,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rust_decimal",
  "rustls",
  "serde",
  "serde_json",
@@ -6420,6 +6433,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "rsa",
+ "rust_decimal",
  "serde",
  "sha1",
  "sha2",
@@ -6461,6 +6475,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "once_cell",
  "rand 0.8.5",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2",

--- a/migrations/20260427000000_performance_sla_management.sql
+++ b/migrations/20260427000000_performance_sla_management.sql
@@ -1,0 +1,91 @@
+-- Performance SLA Management & Breach Response (Issue #405)
+-- Tracks SLO definitions, real-time compliance windows, breach incidents,
+-- post-mortems, and monthly partner compliance reports.
+
+-- ── SLO definitions ──────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS slo_definitions (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name            TEXT NOT NULL UNIQUE,          -- e.g. "api_p99_latency"
+    description     TEXT,
+    metric_name     TEXT NOT NULL,                 -- Prometheus metric to evaluate
+    operator        TEXT NOT NULL CHECK (operator IN ('lt','lte','gt','gte')),
+    threshold       NUMERIC(18,6) NOT NULL,        -- e.g. 0.5 (seconds) or 99.99 (%)
+    window_seconds  INT  NOT NULL DEFAULT 300,     -- evaluation window (5 min default)
+    severity        TEXT NOT NULL DEFAULT 'high' CHECK (severity IN ('critical','high','medium','low')),
+    enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ── SLA breach incidents ──────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sla_breach_incidents (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slo_id              UUID NOT NULL REFERENCES slo_definitions(id),
+    detected_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at         TIMESTAMPTZ,
+    status              TEXT NOT NULL DEFAULT 'open'
+                            CHECK (status IN ('open','investigating','resolved','post_mortem_pending','closed')),
+    observed_value      NUMERIC(18,6) NOT NULL,
+    threshold_value     NUMERIC(18,6) NOT NULL,
+    affected_service    TEXT NOT NULL,
+    root_cause_summary  TEXT,
+    remediation_steps   TEXT,
+    -- forensic context attached automatically at breach time
+    context_snapshot    JSONB NOT NULL DEFAULT '{}',
+    -- communication tracking
+    partners_notified   BOOLEAN NOT NULL DEFAULT FALSE,
+    notification_sent_at TIMESTAMPTZ,
+    etr                 TIMESTAMPTZ,               -- estimated time to resolution
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ── Post-mortem records ───────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sla_post_mortems (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    incident_id     UUID NOT NULL UNIQUE REFERENCES sla_breach_incidents(id),
+    author          TEXT NOT NULL,
+    timeline        JSONB NOT NULL DEFAULT '[]',   -- [{at, event}]
+    root_cause      TEXT NOT NULL,
+    contributing_factors TEXT,
+    remediation     TEXT NOT NULL,
+    preventive_measures TEXT NOT NULL,
+    action_items    JSONB NOT NULL DEFAULT '[]',   -- [{owner, task, due_date, done}]
+    status          TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','review','approved')),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ── Monthly SLA compliance reports ───────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS sla_compliance_reports (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    partner_id      UUID,                          -- NULL = platform-wide report
+    report_month    DATE NOT NULL,                 -- first day of the month
+    total_breaches  INT  NOT NULL DEFAULT 0,
+    mttr_seconds    NUMERIC(12,2),                 -- mean time to resolve
+    availability_pct NUMERIC(7,4),                 -- e.g. 99.9812
+    breach_ids      UUID[] NOT NULL DEFAULT '{}',
+    generated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (partner_id, report_month)
+);
+
+-- ── Indexes ───────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_sla_breaches_status     ON sla_breach_incidents(status);
+CREATE INDEX IF NOT EXISTS idx_sla_breaches_detected   ON sla_breach_incidents(detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sla_breaches_slo        ON sla_breach_incidents(slo_id);
+CREATE INDEX IF NOT EXISTS idx_sla_reports_month       ON sla_compliance_reports(report_month DESC);
+
+-- ── Seed default SLO definitions ─────────────────────────────────────────────
+INSERT INTO slo_definitions (name, description, metric_name, operator, threshold, window_seconds, severity)
+VALUES
+  ('api_p99_latency',    'API P99 latency must stay below 500ms',
+   'aframp_http_request_duration_seconds', 'lt', 0.5,   300, 'critical'),
+  ('api_availability',   'API availability must stay above 99.9%',
+   'aframp_http_requests_total',           'gte', 99.9,  300, 'critical'),
+  ('onramp_success_rate','Onramp success rate must stay above 95%',
+   'aframp_onramp_success_rate',           'gte', 95.0,  600, 'high'),
+  ('offramp_success_rate','Offramp success rate must stay above 95%',
+   'aframp_offramp_success_rate',          'gte', 95.0,  600, 'high'),
+  ('db_query_p95',       'DB query P95 must stay below 200ms',
+   'aframp_db_query_duration_seconds',     'lt', 0.2,   300, 'high')
+ON CONFLICT (name) DO NOTHING;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,10 @@ pub mod agent_cfo;
 // Agent Swarm Intelligence — decentralized P2P coordination layer
 #[cfg(feature = "database")]
 pub mod agent_swarm;
+
+// Performance SLA Management & Breach Response (Issue #405)
+#[cfg(feature = "database")]
+pub mod sla;
 // Agent Admin Dashboard — HITL control system for autonomous agents
 #[cfg(feature = "database")]
 pub mod agent_dashboard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,8 @@ mod dispute;
 
 // DeFi Integration Architecture & Protocol Selection (Issue #370)
 mod defi;
+// Performance SLA Management & Breach Response (Issue #405)
+mod sla;
 use std::sync::Arc;
 use crate::config::AppConfig;
 use crate::health::{HealthChecker, HealthStatus};
@@ -2308,14 +2310,29 @@ async fn main() -> anyhow::Result<()> {
         Router::new()
     };
 
-    let app = Router::new()
-        .route("/", get(root))
-        .route("/health", get(health))
-        .route("/health/ready", get(readiness))
-        .route("/health/live", get(liveness))
-        .route("/metrics", get(metrics::handler::metrics_handler))
-        .route("/api/stellar/account/{address}", get(get_stellar_account))
-        .route("/api/trustlines/operations", post(create_trustline_operation))
+    // ── Performance SLA Management & Breach Response (Issue #405) ────────────
+    let sla_routes = if let Some(pool) = db_pool.clone() {
+        let http = reqwest::Client::new();
+        let sla_state = std::sync::Arc::new(sla::SlaState {
+            repo: std::sync::Arc::new(sla::SlaRepository::new(pool.clone())),
+            pool: pool.clone(),
+        });
+
+        // SLA monitor worker — evaluates SLOs every 60 seconds
+        let monitor = sla::SlaMonitorWorker::new(pool.clone(), http);
+        tokio::spawn(monitor.run(worker_shutdown_rx.clone()));
+        info!("✅ SLA monitor worker started (60s interval)");
+
+        // Monthly compliance report worker
+        let report_worker = sla::SlaReportWorker::new(pool);
+        tokio::spawn(report_worker.run(worker_shutdown_rx.clone()));
+        info!("✅ SLA report worker started");
+
+        sla::sla_routes(sla_state)
+    } else {
+        info!("⏭️  Skipping SLA routes (no database)");
+        Router::new()
+    };
         .route("/api/trustlines/operations/{id}", patch(update_trustline_operation_status))
         .route("/api/trustlines/operations/wallet/{address}", get(list_trustline_operations_by_wallet))
         .route("/api/fees/calculate", post(calculate_fee))
@@ -2369,6 +2386,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(agent_dashboard_routes)
         .merge(pos_routes)
         .merge(dispute_routes)
+        .merge(sla_routes)
         .with_state(AppState {
             db_pool,
             redis_cache,

--- a/src/sla/handlers.rs
+++ b/src/sla/handlers.rs
@@ -1,0 +1,202 @@
+use crate::sla::{
+    models::*,
+    repository::SlaRepository,
+};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{Datelike, NaiveDate};
+use serde::Deserialize;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ── Shared state ──────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct SlaState {
+    pub repo: Arc<SlaRepository>,
+    pub pool: PgPool,
+}
+
+// ── Dashboard ─────────────────────────────────────────────────────────────────
+
+pub async fn get_dashboard(
+    State(s): State<Arc<SlaState>>,
+) -> Result<Json<SlaComplianceDashboard>, (StatusCode, String)> {
+    let (open_incidents, slo_definitions, stats) = tokio::try_join!(
+        s.repo.list_open_incidents(),
+        s.repo.list_slos(),
+        s.repo.dashboard_stats(),
+    )
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let (recent_breaches_30d, mttr_seconds_30d, availability_pct_30d) = stats;
+
+    Ok(Json(SlaComplianceDashboard {
+        open_incidents,
+        slo_definitions,
+        recent_breaches_30d,
+        mttr_seconds_30d,
+        availability_pct_30d,
+    }))
+}
+
+// ── Incidents ─────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct IncidentQuery {
+    pub status: Option<String>,
+}
+
+pub async fn list_incidents(
+    State(s): State<Arc<SlaState>>,
+    Query(q): Query<IncidentQuery>,
+) -> Result<Json<Vec<SlaBreachIncident>>, (StatusCode, String)> {
+    match q.status.as_deref() {
+        None | Some("open") => s.repo.list_open_incidents().await,
+        Some(status) => s.repo.list_incidents_by_status(Some(status)).await,
+    }
+    .map(Json)
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+pub async fn get_incident(
+    State(s): State<Arc<SlaState>>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<SlaBreachIncident>, (StatusCode, String)> {
+    s.repo
+        .get_incident(id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map(Json)
+        .ok_or((StatusCode::NOT_FOUND, "Incident not found".into()))
+}
+
+pub async fn update_incident(
+    State(s): State<Arc<SlaState>>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateIncidentRequest>,
+) -> Result<Json<SlaBreachIncident>, (StatusCode, String)> {
+    s.repo
+        .update_incident(id, &req)
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+// ── Post-mortems ──────────────────────────────────────────────────────────────
+
+pub async fn create_post_mortem(
+    State(s): State<Arc<SlaState>>,
+    Path(incident_id): Path<Uuid>,
+    Json(req): Json<CreatePostMortemRequest>,
+) -> Result<Json<SlaPostMortem>, (StatusCode, String)> {
+    // Verify incident exists
+    s.repo
+        .get_incident(incident_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "Incident not found".into()))?;
+
+    // Transition incident to post_mortem_pending
+    let _ = s
+        .repo
+        .update_incident(
+            incident_id,
+            &UpdateIncidentRequest {
+                status: Some("post_mortem_pending".into()),
+                root_cause_summary: None,
+                remediation_steps: None,
+                etr: None,
+            },
+        )
+        .await;
+
+    s.repo
+        .create_post_mortem(incident_id, &req)
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+pub async fn get_post_mortem(
+    State(s): State<Arc<SlaState>>,
+    Path(incident_id): Path<Uuid>,
+) -> Result<Json<SlaPostMortem>, (StatusCode, String)> {
+    s.repo
+        .get_post_mortem(incident_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map(Json)
+        .ok_or((StatusCode::NOT_FOUND, "Post-mortem not found".into()))
+}
+
+// ── Compliance reports ────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ReportQuery {
+    pub partner_id: Option<Uuid>,
+    pub month: Option<NaiveDate>, // YYYY-MM-DD (first of month)
+}
+
+pub async fn list_reports(
+    State(s): State<Arc<SlaState>>,
+    Query(q): Query<ReportQuery>,
+) -> Result<Json<Vec<SlaComplianceReport>>, (StatusCode, String)> {
+    s.repo
+        .list_reports(q.partner_id)
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+pub async fn generate_report(
+    State(s): State<Arc<SlaState>>,
+    Query(q): Query<ReportQuery>,
+) -> Result<Json<SlaComplianceReport>, (StatusCode, String)> {
+    let month = q.month.unwrap_or_else(|| {
+        let now = chrono::Utc::now();
+        NaiveDate::from_ymd_opt(now.year(), now.month(), 1).unwrap()
+    });
+    s.repo
+        .generate_monthly_report(q.partner_id, month)
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+// ── SLO definitions ───────────────────────────────────────────────────────────
+
+pub async fn list_slos(
+    State(s): State<Arc<SlaState>>,
+) -> Result<Json<Vec<SloDefinition>>, (StatusCode, String)> {
+    s.repo
+        .list_slos()
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+pub fn sla_routes(state: Arc<SlaState>) -> axum::Router {
+    use axum::routing::{get, patch, post};
+    axum::Router::new()
+        // Dashboard
+        .route("/api/admin/sla/dashboard",          get(get_dashboard))
+        // SLO definitions
+        .route("/api/admin/sla/slos",               get(list_slos))
+        // Incidents
+        .route("/api/admin/sla/incidents",          get(list_incidents))
+        .route("/api/admin/sla/incidents/:id",      get(get_incident).patch(update_incident))
+        // Post-mortems
+        .route("/api/admin/sla/incidents/:id/post-mortem",
+               post(create_post_mortem).get(get_post_mortem))
+        // Compliance reports
+        .route("/api/admin/sla/reports",            get(list_reports))
+        .route("/api/admin/sla/reports/generate",   post(generate_report))
+        .with_state(state)
+}

--- a/src/sla/mod.rs
+++ b/src/sla/mod.rs
@@ -1,0 +1,10 @@
+pub mod handlers;
+pub mod models;
+pub mod monitor;
+pub mod report_worker;
+pub mod repository;
+
+pub use handlers::{sla_routes, SlaState};
+pub use monitor::SlaMonitorWorker;
+pub use report_worker::SlaReportWorker;
+pub use repository::SlaRepository;

--- a/src/sla/models.rs
+++ b/src/sla/models.rs
@@ -1,0 +1,105 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::types::BigDecimal;
+use uuid::Uuid;
+
+// ── SLO Definition ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct SloDefinition {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub metric_name: String,
+    pub operator: String,   // "lt" | "lte" | "gt" | "gte"
+    pub threshold: BigDecimal,
+    pub window_seconds: i32,
+    pub severity: String,
+    pub enabled: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ── Breach Incident ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct SlaBreachIncident {
+    pub id: Uuid,
+    pub slo_id: Uuid,
+    pub detected_at: DateTime<Utc>,
+    pub resolved_at: Option<DateTime<Utc>>,
+    pub status: String,
+    pub observed_value: BigDecimal,
+    pub threshold_value: BigDecimal,
+    pub affected_service: String,
+    pub root_cause_summary: Option<String>,
+    pub remediation_steps: Option<String>,
+    pub context_snapshot: serde_json::Value,
+    pub partners_notified: bool,
+    pub notification_sent_at: Option<DateTime<Utc>>,
+    pub etr: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ── Post-Mortem ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct SlaPostMortem {
+    pub id: Uuid,
+    pub incident_id: Uuid,
+    pub author: String,
+    pub timeline: serde_json::Value,
+    pub root_cause: String,
+    pub contributing_factors: Option<String>,
+    pub remediation: String,
+    pub preventive_measures: String,
+    pub action_items: serde_json::Value,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ── Compliance Report ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct SlaComplianceReport {
+    pub id: Uuid,
+    pub partner_id: Option<Uuid>,
+    pub report_month: chrono::NaiveDate,
+    pub total_breaches: i32,
+    pub mttr_seconds: Option<BigDecimal>,
+    pub availability_pct: Option<BigDecimal>,
+    pub breach_ids: Vec<Uuid>,
+    pub generated_at: DateTime<Utc>,
+}
+
+// ── Request / Response DTOs ───────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateIncidentRequest {
+    pub status: Option<String>,
+    pub root_cause_summary: Option<String>,
+    pub remediation_steps: Option<String>,
+    pub etr: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePostMortemRequest {
+    pub author: String,
+    pub timeline: serde_json::Value,
+    pub root_cause: String,
+    pub contributing_factors: Option<String>,
+    pub remediation: String,
+    pub preventive_measures: String,
+    pub action_items: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SlaComplianceDashboard {
+    pub open_incidents: Vec<SlaBreachIncident>,
+    pub slo_definitions: Vec<SloDefinition>,
+    pub recent_breaches_30d: i64,
+    pub mttr_seconds_30d: Option<f64>,
+    pub availability_pct_30d: Option<f64>,
+}

--- a/src/sla/monitor.rs
+++ b/src/sla/monitor.rs
@@ -1,0 +1,208 @@
+/// SLA Monitoring Engine
+///
+/// Polls Prometheus metrics every 60 seconds and evaluates each enabled SLO.
+/// When a breach is detected it:
+///   1. Opens a `sla_breach_incidents` row with a forensic context snapshot.
+///   2. Fires a Slack/webhook notification to the on-call channel.
+///   3. Marks the incident for partner communication.
+///
+/// Idempotency: a new incident is only opened when no `open` or `investigating`
+/// incident already exists for the same SLO.
+use crate::sla::repository::SlaRepository;
+use chrono::Utc;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::sync::watch;
+use tokio::time::{interval, Duration};
+use tracing::{error, info, warn};
+
+pub const MONITOR_INTERVAL_SECS: u64 = 60;
+
+pub struct SlaMonitorWorker {
+    repo: Arc<SlaRepository>,
+    http: reqwest::Client,
+    prometheus_url: String,
+    slack_webhook: Option<String>,
+}
+
+impl SlaMonitorWorker {
+    pub fn new(pool: PgPool, http: reqwest::Client) -> Self {
+        Self {
+            repo: Arc::new(SlaRepository::new(pool)),
+            http,
+            prometheus_url: std::env::var("PROMETHEUS_URL")
+                .unwrap_or_else(|_| "http://localhost:9090".into()),
+            slack_webhook: std::env::var("SLA_SLACK_WEBHOOK").ok(),
+        }
+    }
+
+    pub async fn run(self, mut shutdown_rx: watch::Receiver<bool>) {
+        info!("SlaMonitorWorker started (interval={}s)", MONITOR_INTERVAL_SECS);
+        let mut ticker = interval(Duration::from_secs(MONITOR_INTERVAL_SECS));
+        ticker.tick().await; // fire immediately on startup
+
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    info!("SlaMonitorWorker shutting down");
+                    break;
+                }
+                _ = ticker.tick() => {
+                    if let Err(e) = self.run_cycle().await {
+                        error!(error = %e, "SlaMonitorWorker cycle failed");
+                    }
+                }
+            }
+        }
+    }
+
+    async fn run_cycle(&self) -> anyhow::Result<()> {
+        let slos = self.repo.list_slos().await?;
+
+        for slo in &slos {
+            let observed = match self.query_metric(&slo.metric_name).await {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(metric = %slo.metric_name, error = %e, "Failed to query metric");
+                    continue;
+                }
+            };
+
+            let threshold: f64 = slo.threshold.to_string().parse().unwrap_or(0.0);
+            let breached = match slo.operator.as_str() {
+                "lt"  => observed >= threshold,
+                "lte" => observed > threshold,
+                "gt"  => observed <= threshold,
+                "gte" => observed < threshold,
+                _     => false,
+            };
+
+            if !breached {
+                continue;
+            }
+
+            // Check for an already-open incident for this SLO
+            let open = self.repo.list_open_incidents().await?;
+            let already_open = open.iter().any(|i| {
+                i.slo_id == slo.id
+                    && matches!(i.status.as_str(), "open" | "investigating")
+            });
+            if already_open {
+                continue;
+            }
+
+            warn!(
+                slo = %slo.name,
+                observed,
+                threshold,
+                "SLA breach detected — opening incident"
+            );
+
+            let context = self.build_context_snapshot(slo, observed).await;
+            let incident = self
+                .repo
+                .open_incident(slo.id, observed, threshold, "aframp-backend", context)
+                .await?;
+
+            info!(incident_id = %incident.id, slo = %slo.name, "Incident opened");
+
+            // Fire notification (fire-and-forget)
+            if let Some(ref webhook) = self.slack_webhook {
+                let msg = serde_json::json!({
+                    "text": format!(
+                        "🚨 *SLA Breach Detected* — `{}`\n\
+                         Observed: `{:.4}` | Threshold: `{:.4}` | Severity: `{}`\n\
+                         Incident ID: `{}`",
+                        slo.name, observed, threshold, slo.severity, incident.id
+                    )
+                });
+                let _ = self.http.post(webhook).json(&msg).send().await;
+            }
+
+            // Mark partners notified (status page update hook)
+            let _ = self.repo.mark_partners_notified(incident.id).await;
+        }
+
+        Ok(())
+    }
+
+    /// Query a Prometheus instant vector and return the scalar value.
+    async fn query_metric(&self, metric: &str) -> anyhow::Result<f64> {
+        let url = format!("{}/api/v1/query", self.prometheus_url);
+        let resp: serde_json::Value = self
+            .http
+            .get(&url)
+            .query(&[("query", metric)])
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        let value = resp["data"]["result"]
+            .as_array()
+            .and_then(|r| r.first())
+            .and_then(|r| r["value"].as_array())
+            .and_then(|v| v.get(1))
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
+        Ok(value)
+    }
+
+    async fn build_context_snapshot(
+        &self,
+        slo: &crate::sla::models::SloDefinition,
+        observed: f64,
+    ) -> serde_json::Value {
+        // Collect recent latency trace data from Prometheus
+        let latency_trace = self.query_range_metric(&slo.metric_name, 300).await;
+
+        // Collect recent error-rate spike for forensic context
+        let error_rate = self
+            .query_metric("rate(aframp_http_requests_total{status=~\"5..\"}[5m])")
+            .await
+            .unwrap_or(0.0);
+
+        serde_json::json!({
+            "slo_name": slo.name,
+            "metric_name": slo.metric_name,
+            "observed_value": observed,
+            "threshold": slo.threshold,
+            "operator": slo.operator,
+            "window_seconds": slo.window_seconds,
+            "snapshot_at": Utc::now().to_rfc3339(),
+            "prometheus_url": self.prometheus_url,
+            // Forensic attachments (Issue #405 — automated root-cause context)
+            "latency_trace_5m": latency_trace,
+            "error_rate_5m": error_rate,
+            "recent_logs_hint": format!(
+                "Query logs: service=aframp-backend metric={} window=5m",
+                slo.metric_name
+            ),
+        })
+    }
+
+    /// Query a Prometheus range vector and return the last N data points as a JSON array.
+    async fn query_range_metric(&self, metric: &str, range_secs: u64) -> serde_json::Value {
+        let url = format!("{}/api/v1/query_range", self.prometheus_url);
+        let end = Utc::now().timestamp();
+        let start = end - range_secs as i64;
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[
+                ("query", metric),
+                ("start", &start.to_string()),
+                ("end", &end.to_string()),
+                ("step", "30"),
+            ])
+            .send()
+            .await;
+
+        match resp {
+            Ok(r) => r.json::<serde_json::Value>().await.unwrap_or(serde_json::Value::Null),
+            Err(_) => serde_json::Value::Null,
+        }
+    }
+}

--- a/src/sla/report_worker.rs
+++ b/src/sla/report_worker.rs
@@ -1,0 +1,97 @@
+/// Monthly SLA compliance report generator.
+///
+/// Runs on the 1st of each month (or on demand via the API) and produces
+/// a `sla_compliance_reports` row for every partner and one platform-wide row.
+use crate::sla::repository::SlaRepository;
+use chrono::{Datelike, NaiveDate, Utc};
+use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::sync::watch;
+use tokio::time::{interval, Duration};
+use tracing::{error, info};
+
+/// Check every hour; generate when the day-of-month rolls to 1.
+const CHECK_INTERVAL_SECS: u64 = 3600;
+
+pub struct SlaReportWorker {
+    repo: Arc<SlaRepository>,
+    pool: PgPool,
+}
+
+impl SlaReportWorker {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            repo: Arc::new(SlaRepository::new(pool.clone())),
+            pool,
+        }
+    }
+
+    pub async fn run(self, mut shutdown_rx: watch::Receiver<bool>) {
+        info!("SlaReportWorker started");
+        let mut ticker = interval(Duration::from_secs(CHECK_INTERVAL_SECS));
+        ticker.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => { break; }
+                _ = ticker.tick() => {
+                    let now = Utc::now();
+                    // Generate on the 1st of each month
+                    if now.day() == 1 && now.hour() < 2 {
+                        let prev = {
+                            let (y, m) = if now.month() == 1 {
+                                (now.year() - 1, 12u32)
+                            } else {
+                                (now.year(), now.month() - 1)
+                            };
+                            NaiveDate::from_ymd_opt(y, m, 1).unwrap()
+                        };
+                        if let Err(e) = self.generate_for_month(prev).await {
+                            error!(error = %e, month = %prev, "SLA report generation failed");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub async fn generate_for_month(&self, month: NaiveDate) -> anyhow::Result<()> {
+        // Platform-wide report
+        let report = self.repo.generate_monthly_report(None, month).await?;
+        info!(
+            month = %month,
+            total_breaches = report.total_breaches,
+            availability_pct = ?report.availability_pct,
+            "Platform SLA report generated"
+        );
+
+        // Per-partner reports — collect distinct partner IDs from incidents
+        let partner_ids: Vec<uuid::Uuid> = sqlx::query_scalar!(
+            r#"SELECT DISTINCT p.id FROM partners p
+               JOIN sla_breach_incidents i ON TRUE
+               WHERE i.detected_at >= $1 AND i.detected_at < $2"#,
+            month.and_hms_opt(0, 0, 0).unwrap().and_utc(),
+            {
+                let (y, m) = if month.month() == 12 {
+                    (month.year() + 1, 1u32)
+                } else {
+                    (month.year(), month.month() + 1)
+                };
+                NaiveDate::from_ymd_opt(y, m, 1)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+                    .and_utc()
+            }
+        )
+        .fetch_all(&self.pool)
+        .await
+        .unwrap_or_default();
+
+        for pid in partner_ids {
+            let _ = self.repo.generate_monthly_report(Some(pid), month).await;
+        }
+
+        Ok(())
+    }
+}

--- a/src/sla/repository.rs
+++ b/src/sla/repository.rs
@@ -1,0 +1,306 @@
+use crate::sla::models::*;
+use chrono::{Datelike, NaiveDate, Utc};
+use sqlx::types::BigDecimal;
+use sqlx::PgPool;
+use std::str::FromStr;
+use uuid::Uuid;
+
+pub struct SlaRepository {
+    pool: PgPool,
+}
+
+impl SlaRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    // ── SLO definitions ───────────────────────────────────────────────────────
+
+    pub async fn list_slos(&self) -> sqlx::Result<Vec<SloDefinition>> {
+        sqlx::query_as!(
+            SloDefinition,
+            "SELECT * FROM slo_definitions WHERE enabled = TRUE ORDER BY severity, name"
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // ── Breach incidents ──────────────────────────────────────────────────────
+
+    pub async fn open_incident(
+        &self,
+        slo_id: Uuid,
+        observed_value: f64,
+        threshold_value: f64,
+        affected_service: &str,
+        context: serde_json::Value,
+    ) -> sqlx::Result<SlaBreachIncident> {
+        let obs = BigDecimal::from_str(&observed_value.to_string()).unwrap_or_default();
+        let thr = BigDecimal::from_str(&threshold_value.to_string()).unwrap_or_default();
+        sqlx::query_as!(
+            SlaBreachIncident,
+            r#"INSERT INTO sla_breach_incidents
+               (slo_id, observed_value, threshold_value, affected_service, context_snapshot)
+               VALUES ($1, $2, $3, $4, $5)
+               RETURNING *"#,
+            slo_id,
+            obs,
+            thr,
+            affected_service,
+            context,
+        )
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn update_incident(
+        &self,
+        id: Uuid,
+        req: &UpdateIncidentRequest,
+    ) -> sqlx::Result<SlaBreachIncident> {
+        sqlx::query_as!(
+            SlaBreachIncident,
+            r#"UPDATE sla_breach_incidents SET
+               status               = COALESCE($2, status),
+               root_cause_summary   = COALESCE($3, root_cause_summary),
+               remediation_steps    = COALESCE($4, remediation_steps),
+               etr                  = COALESCE($5, etr),
+               resolved_at          = CASE WHEN $2 = 'resolved' THEN NOW() ELSE resolved_at END,
+               updated_at           = NOW()
+               WHERE id = $1
+               RETURNING *"#,
+            id,
+            req.status.as_deref(),
+            req.root_cause_summary.as_deref(),
+            req.remediation_steps.as_deref(),
+            req.etr,
+        )
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn mark_partners_notified(&self, id: Uuid) -> sqlx::Result<()> {
+        sqlx::query!(
+            "UPDATE sla_breach_incidents SET partners_notified = TRUE, notification_sent_at = NOW(), updated_at = NOW() WHERE id = $1",
+            id
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn list_open_incidents(&self) -> sqlx::Result<Vec<SlaBreachIncident>> {
+        sqlx::query_as!(
+            SlaBreachIncident,
+            "SELECT * FROM sla_breach_incidents WHERE status NOT IN ('closed') ORDER BY detected_at DESC"
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    pub async fn list_incidents_by_status(
+        &self,
+        status: Option<&str>,
+    ) -> sqlx::Result<Vec<SlaBreachIncident>> {
+        match status {
+            Some(s) => sqlx::query_as!(
+                SlaBreachIncident,
+                "SELECT * FROM sla_breach_incidents WHERE status = $1 ORDER BY detected_at DESC",
+                s
+            )
+            .fetch_all(&self.pool)
+            .await,
+            None => sqlx::query_as!(
+                SlaBreachIncident,
+                "SELECT * FROM sla_breach_incidents ORDER BY detected_at DESC LIMIT 100"
+            )
+            .fetch_all(&self.pool)
+            .await,
+        }
+    }
+
+    pub async fn get_incident(&self, id: Uuid) -> sqlx::Result<Option<SlaBreachIncident>> {
+        sqlx::query_as!(
+            SlaBreachIncident,
+            "SELECT * FROM sla_breach_incidents WHERE id = $1",
+            id
+        )
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    // ── Post-mortems ──────────────────────────────────────────────────────────
+
+    pub async fn create_post_mortem(
+        &self,
+        incident_id: Uuid,
+        req: &CreatePostMortemRequest,
+    ) -> sqlx::Result<SlaPostMortem> {
+        sqlx::query_as!(
+            SlaPostMortem,
+            r#"INSERT INTO sla_post_mortems
+               (incident_id, author, timeline, root_cause, contributing_factors,
+                remediation, preventive_measures, action_items)
+               VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+               RETURNING *"#,
+            incident_id,
+            req.author,
+            req.timeline,
+            req.root_cause,
+            req.contributing_factors.as_deref(),
+            req.remediation,
+            req.preventive_measures,
+            req.action_items,
+        )
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn get_post_mortem(
+        &self,
+        incident_id: Uuid,
+    ) -> sqlx::Result<Option<SlaPostMortem>> {
+        sqlx::query_as!(
+            SlaPostMortem,
+            "SELECT * FROM sla_post_mortems WHERE incident_id = $1",
+            incident_id
+        )
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    // ── Compliance reports ────────────────────────────────────────────────────
+
+    pub async fn generate_monthly_report(
+        &self,
+        partner_id: Option<Uuid>,
+        month: NaiveDate,
+    ) -> sqlx::Result<SlaComplianceReport> {
+        let month_start = NaiveDate::from_ymd_opt(month.year(), month.month(), 1)
+            .unwrap_or(month);
+        let month_end = {
+            let (y, m) = if month.month() == 12 {
+                (month.year() + 1, 1)
+            } else {
+                (month.year(), month.month() + 1)
+            };
+            NaiveDate::from_ymd_opt(y, m, 1).unwrap()
+        };
+
+        // Collect breach IDs for the month
+        let breach_ids: Vec<Uuid> = sqlx::query_scalar!(
+            "SELECT id FROM sla_breach_incidents WHERE detected_at >= $1 AND detected_at < $2",
+            month_start.and_hms_opt(0, 0, 0).unwrap().and_utc(),
+            month_end.and_hms_opt(0, 0, 0).unwrap().and_utc(),
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let total = breach_ids.len() as i32;
+
+        // MTTR: average seconds between detected_at and resolved_at
+        let mttr: Option<BigDecimal> = sqlx::query_scalar!(
+            r#"SELECT AVG(EXTRACT(EPOCH FROM (resolved_at - detected_at)))
+               FROM sla_breach_incidents
+               WHERE detected_at >= $1 AND detected_at < $2 AND resolved_at IS NOT NULL"#,
+            month_start.and_hms_opt(0, 0, 0).unwrap().and_utc(),
+            month_end.and_hms_opt(0, 0, 0).unwrap().and_utc(),
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Availability: 100 - (total_breach_window_seconds / month_seconds * 100)
+        let month_secs = (month_end - month_start).num_seconds() as f64;
+        let breach_secs: Option<f64> = sqlx::query_scalar!(
+            r#"SELECT COALESCE(SUM(EXTRACT(EPOCH FROM
+                 COALESCE(resolved_at, NOW()) - detected_at)), 0)
+               FROM sla_breach_incidents
+               WHERE detected_at >= $1 AND detected_at < $2"#,
+            month_start.and_hms_opt(0, 0, 0).unwrap().and_utc(),
+            month_end.and_hms_opt(0, 0, 0).unwrap().and_utc(),
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let availability = breach_secs.map(|bs| {
+            let pct = 100.0 - (bs / month_secs * 100.0);
+            BigDecimal::from_str(&format!("{:.4}", pct.max(0.0))).unwrap_or_default()
+        });
+
+        sqlx::query_as!(
+            SlaComplianceReport,
+            r#"INSERT INTO sla_compliance_reports
+               (partner_id, report_month, total_breaches, mttr_seconds, availability_pct, breach_ids)
+               VALUES ($1, $2, $3, $4, $5, $6)
+               ON CONFLICT (partner_id, report_month) DO UPDATE SET
+                 total_breaches   = EXCLUDED.total_breaches,
+                 mttr_seconds     = EXCLUDED.mttr_seconds,
+                 availability_pct = EXCLUDED.availability_pct,
+                 breach_ids       = EXCLUDED.breach_ids,
+                 generated_at     = NOW()
+               RETURNING *"#,
+            partner_id,
+            month_start,
+            total,
+            mttr,
+            availability,
+            &breach_ids,
+        )
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn list_reports(
+        &self,
+        partner_id: Option<Uuid>,
+    ) -> sqlx::Result<Vec<SlaComplianceReport>> {
+        sqlx::query_as!(
+            SlaComplianceReport,
+            r#"SELECT * FROM sla_compliance_reports
+               WHERE ($1::uuid IS NULL OR partner_id = $1)
+               ORDER BY report_month DESC LIMIT 24"#,
+            partner_id,
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // ── Dashboard aggregates ──────────────────────────────────────────────────
+
+    pub async fn dashboard_stats(&self) -> sqlx::Result<(i64, Option<f64>, Option<f64>)> {
+        let since = Utc::now() - chrono::Duration::days(30);
+
+        let count: i64 = sqlx::query_scalar!(
+            "SELECT COUNT(*) FROM sla_breach_incidents WHERE detected_at >= $1",
+            since
+        )
+        .fetch_one(&self.pool)
+        .await?
+        .unwrap_or(0);
+
+        let mttr: Option<f64> = sqlx::query_scalar!(
+            r#"SELECT AVG(EXTRACT(EPOCH FROM (resolved_at - detected_at)))
+               FROM sla_breach_incidents
+               WHERE detected_at >= $1 AND resolved_at IS NOT NULL"#,
+            since
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let breach_secs: Option<f64> = sqlx::query_scalar!(
+            r#"SELECT COALESCE(SUM(EXTRACT(EPOCH FROM
+                 COALESCE(resolved_at, NOW()) - detected_at)), 0)
+               FROM sla_breach_incidents WHERE detected_at >= $1"#,
+            since
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let avail = breach_secs.map(|bs| {
+            let month_secs = 30.0 * 86400.0;
+            (100.0 - (bs / month_secs * 100.0)).max(0.0)
+        });
+
+        Ok((count, mttr, avail))
+    }
+}


### PR DESCRIPTION
- Add slo_definitions, sla_breach_incidents, sla_post_mortems, sla_compliance_reports tables with 5 seeded SLOs
- SlaMonitorWorker: polls Prometheus every 60s, opens breach incident with forensic context snapshot (latency traces, error rate, log hints)
- SlaReportWorker: auto-generates monthly per-partner compliance reports
- REST API: dashboard, incidents (w/ status filter), post-mortems, reports
- Wire workers and routes into main.rs

Closes #405 