### PR TITLE
feat(infra): horizontal scaling with K8s HPA and Terraform EKS

### DIFF
--- a/infra/k8s/deployment.yaml
+++ b/infra/k8s/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aframp-backend
+  namespace: aframp
+  labels:
+    app: aframp-backend
+    version: "1.0"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: aframp-backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: aframp-backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: aframp-backend
+          image: aframp/backend:latest
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 9090
+              name: metrics
+          env:
+            - name: REGION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['topology.kubernetes.io/region']
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: aframp-db-secrets
+                  key: database_url
+            - name: DATABASE_READ_REPLICA_URL
+              valueFrom:
+                secretKeyRef:
+                  name: aframp-db-secrets
+                  key: database_read_replica_url
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: aframp-cache-secrets
+                  key: redis_url
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                # Drain in-flight requests before pod termination (graceful scale-down)
+                command: ["/bin/sh", "-c", "sleep 10"]
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: aframp-backend
+                topologyKey: kubernetes.io/hostname

--- a/infra/k8s/hpa.yaml
+++ b/infra/k8s/hpa.yaml
@@ -1,0 +1,59 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: aframp-backend-hpa
+  namespace: aframp
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: aframp-backend
+  minReplicas: 3
+  maxReplicas: 20
+  metrics:
+    # Scale on CPU — triggers at 60% utilisation per issue requirement
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+    # Scale on memory
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 70
+    # Custom metric: requests per second from Prometheus adapter
+    - type: Pods
+      pods:
+        metric:
+          name: http_requests_per_second
+        target:
+          type: AverageValue
+          averageValue: "500"
+    # Custom metric: event queue depth (for EDA consumer scaling)
+    - type: External
+      external:
+        metric:
+          name: event_queue_depth
+          selector:
+            matchLabels:
+              queue: aframp-events
+        target:
+          type: AverageValue
+          averageValue: "1000"
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60   # Cooldown: prevent flapping on scale-up
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300  # Cooldown: conservative scale-down (5 min)
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/infra/k8s/service.yaml
+++ b/infra/k8s/service.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aframp-backend
+  namespace: aframp
+  labels:
+    app: aframp-backend
+spec:
+  selector:
+    app: aframp-backend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aframp-backend-ingress
+  namespace: aframp
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - api.aframp.io
+      secretName: aframp-tls
+  rules:
+    - host: api.aframp.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: aframp-backend
+                port:
+                  number: 80

--- a/infra/terraform/horizontal_scaling.tf
+++ b/infra/terraform/horizontal_scaling.tf
@@ -1,0 +1,172 @@
+# Horizontal Scaling Infrastructure (Issue #397)
+# Provisions EKS cluster with node auto-scaling groups per region.
+# Replicable across staging and production via workspace variables.
+
+variable "environment" {
+  description = "Deployment environment (staging | production)"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  default     = "aframp-cluster"
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for worker nodes"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "node_min_size" {
+  type    = number
+  default = 2
+}
+
+variable "node_max_size" {
+  type    = number
+  default = 20
+}
+
+variable "node_desired_size" {
+  type    = number
+  default = 3
+}
+
+# ── EKS Cluster ──────────────────────────────────────────────────────────────
+
+resource "aws_eks_cluster" "aframp" {
+  name     = "${var.cluster_name}-${var.environment}"
+  role_arn = aws_iam_role.eks_cluster.arn
+  version  = "1.29"
+
+  vpc_config {
+    subnet_ids              = aws_subnet.private[*].id
+    endpoint_private_access = true
+    endpoint_public_access  = false
+  }
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# ── Managed Node Group with Auto-Scaling ─────────────────────────────────────
+
+resource "aws_eks_node_group" "aframp_workers" {
+  cluster_name    = aws_eks_cluster.aframp.name
+  node_group_name = "aframp-workers-${var.environment}"
+  node_role_arn   = aws_iam_role.eks_node.arn
+  subnet_ids      = aws_subnet.private[*].id
+  instance_types  = [var.node_instance_type]
+
+  scaling_config {
+    min_size     = var.node_min_size
+    max_size     = var.node_max_size
+    desired_size = var.node_desired_size
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  labels = {
+    environment = var.environment
+    role        = "worker"
+  }
+
+  tags = {
+    Environment                                                   = var.environment
+    "k8s.io/cluster-autoscaler/${aws_eks_cluster.aframp.name}"   = "owned"
+    "k8s.io/cluster-autoscaler/enabled"                          = "true"
+  }
+}
+
+# ── Cluster Autoscaler IAM ────────────────────────────────────────────────────
+
+resource "aws_iam_role" "eks_cluster" {
+  name = "aframp-eks-cluster-${var.environment}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "eks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role" "eks_node" {
+  name = "aframp-eks-node-${var.environment}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "eks_worker_node_policy" {
+  role       = aws_iam_role.eks_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cni_policy" {
+  role       = aws_iam_role.eks_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "eks_ecr_readonly" {
+  role       = aws_iam_role.eks_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+# ── Cluster Autoscaler policy (scales node groups based on pending pods) ──────
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name = "aframp-cluster-autoscaler-${var.environment}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeScalingActivities",
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeLaunchTemplateVersions",
+        "ec2:GetInstanceTypesFromInstanceRequirements",
+        "eks:DescribeNodegroup"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.aframp.endpoint
+}
+
+output "cluster_name" {
+  value = aws_eks_cluster.aframp.name
+}


### PR DESCRIPTION
Implements elastic horizontal scaling infrastructure for Issue #397.

K8s manifests:
- deployment.yaml: stateless pods with PreStop drain hook (10s), pod anti-affinity for HA, readiness/liveness probes, resource limits
- hpa.yaml: HorizontalPodAutoscaler scaling on CPU (60%), memory (70%), http_requests_per_second, and event_queue_depth custom metrics; scale-up cooldown 60s, scale-down cooldown 300s (prevents flapping)
- service.yaml: ClusterIP + Nginx Ingress with TLS termination

Terraform IaC (horizontal_scaling.tf):
- EKS cluster with managed node group (min=2, max=20, desired=3)
- Cluster Autoscaler IAM policy for node group scaling
- Parameterised by environment/region — replicable across staging/prod without configuration drift

Closes #397 