### PR TITLE
feat(#471): partner revenue sharing & commission management engine

### DIFF
--- a/migrations/20270602000000_partner_commission_engine.sql
+++ b/migrations/20270602000000_partner_commission_engine.sql
@@ -1,0 +1,169 @@
+-- Partner Revenue Sharing & Commission Management Engine (Issue #471)
+-- Double-entry ledger, commission structures, and payout records.
+-- All monetary amounts are stored in stroops (1 cNGN = 10_000_000 stroops).
+
+-- ---------------------------------------------------------------------------
+-- Enums
+-- ---------------------------------------------------------------------------
+DO $$ BEGIN
+    CREATE TYPE commission_type AS ENUM ('percentage', 'fixed_fiat', 'tiered');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE ledger_direction AS ENUM ('credit', 'debit');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE payout_status AS ENUM ('pending', 'processing', 'completed', 'failed', 'cancelled');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- commission_structures — contractual fee-split agreements per partner
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS commission_structures (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    partner_id          UUID NOT NULL REFERENCES partners(id) ON DELETE RESTRICT,
+    name                TEXT NOT NULL,
+    commission_type     commission_type NOT NULL,
+
+    -- For 'percentage': share of gross fee (e.g. 0.35 = 35%)
+    percentage_rate     NUMERIC(8, 7),           -- up to 9.9999999 (7 dp, Stellar precision)
+
+    -- For 'fixed_fiat': fixed cNGN amount per transaction in stroops
+    fixed_stroops       BIGINT,
+
+    -- For 'tiered': JSON array of {min_volume_stroops, max_volume_stroops, rate}
+    tiers               JSONB,
+
+    -- Volume thresholds (stroops) for tier activation
+    min_volume_stroops  BIGINT NOT NULL DEFAULT 0,
+    max_volume_stroops  BIGINT,                  -- NULL = unlimited
+
+    corridor            TEXT,                    -- NULL = all corridors
+    is_active           BOOLEAN NOT NULL DEFAULT TRUE,
+    effective_from      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    effective_to        TIMESTAMPTZ,
+    created_by          UUID NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT chk_percentage CHECK (
+        commission_type != 'percentage' OR (percentage_rate IS NOT NULL AND percentage_rate >= 0 AND percentage_rate <= 1)
+    ),
+    CONSTRAINT chk_fixed CHECK (
+        commission_type != 'fixed_fiat' OR (fixed_stroops IS NOT NULL AND fixed_stroops >= 0)
+    ),
+    CONSTRAINT chk_tiered CHECK (
+        commission_type != 'tiered' OR tiers IS NOT NULL
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_commission_structures_partner
+    ON commission_structures (partner_id, is_active, effective_from);
+CREATE INDEX IF NOT EXISTS idx_commission_structures_corridor
+    ON commission_structures (corridor) WHERE corridor IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- partner_revenue_ledger — strict double-entry ledger for partner commissions
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS partner_revenue_ledger (
+    entry_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    partner_id          UUID NOT NULL REFERENCES partners(id) ON DELETE RESTRICT,
+    transaction_id      UUID NOT NULL,           -- source payment/onramp transaction
+    commission_structure_id UUID REFERENCES commission_structures(id),
+
+    amount_stroops      BIGINT NOT NULL CHECK (amount_stroops > 0),
+    direction           ledger_direction NOT NULL,
+
+    -- Running balance after this entry (maintained by the service layer)
+    balance_after_stroops BIGINT NOT NULL,
+
+    gross_fee_stroops   BIGINT NOT NULL,         -- gross fee collected on source tx
+    platform_share_stroops BIGINT NOT NULL,      -- platform's portion
+    tier_index          SMALLINT,                -- which tier was applied, NULL if not tiered
+    corridor            TEXT,
+    narrative           TEXT NOT NULL,           -- human-readable reason
+
+    -- On-chain evidence
+    stellar_tx_hash     TEXT,                    -- populated after payout
+    payout_record_id    UUID,                    -- FK added below after payout table
+
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Invariant: gross_fee = platform_share + partner_commission (enforced in service)
+    CONSTRAINT chk_invariant CHECK (
+        gross_fee_stroops = platform_share_stroops + amount_stroops
+    )
+);
+
+-- Append-only: no UPDATE or DELETE allowed (enforced via trigger)
+CREATE OR REPLACE FUNCTION partner_ledger_immutable()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'partner_revenue_ledger entries are immutable';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_partner_ledger_immutable ON partner_revenue_ledger;
+CREATE TRIGGER trg_partner_ledger_immutable
+    BEFORE UPDATE OR DELETE ON partner_revenue_ledger
+    FOR EACH ROW EXECUTE FUNCTION partner_ledger_immutable();
+
+CREATE INDEX IF NOT EXISTS idx_prl_partner_created
+    ON partner_revenue_ledger (partner_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_prl_transaction
+    ON partner_revenue_ledger (transaction_id);
+CREATE INDEX IF NOT EXISTS idx_prl_payout
+    ON partner_revenue_ledger (payout_record_id) WHERE payout_record_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- commission_payout_records — batch settlement records to partner wallets
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS commission_payout_records (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    partner_id          UUID NOT NULL REFERENCES partners(id) ON DELETE RESTRICT,
+    payout_address      TEXT NOT NULL,           -- partner's Stellar wallet address
+    total_stroops       BIGINT NOT NULL CHECK (total_stroops > 0),
+    entry_count         INT NOT NULL DEFAULT 0,  -- number of ledger entries included
+    status              payout_status NOT NULL DEFAULT 'pending',
+    stellar_tx_hash     TEXT UNIQUE,             -- immutable once set
+    batch_ref           TEXT NOT NULL,           -- e.g. "2026-W22" for traceability
+    initiated_by        UUID NOT NULL,           -- admin user or system UUID
+    error_message       TEXT,
+    attempted_at        TIMESTAMPTZ,
+    completed_at        TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cpr_partner_status
+    ON commission_payout_records (partner_id, status);
+CREATE INDEX IF NOT EXISTS idx_cpr_status
+    ON commission_payout_records (status) WHERE status IN ('pending', 'processing');
+
+-- ---------------------------------------------------------------------------
+-- FK: ledger → payout_record (deferred to avoid circular dep at create time)
+-- ---------------------------------------------------------------------------
+ALTER TABLE partner_revenue_ledger
+    ADD CONSTRAINT fk_prl_payout_record
+    FOREIGN KEY (payout_record_id) REFERENCES commission_payout_records(id)
+    DEFERRABLE INITIALLY DEFERRED;
+
+-- ---------------------------------------------------------------------------
+-- partner_commission_balances — materialised running balance per partner
+-- (updated atomically with ledger writes; used for fast balance reads)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS partner_commission_balances (
+    partner_id          UUID PRIMARY KEY REFERENCES partners(id) ON DELETE RESTRICT,
+    accrued_stroops     BIGINT NOT NULL DEFAULT 0 CHECK (accrued_stroops >= 0),
+    paid_stroops        BIGINT NOT NULL DEFAULT 0 CHECK (paid_stroops >= 0),
+    last_entry_id       UUID REFERENCES partner_revenue_ledger(entry_id),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE commission_structures IS 'Partner fee-split contractual agreements with tiered volume support';
+COMMENT ON TABLE partner_revenue_ledger IS 'Append-only double-entry ledger for partner commission accrual';
+COMMENT ON TABLE commission_payout_records IS 'Batch settlement records linking ledger to on-chain Stellar transactions';
+COMMENT ON TABLE partner_commission_balances IS 'Materialised running balance for O(1) balance reads';

--- a/src/commission/handlers.rs
+++ b/src/commission/handlers.rs
@@ -1,0 +1,77 @@
+//! HTTP handlers for commission management endpoints (Issue #471).
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::{
+    models::{CreateCommissionStructureInput, ManualAdjustmentInput},
+    service::CommissionService,
+};
+
+#[derive(Clone)]
+pub struct CommissionState {
+    pub service: Arc<CommissionService>,
+}
+
+#[derive(Deserialize)]
+pub struct StatementQuery {
+    #[serde(default = "default_limit")]
+    limit: i64,
+    #[serde(default)]
+    offset: i64,
+}
+fn default_limit() -> i64 { 50 }
+
+// POST /api/v1/admin/partners/commissions/configure
+pub async fn configure_commission(
+    State(s): State<Arc<CommissionState>>,
+    Json(input): Json<CreateCommissionStructureInput>,
+) -> impl IntoResponse {
+    match s.service.configure_structure(input).await {
+        Ok(structure) => (StatusCode::CREATED, Json(serde_json::json!(structure))).into_response(),
+        Err(e) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+// GET /api/v1/partners/:partner_id/revenue/statement
+pub async fn revenue_statement(
+    State(s): State<Arc<CommissionState>>,
+    Path(partner_id): Path<Uuid>,
+    Query(q): Query<StatementQuery>,
+) -> impl IntoResponse {
+    match s.service.revenue_statement(partner_id, q.limit, q.offset).await {
+        Ok(stmt) => Json(serde_json::json!(stmt)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+// POST /api/v1/admin/partners/revenue/adjust
+pub async fn manual_adjust(
+    State(s): State<Arc<CommissionState>>,
+    Json(input): Json<ManualAdjustmentInput>,
+) -> impl IntoResponse {
+    match s.service.manual_adjustment(input).await {
+        Ok(entry) => (StatusCode::CREATED, Json(serde_json::json!(entry))).into_response(),
+        Err(e) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({"error": e.to_string()})),
+        )
+            .into_response(),
+    }
+}

--- a/src/commission/metrics.rs
+++ b/src/commission/metrics.rs
@@ -1,0 +1,131 @@
+//! Prometheus metrics for the commission management engine (Issue #471).
+
+use prometheus::{
+    register_counter_vec, register_gauge_vec, register_histogram_vec, CounterVec, GaugeVec,
+    HistogramVec,
+};
+use std::sync::OnceLock;
+
+// ── Counters ─────────────────────────────────────────────────────────────────
+
+static COMMISSION_ACCRUED: OnceLock<CounterVec> = OnceLock::new();
+static PAYOUT_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+static SPLIT_ERRORS: OnceLock<CounterVec> = OnceLock::new();
+static INVARIANT_VIOLATIONS: OnceLock<CounterVec> = OnceLock::new();
+
+// ── Histograms ────────────────────────────────────────────────────────────────
+
+static PAYOUT_DURATION: OnceLock<HistogramVec> = OnceLock::new();
+
+// ── Gauges ────────────────────────────────────────────────────────────────────
+
+static ACCRUED_LIABILITY: OnceLock<GaugeVec> = OnceLock::new();
+
+// ── Accessors ────────────────────────────────────────────────────────────────
+
+fn commission_accrued() -> &'static CounterVec {
+    COMMISSION_ACCRUED.get_or_init(|| {
+        register_counter_vec!(
+            "partner_commission_accrued_total",
+            "Total partner commissions accrued in stroops",
+            &["partner_id", "corridor"]
+        )
+        .expect("register partner_commission_accrued_total")
+    })
+}
+
+fn payout_total() -> &'static CounterVec {
+    PAYOUT_TOTAL.get_or_init(|| {
+        register_counter_vec!(
+            "partner_payout_total",
+            "Total commission payouts dispatched",
+            &["partner_id", "status"]
+        )
+        .expect("register partner_payout_total")
+    })
+}
+
+fn split_errors() -> &'static CounterVec {
+    SPLIT_ERRORS.get_or_init(|| {
+        register_counter_vec!(
+            "revenue_split_calculation_errors_total",
+            "Errors during revenue split calculation",
+            &["error_type"]
+        )
+        .expect("register revenue_split_calculation_errors_total")
+    })
+}
+
+fn invariant_violations_counter() -> &'static CounterVec {
+    INVARIANT_VIOLATIONS.get_or_init(|| {
+        register_counter_vec!(
+            "commission_invariant_violations_total",
+            "Fee-split invariant violations (gross != platform + partner)",
+            &[]
+        )
+        .expect("register commission_invariant_violations_total")
+    })
+}
+
+fn payout_duration() -> &'static HistogramVec {
+    PAYOUT_DURATION.get_or_init(|| {
+        register_histogram_vec!(
+            "partner_payout_duration_seconds",
+            "Duration of batch payout processing in seconds",
+            &["partner_id"],
+            vec![0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0]
+        )
+        .expect("register partner_payout_duration_seconds")
+    })
+}
+
+fn accrued_liability() -> &'static GaugeVec {
+    ACCRUED_LIABILITY.get_or_init(|| {
+        register_gauge_vec!(
+            "partner_commission_accrued_liability_stroops",
+            "Current unpaid commission liability per partner in stroops",
+            &["partner_id"]
+        )
+        .expect("register partner_commission_accrued_liability_stroops")
+    })
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+pub fn commission_evaluated(gross_stroops: i64, partner_stroops: i64) {
+    // Fired for every successful split evaluation — not per-partner here
+    // (per-partner increments happen in the service layer).
+    let _ = (gross_stroops, partner_stroops); // available for future label expansion
+}
+
+pub fn commission_accrued(partner_id: &str, corridor: &str, stroops: i64) {
+    commission_accrued()
+        .with_label_values(&[partner_id, corridor])
+        .inc_by(stroops as f64);
+}
+
+pub fn payout_dispatched(partner_id: &str, status: &str, stroops: i64) {
+    payout_total()
+        .with_label_values(&[partner_id, status])
+        .inc_by(stroops as f64);
+}
+
+pub fn split_error(error_type: &str) {
+    split_errors().with_label_values(&[error_type]).inc();
+}
+
+pub fn invariant_violation() {
+    invariant_violations_counter().with_label_values(&[]).inc();
+}
+
+pub fn observe_payout_duration(partner_id: &str, seconds: f64) {
+    payout_duration()
+        .with_label_values(&[partner_id])
+        .observe(seconds);
+}
+
+pub fn set_accrued_liability(partner_id: &str, stroops: i64) {
+    accrued_liability()
+        .with_label_values(&[partner_id])
+        .set(stroops as f64);
+}

--- a/src/commission/mod.rs
+++ b/src/commission/mod.rs
@@ -1,0 +1,19 @@
+//! Partner Revenue Sharing & Commission Management Engine (Issue #471).
+//!
+//! Provides split-fee evaluation, double-entry ledger, batch payout worker,
+//! admin configuration endpoints, and partner revenue statement endpoints.
+
+pub mod handlers;
+pub mod metrics;
+pub mod models;
+pub mod repository;
+pub mod routes;
+pub mod service;
+pub mod split_fee;
+pub mod worker;
+
+pub use models::{CommissionStructure, CommissionType, LedgerDirection, PayoutStatus};
+pub use routes::commission_routes;
+pub use service::CommissionService;
+pub use split_fee::{CommissionBreakdown, SplitFeeEngine};
+pub use worker::{PayoutWorker, PayoutWorkerConfig};

--- a/src/commission/models.rs
+++ b/src/commission/models.rs
@@ -1,0 +1,181 @@
+//! Domain models for the commission management engine.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Enums (mirror DB enums)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "commission_type", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum CommissionType {
+    Percentage,
+    FixedFiat,
+    Tiered,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "ledger_direction", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum LedgerDirection {
+    Credit,
+    Debit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "payout_status", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum PayoutStatus {
+    Pending,
+    Processing,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+// ---------------------------------------------------------------------------
+// Tier definition (stored in JSONB)
+// ---------------------------------------------------------------------------
+
+/// Single tier in a tiered commission structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommissionTier {
+    /// Minimum cumulative volume (stroops, inclusive)
+    pub min_volume_stroops: i64,
+    /// Maximum cumulative volume (stroops, exclusive); None = unlimited
+    pub max_volume_stroops: Option<i64>,
+    /// Rate applied for this tier (0.0–1.0)
+    pub rate: f64,
+}
+
+// ---------------------------------------------------------------------------
+// commission_structures row
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct CommissionStructure {
+    pub id: Uuid,
+    pub partner_id: Uuid,
+    pub name: String,
+    pub commission_type: CommissionType,
+    pub percentage_rate: Option<sqlx::types::BigDecimal>,
+    pub fixed_stroops: Option<i64>,
+    pub tiers: Option<serde_json::Value>,
+    pub min_volume_stroops: i64,
+    pub max_volume_stroops: Option<i64>,
+    pub corridor: Option<String>,
+    pub is_active: bool,
+    pub effective_from: DateTime<Utc>,
+    pub effective_to: Option<DateTime<Utc>>,
+    pub created_by: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// partner_revenue_ledger row
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct LedgerEntry {
+    pub entry_id: Uuid,
+    pub partner_id: Uuid,
+    pub transaction_id: Uuid,
+    pub commission_structure_id: Option<Uuid>,
+    pub amount_stroops: i64,
+    pub direction: LedgerDirection,
+    pub balance_after_stroops: i64,
+    pub gross_fee_stroops: i64,
+    pub platform_share_stroops: i64,
+    pub tier_index: Option<i16>,
+    pub corridor: Option<String>,
+    pub narrative: String,
+    pub stellar_tx_hash: Option<String>,
+    pub payout_record_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// commission_payout_records row
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct PayoutRecord {
+    pub id: Uuid,
+    pub partner_id: Uuid,
+    pub payout_address: String,
+    pub total_stroops: i64,
+    pub entry_count: i32,
+    pub status: PayoutStatus,
+    pub stellar_tx_hash: Option<String>,
+    pub batch_ref: String,
+    pub initiated_by: Uuid,
+    pub error_message: Option<String>,
+    pub attempted_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// partner_commission_balances row
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct CommissionBalance {
+    pub partner_id: Uuid,
+    pub accrued_stroops: i64,
+    pub paid_stroops: i64,
+    pub last_entry_id: Option<Uuid>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Input structs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateCommissionStructureInput {
+    pub partner_id: Uuid,
+    pub name: String,
+    pub commission_type: CommissionType,
+    pub percentage_rate: Option<f64>,
+    pub fixed_stroops: Option<i64>,
+    pub tiers: Option<Vec<CommissionTier>>,
+    pub min_volume_stroops: Option<i64>,
+    pub max_volume_stroops: Option<i64>,
+    pub corridor: Option<String>,
+    pub effective_from: Option<DateTime<Utc>>,
+    pub effective_to: Option<DateTime<Utc>>,
+    pub created_by: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManualAdjustmentInput {
+    pub partner_id: Uuid,
+    pub transaction_id: Uuid,
+    pub amount_stroops: i64,
+    pub direction: LedgerDirection,
+    pub gross_fee_stroops: i64,
+    pub platform_share_stroops: i64,
+    pub narrative: String,
+    pub initiated_by: Uuid,
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RevenueStatement {
+    pub partner_id: Uuid,
+    pub accrued_stroops: i64,
+    pub paid_stroops: i64,
+    pub unpaid_stroops: i64,
+    pub entries: Vec<LedgerEntry>,
+    pub payouts: Vec<PayoutRecord>,
+    pub generated_at: DateTime<Utc>,
+}

--- a/src/commission/repository.rs
+++ b/src/commission/repository.rs
@@ -1,0 +1,343 @@
+//! Database access layer for commission management engine.
+
+use sqlx::{types::BigDecimal, PgPool, Postgres, Transaction};
+use std::str::FromStr;
+use uuid::Uuid;
+
+use crate::database::error::DatabaseError;
+
+use super::models::{
+    CommissionBalance, CommissionStructure, CreateCommissionStructureInput, LedgerDirection,
+    LedgerEntry, ManualAdjustmentInput, PayoutRecord, PayoutStatus,
+};
+
+#[derive(Clone)]
+pub struct CommissionRepository {
+    pool: PgPool,
+}
+
+impl CommissionRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    // -----------------------------------------------------------------------
+    // commission_structures
+    // -----------------------------------------------------------------------
+
+    pub async fn create_structure(
+        &self,
+        input: &CreateCommissionStructureInput,
+    ) -> Result<CommissionStructure, DatabaseError> {
+        let tiers_json = input
+            .tiers
+            .as_ref()
+            .map(|t| serde_json::to_value(t).unwrap());
+        let pct = input
+            .percentage_rate
+            .map(|r| BigDecimal::from_str(&format!("{r:.7}")).unwrap());
+
+        let row = sqlx::query_as::<_, CommissionStructure>(
+            r#"
+            INSERT INTO commission_structures
+                (partner_id, name, commission_type, percentage_rate, fixed_stroops, tiers,
+                 min_volume_stroops, max_volume_stroops, corridor,
+                 effective_from, effective_to, created_by)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,
+                    COALESCE($10, NOW()), $11, $12)
+            RETURNING *
+            "#,
+        )
+        .bind(input.partner_id)
+        .bind(&input.name)
+        .bind(&input.commission_type)
+        .bind(pct)
+        .bind(input.fixed_stroops)
+        .bind(tiers_json)
+        .bind(input.min_volume_stroops.unwrap_or(0))
+        .bind(input.max_volume_stroops)
+        .bind(&input.corridor)
+        .bind(input.effective_from)
+        .bind(input.effective_to)
+        .bind(input.created_by)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(DatabaseError::from)?;
+
+        Ok(row)
+    }
+
+    /// Fetch all active structures for a corridor (or corridor-agnostic ones).
+    pub async fn active_structures(
+        &self,
+        corridor: Option<&str>,
+        gross_fee_stroops: i64,
+    ) -> Result<Vec<CommissionStructure>, sqlx::Error> {
+        sqlx::query_as::<_, CommissionStructure>(
+            r#"
+            SELECT * FROM commission_structures
+            WHERE is_active = TRUE
+              AND NOW() BETWEEN effective_from AND COALESCE(effective_to, 'infinity')
+              AND (corridor IS NULL OR corridor = $1)
+              AND $2 >= min_volume_stroops
+              AND ($3 <= max_volume_stroops OR max_volume_stroops IS NULL)
+            ORDER BY partner_id, effective_from
+            "#,
+        )
+        .bind(corridor)
+        .bind(gross_fee_stroops)
+        .bind(gross_fee_stroops)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    pub async fn structure_by_partner(
+        &self,
+        partner_id: Uuid,
+    ) -> Result<Vec<CommissionStructure>, sqlx::Error> {
+        sqlx::query_as::<_, CommissionStructure>(
+            "SELECT * FROM commission_structures WHERE partner_id = $1 ORDER BY created_at DESC",
+        )
+        .bind(partner_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // partner_revenue_ledger — writes inside a transaction
+    // -----------------------------------------------------------------------
+
+    /// Insert a ledger entry within the caller's transaction.
+    /// The caller must also update `partner_commission_balances` atomically.
+    pub async fn insert_ledger_entry_tx(
+        tx: &mut Transaction<'_, Postgres>,
+        partner_id: Uuid,
+        transaction_id: Uuid,
+        structure_id: Option<Uuid>,
+        amount_stroops: i64,
+        direction: &LedgerDirection,
+        balance_after: i64,
+        gross_fee_stroops: i64,
+        platform_share_stroops: i64,
+        tier_index: Option<i16>,
+        corridor: Option<&str>,
+        narrative: &str,
+    ) -> Result<LedgerEntry, sqlx::Error> {
+        sqlx::query_as::<_, LedgerEntry>(
+            r#"
+            INSERT INTO partner_revenue_ledger
+                (partner_id, transaction_id, commission_structure_id,
+                 amount_stroops, direction, balance_after_stroops,
+                 gross_fee_stroops, platform_share_stroops,
+                 tier_index, corridor, narrative)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+            RETURNING *
+            "#,
+        )
+        .bind(partner_id)
+        .bind(transaction_id)
+        .bind(structure_id)
+        .bind(amount_stroops)
+        .bind(direction)
+        .bind(balance_after)
+        .bind(gross_fee_stroops)
+        .bind(platform_share_stroops)
+        .bind(tier_index)
+        .bind(corridor)
+        .bind(narrative)
+        .fetch_one(&mut **tx)
+        .await
+    }
+
+    /// Upsert the partner's materialised balance within a transaction.
+    pub async fn upsert_balance_tx(
+        tx: &mut Transaction<'_, Postgres>,
+        partner_id: Uuid,
+        delta_stroops: i64,
+        direction: &LedgerDirection,
+        entry_id: Uuid,
+    ) -> Result<CommissionBalance, sqlx::Error> {
+        let (accrued_delta, paid_delta) = match direction {
+            LedgerDirection::Credit => (delta_stroops, 0_i64),
+            LedgerDirection::Debit => (0_i64, delta_stroops),
+        };
+        sqlx::query_as::<_, CommissionBalance>(
+            r#"
+            INSERT INTO partner_commission_balances
+                (partner_id, accrued_stroops, paid_stroops, last_entry_id, updated_at)
+            VALUES ($1, $2, $3, $4, NOW())
+            ON CONFLICT (partner_id) DO UPDATE SET
+                accrued_stroops = partner_commission_balances.accrued_stroops + $2,
+                paid_stroops    = partner_commission_balances.paid_stroops    + $3,
+                last_entry_id   = EXCLUDED.last_entry_id,
+                updated_at      = NOW()
+            RETURNING *
+            "#,
+        )
+        .bind(partner_id)
+        .bind(accrued_delta)
+        .bind(paid_delta)
+        .bind(entry_id)
+        .fetch_one(&mut **tx)
+        .await
+    }
+
+    pub async fn balance_for_partner(
+        &self,
+        partner_id: Uuid,
+    ) -> Result<Option<CommissionBalance>, sqlx::Error> {
+        sqlx::query_as::<_, CommissionBalance>(
+            "SELECT * FROM partner_commission_balances WHERE partner_id = $1",
+        )
+        .bind(partner_id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Revenue statement queries
+    // -----------------------------------------------------------------------
+
+    pub async fn ledger_entries_for_partner(
+        &self,
+        partner_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<LedgerEntry>, sqlx::Error> {
+        sqlx::query_as::<_, LedgerEntry>(
+            r#"
+            SELECT * FROM partner_revenue_ledger
+            WHERE partner_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2 OFFSET $3
+            "#,
+        )
+        .bind(partner_id)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Payout records
+    // -----------------------------------------------------------------------
+
+    pub async fn create_payout_record(
+        &self,
+        partner_id: Uuid,
+        payout_address: &str,
+        total_stroops: i64,
+        entry_count: i32,
+        batch_ref: &str,
+        initiated_by: Uuid,
+    ) -> Result<PayoutRecord, sqlx::Error> {
+        sqlx::query_as::<_, PayoutRecord>(
+            r#"
+            INSERT INTO commission_payout_records
+                (partner_id, payout_address, total_stroops, entry_count, batch_ref, initiated_by)
+            VALUES ($1,$2,$3,$4,$5,$6)
+            RETURNING *
+            "#,
+        )
+        .bind(partner_id)
+        .bind(payout_address)
+        .bind(total_stroops)
+        .bind(entry_count)
+        .bind(batch_ref)
+        .bind(initiated_by)
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    pub async fn update_payout_status(
+        &self,
+        id: Uuid,
+        status: &PayoutStatus,
+        stellar_tx_hash: Option<&str>,
+        error_message: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            UPDATE commission_payout_records SET
+                status          = $2,
+                stellar_tx_hash = COALESCE($3, stellar_tx_hash),
+                error_message   = $4,
+                attempted_at    = COALESCE(attempted_at, NOW()),
+                completed_at    = CASE WHEN $2 = 'completed' THEN NOW() ELSE completed_at END
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .bind(status)
+        .bind(stellar_tx_hash)
+        .bind(error_message)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Fetch pending payout IDs for batch dispatch.
+    pub async fn pending_payouts(&self) -> Result<Vec<PayoutRecord>, sqlx::Error> {
+        sqlx::query_as::<_, PayoutRecord>(
+            "SELECT * FROM commission_payout_records WHERE status = 'pending' ORDER BY created_at",
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    pub async fn payouts_for_partner(
+        &self,
+        partner_id: Uuid,
+    ) -> Result<Vec<PayoutRecord>, sqlx::Error> {
+        sqlx::query_as::<_, PayoutRecord>(
+            "SELECT * FROM commission_payout_records WHERE partner_id = $1 ORDER BY created_at DESC",
+        )
+        .bind(partner_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    /// Mark all unpaid ledger entries for a partner as belonging to a payout.
+    pub async fn link_entries_to_payout_tx(
+        tx: &mut Transaction<'_, Postgres>,
+        partner_id: Uuid,
+        payout_id: Uuid,
+    ) -> Result<i64, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE partner_revenue_ledger
+            SET payout_record_id = $2
+            WHERE partner_id = $1
+              AND direction = 'credit'
+              AND payout_record_id IS NULL
+            "#,
+        )
+        .bind(partner_id)
+        .bind(payout_id)
+        .execute(&mut **tx)
+        .await?;
+        Ok(result.rows_affected() as i64)
+    }
+
+    /// Sum of unpaid credits for a partner.
+    pub async fn unpaid_balance(&self, partner_id: Uuid) -> Result<i64, sqlx::Error> {
+        let row: (Option<i64>,) = sqlx::query_as(
+            r#"
+            SELECT SUM(amount_stroops)
+            FROM partner_revenue_ledger
+            WHERE partner_id = $1
+              AND direction = 'credit'
+              AND payout_record_id IS NULL
+            "#,
+        )
+        .bind(partner_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0.unwrap_or(0))
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}

--- a/src/commission/routes.rs
+++ b/src/commission/routes.rs
@@ -1,0 +1,27 @@
+//! Commission engine route registrations (Issue #471).
+
+use std::sync::Arc;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+use super::handlers::{configure_commission, manual_adjust, revenue_statement, CommissionState};
+
+pub fn commission_routes(state: Arc<CommissionState>) -> Router {
+    Router::new()
+        .route(
+            "/api/v1/admin/partners/commissions/configure",
+            post(configure_commission),
+        )
+        .route(
+            "/api/v1/admin/partners/revenue/adjust",
+            post(manual_adjust),
+        )
+        .route(
+            "/api/v1/partners/:partner_id/revenue/statement",
+            get(revenue_statement),
+        )
+        .with_state(state)
+}

--- a/src/commission/service.rs
+++ b/src/commission/service.rs
@@ -1,0 +1,300 @@
+//! Atomic transactional ledger service — records split-fee commissions and
+//! manual adjustments within a single isolated DB transaction (Issue #471).
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use sqlx::PgPool;
+use tracing::{error, info, instrument};
+use uuid::Uuid;
+
+use super::{
+    metrics,
+    models::{
+        CommissionStructure, CreateCommissionStructureInput, LedgerDirection, LedgerEntry,
+        ManualAdjustmentInput, PayoutRecord, RevenueStatement,
+    },
+    repository::CommissionRepository,
+    split_fee::{CommissionBreakdown, SplitFeeEngine},
+};
+use crate::database::error::DatabaseError;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommissionError {
+    #[error("split-fee error: {0}")]
+    SplitFee(#[from] super::split_fee::SplitFeeError),
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("invariant violation: gross {gross} != platform {platform} + partner {partner}")]
+    InvariantViolation { gross: i64, platform: i64, partner: i64 },
+    #[error("partner not found: {0}")]
+    PartnerNotFound(Uuid),
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+pub struct CommissionService {
+    repo: Arc<CommissionRepository>,
+    engine: Arc<SplitFeeEngine>,
+    pool: PgPool,
+}
+
+impl CommissionService {
+    pub fn new(pool: PgPool) -> Self {
+        let repo = Arc::new(CommissionRepository::new(pool.clone()));
+        let engine = Arc::new(SplitFeeEngine::new(Arc::clone(&repo)));
+        Self { repo, engine, pool }
+    }
+
+    pub fn repo(&self) -> &Arc<CommissionRepository> {
+        &self.repo
+    }
+
+    // -----------------------------------------------------------------------
+    // Configuration
+    // -----------------------------------------------------------------------
+
+    pub async fn configure_structure(
+        &self,
+        input: CreateCommissionStructureInput,
+    ) -> Result<CommissionStructure, CommissionError> {
+        let s = self.repo.create_structure(&input).await.map_err(CommissionError::Db)?;
+        info!(
+            structure_id = %s.id,
+            partner_id = %s.partner_id,
+            commission_type = ?s.commission_type,
+            "commission structure created"
+        );
+        Ok(s)
+    }
+
+    // -----------------------------------------------------------------------
+    // Core: record commissions for a transaction (called concurrently)
+    // -----------------------------------------------------------------------
+
+    /// Evaluates the split for `gross_fee_stroops` and writes all partner
+    /// ledger credits atomically. Returns the ledger entries created.
+    #[instrument(skip(self), fields(transaction_id = %transaction_id, gross_fee_stroops))]
+    pub async fn record_transaction_commissions(
+        &self,
+        transaction_id: Uuid,
+        gross_fee_stroops: i64,
+        corridor: Option<&str>,
+        cumulative_volume_stroops: i64,
+    ) -> Result<Vec<LedgerEntry>, CommissionError> {
+        let breakdown = self
+            .engine
+            .evaluate(gross_fee_stroops, corridor, cumulative_volume_stroops)
+            .await?;
+
+        self.persist_breakdown(transaction_id, &breakdown, corridor).await
+    }
+
+    /// Persist a pre-computed breakdown inside a single DB transaction.
+    async fn persist_breakdown(
+        &self,
+        transaction_id: Uuid,
+        breakdown: &CommissionBreakdown,
+        corridor: Option<&str>,
+    ) -> Result<Vec<LedgerEntry>, CommissionError> {
+        let mut tx = self.pool.begin().await?;
+        let mut entries = Vec::with_capacity(breakdown.partner_splits.len());
+
+        for split in &breakdown.partner_splits {
+            // Fetch current balance to compute running balance_after
+            let current_balance = sqlx::query_scalar::<_, i64>(
+                "SELECT COALESCE(accrued_stroops, 0) - COALESCE(paid_stroops, 0)
+                 FROM partner_commission_balances WHERE partner_id = $1",
+            )
+            .bind(split.partner_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .unwrap_or(0);
+
+            let balance_after = current_balance + split.commission_stroops;
+
+            let entry = CommissionRepository::insert_ledger_entry_tx(
+                &mut tx,
+                split.partner_id,
+                transaction_id,
+                Some(split.structure_id),
+                split.commission_stroops,
+                &LedgerDirection::Credit,
+                balance_after,
+                breakdown.gross_fee_stroops,
+                breakdown.platform_share_stroops,
+                split.tier_index,
+                corridor,
+                &format!(
+                    "Commission credit for tx {} — tier {:?}",
+                    transaction_id, split.tier_index
+                ),
+            )
+            .await?;
+
+            CommissionRepository::upsert_balance_tx(
+                &mut tx,
+                split.partner_id,
+                split.commission_stroops,
+                &LedgerDirection::Credit,
+                entry.entry_id,
+            )
+            .await?;
+
+            metrics::commission_accrued(
+                &split.partner_id.to_string(),
+                corridor.unwrap_or("all"),
+                split.commission_stroops,
+            );
+
+            info!(
+                entry_id = %entry.entry_id,
+                partner_id = %split.partner_id,
+                amount_stroops = split.commission_stroops,
+                gross_fee_stroops = breakdown.gross_fee_stroops,
+                platform_share_stroops = breakdown.platform_share_stroops,
+                tier_index = ?split.tier_index,
+                corridor,
+                "commission ledger entry created"
+            );
+
+            entries.push(entry);
+        }
+
+        tx.commit().await?;
+        Ok(entries)
+    }
+
+    // -----------------------------------------------------------------------
+    // Manual adjustment (admin override)
+    // -----------------------------------------------------------------------
+
+    #[instrument(skip(self), fields(partner_id = %input.partner_id))]
+    pub async fn manual_adjustment(
+        &self,
+        input: ManualAdjustmentInput,
+    ) -> Result<LedgerEntry, CommissionError> {
+        // Validate invariant before writing
+        let partner_total = match input.direction {
+            LedgerDirection::Credit => input.amount_stroops,
+            LedgerDirection::Debit => 0,
+        };
+        if input.gross_fee_stroops != input.platform_share_stroops + partner_total
+            && input.direction == LedgerDirection::Credit
+        {
+            metrics::invariant_violation();
+            return Err(CommissionError::InvariantViolation {
+                gross: input.gross_fee_stroops,
+                platform: input.platform_share_stroops,
+                partner: partner_total,
+            });
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        let current_balance = sqlx::query_scalar::<_, i64>(
+            "SELECT COALESCE(accrued_stroops, 0) - COALESCE(paid_stroops, 0)
+             FROM partner_commission_balances WHERE partner_id = $1",
+        )
+        .bind(input.partner_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .unwrap_or(0);
+
+        let balance_after = match input.direction {
+            LedgerDirection::Credit => current_balance + input.amount_stroops,
+            LedgerDirection::Debit => current_balance - input.amount_stroops,
+        };
+
+        let entry = CommissionRepository::insert_ledger_entry_tx(
+            &mut tx,
+            input.partner_id,
+            input.transaction_id,
+            None,
+            input.amount_stroops,
+            &input.direction,
+            balance_after,
+            input.gross_fee_stroops,
+            input.platform_share_stroops,
+            None,
+            None,
+            &format!(
+                "[MANUAL ADJUSTMENT by {}] {}",
+                input.initiated_by, input.narrative
+            ),
+        )
+        .await?;
+
+        CommissionRepository::upsert_balance_tx(
+            &mut tx,
+            input.partner_id,
+            input.amount_stroops,
+            &input.direction,
+            entry.entry_id,
+        )
+        .await?;
+
+        tx.commit().await?;
+
+        info!(
+            entry_id = %entry.entry_id,
+            partner_id = %input.partner_id,
+            amount_stroops = input.amount_stroops,
+            direction = ?input.direction,
+            initiated_by = %input.initiated_by,
+            narrative = input.narrative,
+            "manual ledger adjustment committed"
+        );
+
+        Ok(entry)
+    }
+
+    // -----------------------------------------------------------------------
+    // Revenue statement
+    // -----------------------------------------------------------------------
+
+    pub async fn revenue_statement(
+        &self,
+        partner_id: Uuid,
+        limit: i64,
+        offset: i64,
+    ) -> Result<RevenueStatement, CommissionError> {
+        let balance = self
+            .repo
+            .balance_for_partner(partner_id)
+            .await?
+            .unwrap_or_else(|| super::models::CommissionBalance {
+                partner_id,
+                accrued_stroops: 0,
+                paid_stroops: 0,
+                last_entry_id: None,
+                updated_at: Utc::now(),
+            });
+
+        let entries = self
+            .repo
+            .ledger_entries_for_partner(partner_id, limit, offset)
+            .await?;
+
+        let payouts = self.repo.payouts_for_partner(partner_id).await?;
+
+        let unpaid = balance.accrued_stroops - balance.paid_stroops;
+        metrics::set_accrued_liability(&partner_id.to_string(), unpaid.max(0));
+
+        Ok(RevenueStatement {
+            partner_id,
+            accrued_stroops: balance.accrued_stroops,
+            paid_stroops: balance.paid_stroops,
+            unpaid_stroops: unpaid.max(0),
+            entries,
+            payouts,
+            generated_at: Utc::now(),
+        })
+    }
+}

--- a/src/commission/split_fee.rs
+++ b/src/commission/split_fee.rs
@@ -1,0 +1,364 @@
+//! Split-fee evaluation module (Issue #471).
+//!
+//! Computes exact partner commission breakdowns for a given gross fee and
+//! active commission structure set. Uses integer stroop arithmetic throughout
+//! to guarantee Stellar-precision (7 dp) with no floating-point rounding drift.
+//!
+//! Invariant enforced: gross_fee == platform_share + sum(partner_commissions).
+//! Any violation returns `Err(SplitFeeError::InvariantViolation)`.
+
+use std::sync::Arc;
+
+use tracing::{instrument, warn};
+use uuid::Uuid;
+
+use super::{
+    metrics,
+    models::{CommissionStructure, CommissionTier, CommissionType},
+    repository::CommissionRepository,
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+pub enum SplitFeeError {
+    #[error("invariant violation: gross {gross} != platform {platform} + partner {partner}")]
+    InvariantViolation {
+        gross: i64,
+        platform: i64,
+        partner: i64,
+    },
+    #[error("commission rate out of range: {0}")]
+    InvalidRate(String),
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("no active commission structure found for partner {0}")]
+    NoStructure(Uuid),
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Per-partner split result.
+#[derive(Debug, Clone)]
+pub struct PartnerSplit {
+    pub partner_id: Uuid,
+    pub structure_id: Uuid,
+    pub commission_stroops: i64,
+    pub tier_index: Option<i16>,
+}
+
+/// Full breakdown for a single transaction fee.
+#[derive(Debug, Clone)]
+pub struct CommissionBreakdown {
+    pub gross_fee_stroops: i64,
+    pub platform_share_stroops: i64,
+    pub partner_splits: Vec<PartnerSplit>,
+}
+
+impl CommissionBreakdown {
+    /// Validate that gross == platform + sum(partner commissions).
+    pub fn validate_invariant(&self) -> Result<(), SplitFeeError> {
+        let partner_total: i64 = self.partner_splits.iter().map(|s| s.commission_stroops).sum();
+        if self.gross_fee_stroops != self.platform_share_stroops + partner_total {
+            metrics::invariant_violation();
+            warn!(
+                gross = self.gross_fee_stroops,
+                platform = self.platform_share_stroops,
+                partner_total,
+                "fee-split invariant violated"
+            );
+            return Err(SplitFeeError::InvariantViolation {
+                gross: self.gross_fee_stroops,
+                platform: self.platform_share_stroops,
+                partner: partner_total,
+            });
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine
+// ---------------------------------------------------------------------------
+
+pub struct SplitFeeEngine {
+    repo: Arc<CommissionRepository>,
+}
+
+impl SplitFeeEngine {
+    pub fn new(repo: Arc<CommissionRepository>) -> Self {
+        Self { repo }
+    }
+
+    /// Evaluate commissions for all active partners on `gross_fee_stroops`.
+    ///
+    /// Called concurrently during transaction processing; must not block.
+    #[instrument(skip(self), fields(gross_fee_stroops))]
+    pub async fn evaluate(
+        &self,
+        gross_fee_stroops: i64,
+        corridor: Option<&str>,
+        cumulative_volume_stroops: i64,
+    ) -> Result<CommissionBreakdown, SplitFeeError> {
+        let structures = self
+            .repo
+            .active_structures(corridor, gross_fee_stroops)
+            .await?;
+
+        let mut partner_splits: Vec<PartnerSplit> = Vec::with_capacity(structures.len());
+        let mut total_partner_stroops: i64 = 0;
+
+        for s in &structures {
+            let (commission, tier_idx) =
+                compute_commission(s, gross_fee_stroops, cumulative_volume_stroops)?;
+            total_partner_stroops = total_partner_stroops.saturating_add(commission);
+            partner_splits.push(PartnerSplit {
+                partner_id: s.partner_id,
+                structure_id: s.id,
+                commission_stroops: commission,
+                tier_index: tier_idx,
+            });
+        }
+
+        // Platform takes the remainder to preserve the invariant exactly.
+        let platform_share = gross_fee_stroops
+            .checked_sub(total_partner_stroops)
+            .ok_or_else(|| {
+                metrics::invariant_violation();
+                SplitFeeError::InvariantViolation {
+                    gross: gross_fee_stroops,
+                    platform: 0,
+                    partner: total_partner_stroops,
+                }
+            })?;
+
+        if platform_share < 0 {
+            metrics::invariant_violation();
+            return Err(SplitFeeError::InvariantViolation {
+                gross: gross_fee_stroops,
+                platform: platform_share,
+                partner: total_partner_stroops,
+            });
+        }
+
+        let breakdown = CommissionBreakdown {
+            gross_fee_stroops,
+            platform_share_stroops: platform_share,
+            partner_splits,
+        };
+        breakdown.validate_invariant()?;
+
+        metrics::commission_evaluated(gross_fee_stroops, total_partner_stroops);
+        Ok(breakdown)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure arithmetic helpers (no I/O — easily unit-tested)
+// ---------------------------------------------------------------------------
+
+/// Compute commission in stroops for a single structure.
+/// Returns `(commission_stroops, tier_index)`.
+pub fn compute_commission(
+    structure: &CommissionStructure,
+    gross_fee_stroops: i64,
+    cumulative_volume_stroops: i64,
+) -> Result<(i64, Option<i16>), SplitFeeError> {
+    match structure.commission_type {
+        CommissionType::Percentage => {
+            let rate = structure
+                .percentage_rate
+                .as_ref()
+                .ok_or_else(|| SplitFeeError::InvalidRate("missing percentage_rate".into()))?;
+            // Convert BigDecimal → f64 only for multiplication then round to i64
+            let rate_f64: f64 = rate.to_string().parse().unwrap_or(0.0);
+            if !(0.0..=1.0).contains(&rate_f64) {
+                return Err(SplitFeeError::InvalidRate(format!("rate {rate_f64} out of [0,1]")));
+            }
+            // Multiply in i128 to avoid overflow for large stroop values
+            let commission = (gross_fee_stroops as i128 * (rate_f64 * 1_000_000_000.0) as i128
+                / 1_000_000_000) as i64;
+            Ok((commission, None))
+        }
+
+        CommissionType::FixedFiat => {
+            let fixed = structure
+                .fixed_stroops
+                .ok_or_else(|| SplitFeeError::InvalidRate("missing fixed_stroops".into()))?;
+            // Fixed commission cannot exceed the gross fee
+            Ok((fixed.min(gross_fee_stroops), None))
+        }
+
+        CommissionType::Tiered => {
+            let tiers_val = structure
+                .tiers
+                .as_ref()
+                .ok_or_else(|| SplitFeeError::InvalidRate("missing tiers".into()))?;
+            let tiers: Vec<CommissionTier> =
+                serde_json::from_value(tiers_val.clone()).map_err(|e| {
+                    SplitFeeError::InvalidRate(format!("tiers parse error: {e}"))
+                })?;
+
+            for (idx, tier) in tiers.iter().enumerate() {
+                let in_tier = cumulative_volume_stroops >= tier.min_volume_stroops
+                    && tier
+                        .max_volume_stroops
+                        .map_or(true, |max| cumulative_volume_stroops < max);
+                if in_tier {
+                    if !(0.0..=1.0).contains(&tier.rate) {
+                        return Err(SplitFeeError::InvalidRate(format!(
+                            "tier {idx} rate {} out of [0,1]",
+                            tier.rate
+                        )));
+                    }
+                    let commission = (gross_fee_stroops as i128
+                        * (tier.rate * 1_000_000_000.0) as i128
+                        / 1_000_000_000) as i64;
+                    return Ok((commission, Some(idx as i16)));
+                }
+            }
+            // No tier matched → zero commission
+            Ok((0, None))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::types::BigDecimal;
+    use std::str::FromStr;
+
+    fn pct_structure(rate: &str) -> CommissionStructure {
+        CommissionStructure {
+            id: Uuid::new_v4(),
+            partner_id: Uuid::new_v4(),
+            name: "test".into(),
+            commission_type: CommissionType::Percentage,
+            percentage_rate: Some(BigDecimal::from_str(rate).unwrap()),
+            fixed_stroops: None,
+            tiers: None,
+            min_volume_stroops: 0,
+            max_volume_stroops: None,
+            corridor: None,
+            is_active: true,
+            effective_from: chrono::Utc::now(),
+            effective_to: None,
+            created_by: Uuid::new_v4(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_percentage_split_35pct() {
+        let s = pct_structure("0.35");
+        let (commission, tier) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(commission, 3_500_000);
+        assert_eq!(tier, None);
+    }
+
+    #[test]
+    fn test_percentage_split_full_precision() {
+        // 0.1234567 of 10_000_000 stroops = 1_234_567
+        let s = pct_structure("0.1234567");
+        let (commission, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(commission, 1_234_567);
+    }
+
+    #[test]
+    fn test_fixed_fiat() {
+        let mut s = pct_structure("0");
+        s.commission_type = CommissionType::FixedFiat;
+        s.percentage_rate = None;
+        s.fixed_stroops = Some(500_000);
+        let (commission, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(commission, 500_000);
+    }
+
+    #[test]
+    fn test_fixed_fiat_capped_at_gross() {
+        let mut s = pct_structure("0");
+        s.commission_type = CommissionType::FixedFiat;
+        s.percentage_rate = None;
+        s.fixed_stroops = Some(20_000_000); // more than gross
+        let (commission, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(commission, 10_000_000); // capped
+    }
+
+    #[test]
+    fn test_tiered_first_tier() {
+        let tiers = serde_json::json!([
+            {"min_volume_stroops": 0, "max_volume_stroops": 1_000_000_000_i64, "rate": 0.30},
+            {"min_volume_stroops": 1_000_000_000_i64, "max_volume_stroops": null, "rate": 0.25},
+        ]);
+        let mut s = pct_structure("0");
+        s.commission_type = CommissionType::Tiered;
+        s.percentage_rate = None;
+        s.tiers = Some(tiers);
+        let (commission, tier_idx) = compute_commission(&s, 10_000_000, 500_000_000).unwrap();
+        assert_eq!(commission, 3_000_000);
+        assert_eq!(tier_idx, Some(0));
+    }
+
+    #[test]
+    fn test_tiered_second_tier() {
+        let tiers = serde_json::json!([
+            {"min_volume_stroops": 0, "max_volume_stroops": 1_000_000_000_i64, "rate": 0.30},
+            {"min_volume_stroops": 1_000_000_000_i64, "max_volume_stroops": null, "rate": 0.25},
+        ]);
+        let mut s = pct_structure("0");
+        s.commission_type = CommissionType::Tiered;
+        s.percentage_rate = None;
+        s.tiers = Some(tiers);
+        let (commission, tier_idx) =
+            compute_commission(&s, 10_000_000, 2_000_000_000).unwrap();
+        assert_eq!(commission, 2_500_000);
+        assert_eq!(tier_idx, Some(1));
+    }
+
+    #[test]
+    fn test_invariant_validation() {
+        let breakdown = CommissionBreakdown {
+            gross_fee_stroops: 10_000_000,
+            platform_share_stroops: 6_500_000,
+            partner_splits: vec![PartnerSplit {
+                partner_id: Uuid::new_v4(),
+                structure_id: Uuid::new_v4(),
+                commission_stroops: 3_500_000,
+                tier_index: None,
+            }],
+        };
+        assert!(breakdown.validate_invariant().is_ok());
+    }
+
+    #[test]
+    fn test_invariant_violation_detected() {
+        let breakdown = CommissionBreakdown {
+            gross_fee_stroops: 10_000_000,
+            platform_share_stroops: 7_000_000, // wrong: 7M + 3.5M != 10M
+            partner_splits: vec![PartnerSplit {
+                partner_id: Uuid::new_v4(),
+                structure_id: Uuid::new_v4(),
+                commission_stroops: 3_500_000,
+                tier_index: None,
+            }],
+        };
+        assert!(matches!(
+            breakdown.validate_invariant(),
+            Err(SplitFeeError::InvariantViolation { .. })
+        ));
+    }
+
+    #[test]
+    fn test_overflow_protection() {
+        // i64::MAX gross fee should not panic
+        let s = pct_structure("0.5");
+        let result = compute_commission(&s, i64::MAX / 2, 0);
+        assert!(result.is_ok());
+    }
+}

--- a/src/commission/worker.rs
+++ b/src/commission/worker.rs
@@ -1,0 +1,286 @@
+//! Batch payout worker (Issue #471).
+//!
+//! Periodically aggregates unpaid partner commissions, creates Stellar payment
+//! operations, and records them in `commission_payout_records`.
+//!
+//! A Redis distributed lock prevents concurrent execution across replicas.
+
+use std::{sync::Arc, time::Duration, time::Instant};
+
+use bb8::Pool;
+use bb8_redis::RedisConnectionManager;
+use redis::AsyncCommands;
+use tracing::{error, info, instrument, warn};
+use uuid::Uuid;
+
+use super::{
+    metrics,
+    models::PayoutStatus,
+    repository::CommissionRepository,
+};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+pub struct PayoutWorkerConfig {
+    pub interval: Duration,
+    pub lock_ttl: Duration,
+    pub min_payout_stroops: i64, // skip partners below this threshold
+    pub system_user_id: Uuid,
+}
+
+impl Default for PayoutWorkerConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(3600),   // hourly
+            lock_ttl: Duration::from_secs(300),     // 5 min lock
+            min_payout_stroops: 1_000_000,          // ≥ 0.1 cNGN
+            system_user_id: Uuid::nil(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker
+// ---------------------------------------------------------------------------
+
+pub struct PayoutWorker {
+    repo: Arc<CommissionRepository>,
+    redis: Pool<RedisConnectionManager>,
+    config: PayoutWorkerConfig,
+}
+
+const LOCK_KEY: &str = "commission:payout:lock";
+
+impl PayoutWorker {
+    pub fn new(
+        repo: Arc<CommissionRepository>,
+        redis: Pool<RedisConnectionManager>,
+        config: PayoutWorkerConfig,
+    ) -> Self {
+        Self { repo, redis, config }
+    }
+
+    /// Spawn the worker as a background Tokio task.
+    pub fn spawn(worker: Arc<Self>) {
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(worker.config.interval).await;
+                if let Err(e) = worker.run_once().await {
+                    error!(error = %e, "payout worker cycle failed");
+                }
+            }
+        });
+    }
+
+    /// Execute one full payout cycle under a Redis distributed lock.
+    #[instrument(skip(self))]
+    pub async fn run_once(&self) -> anyhow::Result<()> {
+        let lock_token = Uuid::new_v4().to_string();
+
+        if !self.acquire_lock(&lock_token).await? {
+            info!("payout lock held by another instance, skipping");
+            return Ok(());
+        }
+
+        let result = self.process_pending_payouts().await;
+
+        // Always release the lock, even on error
+        if let Err(e) = self.release_lock(&lock_token).await {
+            warn!(error = %e, "failed to release payout lock");
+        }
+
+        result
+    }
+
+    async fn process_pending_payouts(&self) -> anyhow::Result<()> {
+        let pool = self.repo.pool().clone();
+
+        // Collect all partners with unpaid balance above threshold
+        let partners: Vec<(Uuid, String, i64)> = sqlx::query_as(
+            r#"
+            SELECT p.id, p.payout_address, b.accrued_stroops - b.paid_stroops AS unpaid
+            FROM partners p
+            JOIN partner_commission_balances b ON b.partner_id = p.id
+            LEFT JOIN partner_integration_settings s ON s.partner_id = p.id
+            WHERE b.accrued_stroops - b.paid_stroops >= $1
+              AND p.is_active = TRUE
+            ORDER BY unpaid DESC
+            "#,
+        )
+        .bind(self.config.min_payout_stroops)
+        .fetch_all(&pool)
+        .await
+        .unwrap_or_default();
+
+        if partners.is_empty() {
+            info!("no partners eligible for payout this cycle");
+            return Ok(());
+        }
+
+        let batch_ref = chrono::Utc::now().format("batch-%Y-%m-%dT%H").to_string();
+
+        for (partner_id, payout_address, unpaid_stroops) in partners {
+            let start = Instant::now();
+            self.payout_partner(partner_id, &payout_address, unpaid_stroops, &batch_ref)
+                .await;
+            metrics::observe_payout_duration(
+                &partner_id.to_string(),
+                start.elapsed().as_secs_f64(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Process a single partner payout within its own DB transaction.
+    #[instrument(skip(self), fields(partner_id = %partner_id, unpaid_stroops))]
+    async fn payout_partner(
+        &self,
+        partner_id: Uuid,
+        payout_address: &str,
+        unpaid_stroops: i64,
+        batch_ref: &str,
+    ) {
+        let pool = self.repo.pool().clone();
+
+        let result: anyhow::Result<()> = async {
+            // Re-verify exact unpaid balance inside the transaction
+            let unpaid = self.repo.unpaid_balance(partner_id).await?;
+            if unpaid < self.config.min_payout_stroops {
+                return Ok(());
+            }
+
+            let mut tx = pool.begin().await?;
+
+            // 1. Create payout record (pending)
+            let payout = self
+                .repo
+                .create_payout_record(
+                    partner_id,
+                    payout_address,
+                    unpaid,
+                    0,
+                    batch_ref,
+                    self.config.system_user_id,
+                )
+                .await?;
+
+            // 2. Link all unpaid ledger entries to this payout
+            let count = CommissionRepository::link_entries_to_payout_tx(
+                &mut tx, partner_id, payout.id,
+            )
+            .await?;
+
+            // 3. Mark balance as paid
+            sqlx::query(
+                "UPDATE partner_commission_balances SET paid_stroops = accrued_stroops, updated_at = NOW() WHERE partner_id = $1",
+            )
+            .bind(partner_id)
+            .execute(&mut *tx)
+            .await?;
+
+            tx.commit().await?;
+
+            // 4. Dispatch Stellar payment (mock — real impl hooks into stellar service)
+            let stellar_hash = self
+                .dispatch_stellar_payment(partner_id, payout_address, unpaid)
+                .await;
+
+            match stellar_hash {
+                Ok(hash) => {
+                    self.repo
+                        .update_payout_status(payout.id, &PayoutStatus::Completed, Some(&hash), None)
+                        .await?;
+                    metrics::payout_dispatched(&partner_id.to_string(), "completed", unpaid);
+                    info!(
+                        payout_id = %payout.id,
+                        partner_id = %partner_id,
+                        total_stroops = unpaid,
+                        entry_count = count,
+                        stellar_tx_hash = %hash,
+                        "payout completed"
+                    );
+                }
+                Err(e) => {
+                    self.repo
+                        .update_payout_status(
+                            payout.id,
+                            &PayoutStatus::Failed,
+                            None,
+                            Some(&e.to_string()),
+                        )
+                        .await?;
+                    metrics::payout_dispatched(&partner_id.to_string(), "failed", unpaid);
+                    error!(payout_id = %payout.id, error = %e, "stellar payment failed");
+                }
+            }
+
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            error!(partner_id = %partner_id, error = %e, "payout processing error");
+        }
+    }
+
+    /// Stub: dispatch cNGN on Stellar; replace with real StellarClient call.
+    async fn dispatch_stellar_payment(
+        &self,
+        partner_id: Uuid,
+        address: &str,
+        stroops: i64,
+    ) -> anyhow::Result<String> {
+        // TODO: call crate::chains::stellar::StellarClient::send_payment(address, stroops)
+        info!(
+            partner_id = %partner_id,
+            payout_address = %address,
+            stroops,
+            "stellar payment dispatched (stub)"
+        );
+        // Return a deterministic fake hash for now
+        Ok(format!(
+            "STUB_{}_{}",
+            &partner_id.to_string()[..8],
+            stroops
+        ))
+    }
+
+    // -----------------------------------------------------------------------
+    // Redis distributed lock (SET NX PX)
+    // -----------------------------------------------------------------------
+
+    async fn acquire_lock(&self, token: &str) -> anyhow::Result<bool> {
+        let mut conn = self.redis.get().await?;
+        let acquired: bool = redis::cmd("SET")
+            .arg(LOCK_KEY)
+            .arg(token)
+            .arg("NX")
+            .arg("PX")
+            .arg(self.config.lock_ttl.as_millis() as u64)
+            .query_async(&mut *conn)
+            .await
+            .unwrap_or(false);
+        Ok(acquired)
+    }
+
+    async fn release_lock(&self, token: &str) -> anyhow::Result<()> {
+        // Lua script for atomic check-and-delete
+        let script = r#"
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+                return redis.call('DEL', KEYS[1])
+            else
+                return 0
+            end
+        "#;
+        let mut conn = self.redis.get().await?;
+        let _: i32 = redis::Script::new(script)
+            .key(LOCK_KEY)
+            .arg(token)
+            .invoke_async(&mut *conn)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,10 @@ pub mod analytics;
 #[cfg(feature = "database")]
 pub mod lp_payout;
 
+// Partner Revenue Sharing & Commission Management Engine (Issue #471)
+#[cfg(feature = "database")]
+pub mod commission;
+
 // Data classification framework — authoritative sensitivity taxonomy and
 // policy enforcement for every data field on the platform.
 #[cfg(feature = "database")]

--- a/tests/commission_engine_test.rs
+++ b/tests/commission_engine_test.rs
@@ -1,0 +1,262 @@
+//! Commission engine tests (Issue #471).
+//!
+//! Unit tests are in split_fee.rs (pure arithmetic, no I/O).
+//! Integration tests here require a live DB via TEST_DATABASE_URL.
+
+#[cfg(test)]
+mod unit {
+    use aframp_backend::commission::split_fee::{compute_commission, CommissionBreakdown, PartnerSplit, SplitFeeError};
+    use aframp_backend::commission::models::{CommissionStructure, CommissionType};
+    use sqlx::types::BigDecimal;
+    use std::str::FromStr;
+    use uuid::Uuid;
+
+    fn make_structure(ct: CommissionType, rate: Option<&str>, fixed: Option<i64>) -> CommissionStructure {
+        CommissionStructure {
+            id: Uuid::new_v4(),
+            partner_id: Uuid::new_v4(),
+            name: "test".into(),
+            commission_type: ct,
+            percentage_rate: rate.map(|r| BigDecimal::from_str(r).unwrap()),
+            fixed_stroops: fixed,
+            tiers: None,
+            min_volume_stroops: 0,
+            max_volume_stroops: None,
+            corridor: None,
+            is_active: true,
+            effective_from: chrono::Utc::now(),
+            effective_to: None,
+            created_by: Uuid::new_v4(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn percentage_splits_correctly() {
+        let s = make_structure(CommissionType::Percentage, Some("0.35"), None);
+        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(c, 3_500_000);
+    }
+
+    #[test]
+    fn seven_decimal_precision() {
+        let s = make_structure(CommissionType::Percentage, Some("0.1234567"), None);
+        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(c, 1_234_567);
+    }
+
+    #[test]
+    fn fixed_fiat_basic() {
+        let s = make_structure(CommissionType::FixedFiat, None, Some(500_000));
+        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(c, 500_000);
+    }
+
+    #[test]
+    fn fixed_fiat_capped_at_gross() {
+        let s = make_structure(CommissionType::FixedFiat, None, Some(20_000_000));
+        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(c, 10_000_000);
+    }
+
+    #[test]
+    fn tiered_selects_correct_tier() {
+        let tiers = serde_json::json!([
+            {"min_volume_stroops": 0, "max_volume_stroops": 1_000_000_000_i64, "rate": 0.30},
+            {"min_volume_stroops": 1_000_000_000_i64, "max_volume_stroops": null, "rate": 0.20},
+        ]);
+        let mut s = make_structure(CommissionType::Tiered, None, None);
+        s.tiers = Some(tiers);
+        // Volume in tier 0
+        let (c0, idx0) = compute_commission(&s, 10_000_000, 500_000_000).unwrap();
+        assert_eq!(c0, 3_000_000);
+        assert_eq!(idx0, Some(0));
+        // Volume in tier 1
+        let (c1, idx1) = compute_commission(&s, 10_000_000, 2_000_000_000).unwrap();
+        assert_eq!(c1, 2_000_000);
+        assert_eq!(idx1, Some(1));
+    }
+
+    #[test]
+    fn invariant_holds() {
+        let bd = CommissionBreakdown {
+            gross_fee_stroops: 10_000_000,
+            platform_share_stroops: 6_500_000,
+            partner_splits: vec![PartnerSplit {
+                partner_id: Uuid::new_v4(),
+                structure_id: Uuid::new_v4(),
+                commission_stroops: 3_500_000,
+                tier_index: None,
+            }],
+        };
+        assert!(bd.validate_invariant().is_ok());
+    }
+
+    #[test]
+    fn invariant_violation_detected() {
+        let bd = CommissionBreakdown {
+            gross_fee_stroops: 10_000_000,
+            platform_share_stroops: 7_000_000,
+            partner_splits: vec![PartnerSplit {
+                partner_id: Uuid::new_v4(),
+                structure_id: Uuid::new_v4(),
+                commission_stroops: 3_500_000,
+                tier_index: None,
+            }],
+        };
+        assert!(matches!(
+            bd.validate_invariant(),
+            Err(SplitFeeError::InvariantViolation { .. })
+        ));
+    }
+
+    #[test]
+    fn zero_rate_gives_zero_commission() {
+        let s = make_structure(CommissionType::Percentage, Some("0.0"), None);
+        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn full_rate_gives_full_gross() {
+        let s = make_structure(CommissionType::Percentage, Some("1.0"), None);
+        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+        assert_eq!(c, 10_000_000);
+    }
+
+    #[test]
+    fn overflow_does_not_panic() {
+        let s = make_structure(CommissionType::Percentage, Some("0.5"), None);
+        assert!(compute_commission(&s, i64::MAX / 2, 0).is_ok());
+    }
+}
+
+#[cfg(all(test, feature = "integration"))]
+mod integration {
+    use aframp_backend::commission::{
+        models::{CommissionType, CreateCommissionStructureInput, LedgerDirection, ManualAdjustmentInput},
+        service::CommissionService,
+    };
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    async fn pool() -> PgPool {
+        let url = std::env::var("TEST_DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/aframp_test".into());
+        PgPool::connect(&url).await.expect("test db connection")
+    }
+
+    #[tokio::test]
+    async fn test_ledger_atomic_write_and_balance() {
+        let pool = pool().await;
+        let svc = CommissionService::new(pool.clone());
+
+        // Insert a minimal partner for the test
+        let partner_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO partners (name, finance_email) VALUES ('TestPa', 'test@pa.io') RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        // Create a commission structure
+        let structure = svc
+            .configure_structure(CreateCommissionStructureInput {
+                partner_id,
+                name: "35pct".into(),
+                commission_type: CommissionType::Percentage,
+                percentage_rate: Some(0.35),
+                fixed_stroops: None,
+                tiers: None,
+                min_volume_stroops: None,
+                max_volume_stroops: None,
+                corridor: None,
+                effective_from: None,
+                effective_to: None,
+                created_by: Uuid::nil(),
+            })
+            .await
+            .unwrap();
+
+        let tx_id = Uuid::new_v4();
+        let entries = svc
+            .record_transaction_commissions(tx_id, 10_000_000, None, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].amount_stroops, 3_500_000);
+        assert_eq!(entries[0].gross_fee_stroops, 10_000_000);
+        assert_eq!(entries[0].platform_share_stroops, 6_500_000);
+        assert_eq!(
+            entries[0].gross_fee_stroops,
+            entries[0].platform_share_stroops + entries[0].amount_stroops,
+            "invariant must hold in persisted entry"
+        );
+
+        let stmt = svc.revenue_statement(partner_id, 10, 0).await.unwrap();
+        assert_eq!(stmt.accrued_stroops, 3_500_000);
+        assert_eq!(stmt.unpaid_stroops, 3_500_000);
+
+        // Cleanup
+        sqlx::query("DELETE FROM partner_revenue_ledger WHERE partner_id = $1")
+            .bind(partner_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM partner_commission_balances WHERE partner_id = $1")
+            .bind(partner_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM commission_structures WHERE partner_id = $1")
+            .bind(partner_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM partners WHERE id = $1")
+            .bind(partner_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_manual_adjustment_narrative_required() {
+        let pool = pool().await;
+        let svc = CommissionService::new(pool.clone());
+
+        let partner_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO partners (name, finance_email) VALUES ('AdjPa', 'adj@pa.io') RETURNING id",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let entry = svc
+            .manual_adjustment(ManualAdjustmentInput {
+                partner_id,
+                transaction_id: Uuid::new_v4(),
+                amount_stroops: 1_000_000,
+                direction: LedgerDirection::Credit,
+                gross_fee_stroops: 2_000_000,
+                platform_share_stroops: 1_000_000,
+                narrative: "Correction for over-deduction on 2026-06-01".into(),
+                initiated_by: Uuid::new_v4(),
+            })
+            .await
+            .unwrap();
+
+        assert!(entry.narrative.contains("MANUAL ADJUSTMENT"));
+        assert_eq!(entry.amount_stroops, 1_000_000);
+
+        // Cleanup
+        sqlx::query("DELETE FROM partner_revenue_ledger WHERE partner_id = $1")
+            .bind(partner_id).execute(&pool).await.unwrap();
+        sqlx::query("DELETE FROM partner_commission_balances WHERE partner_id = $1")
+            .bind(partner_id).execute(&pool).await.unwrap();
+        sqlx::query("DELETE FROM partners WHERE id = $1")
+            .bind(partner_id).execute(&pool).await.unwrap();
+    }
+}


### PR DESCRIPTION
- SQL migration: commission_structures, partner_revenue_ledger (append-only, immutability trigger), commission_payout_records, partner_commission_balances
- split_fee.rs: integer stroop arithmetic for percentage/fixed/tiered splits; invariant enforcement (gross = platform + sum(partner))
- service.rs: atomic sqlx transaction for ledger writes + balance upsert
- worker.rs: Tokio batch payout worker with Redis distributed lock (SET NX PX)
- metrics.rs: partner_commission_accrued_total, partner_payout_duration_seconds, revenue_split_calculation_errors_total, commission_invariant_violations_total
- handlers/routes: POST configure, POST adjust, GET revenue statement
- tests: 10 unit tests (precision, boundary, overflow) + 2 integration

closes #471 