### PR TITLE
am done with the issue

### DIFF
--- a/src/key_management/tests.rs
+++ b/src/key_management/tests.rs
@@ -13,6 +13,10 @@ mod tests {
         },
     };
 
+    // `unwrap()` is intentional throughout these tests: a panic is the correct
+    // failure signal when an operation that must succeed in the given test
+    // scenario returns an error.
+
     // -----------------------------------------------------------------------
     // Rotation schedule calculation
     // -----------------------------------------------------------------------

--- a/src/metrics/issuer.rs
+++ b/src/metrics/issuer.rs
@@ -10,42 +10,52 @@ static CNGN_TOTAL_CIRCULATION: OnceLock<GaugeVec> = OnceLock::new();
 static ISSUER_FLAGS_OK: OnceLock<GaugeVec> = OnceLock::new();
 static ISSUER_MASTER_WEIGHT: OnceLock<GaugeVec> = OnceLock::new();
 
+// Each accessor panics if called before `register()` — an unrecoverable
+// startup-ordering bug. `#[track_caller]` makes the panic point at the
+// call site rather than this module, simplifying diagnosis.
+
+#[track_caller]
 pub fn issuer_account_xlm_balance() -> &'static GaugeVec {
     ISSUER_ACCOUNT_XLM_BALANCE
         .get()
-        .expect("issuer metrics not initialised")
+        .expect("issuer metrics not initialised — call metrics::register_all() at startup")
 }
 
+#[track_caller]
 pub fn distribution_account_xlm_balance() -> &'static GaugeVec {
     DISTRIBUTION_ACCOUNT_XLM_BALANCE
         .get()
-        .expect("issuer metrics not initialised")
+        .expect("issuer metrics not initialised — call metrics::register_all() at startup")
 }
 
+#[track_caller]
 pub fn fee_account_balance_xlm() -> &'static GaugeVec {
     FEE_ACCOUNT_XLM_BALANCE
         .get()
-        .expect("issuer metrics not initialised")
+        .expect("issuer metrics not initialised — call metrics::register_all() at startup")
 }
 
+#[track_caller]
 pub fn cngn_total_circulation() -> &'static GaugeVec {
     CNGN_TOTAL_CIRCULATION
         .get()
-        .expect("issuer metrics not initialised")
+        .expect("issuer metrics not initialised — call metrics::register_all() at startup")
 }
 
 /// 1.0 = flags correctly set, 0.0 = one or more flags missing (alert condition).
+#[track_caller]
 pub fn issuer_flags_ok() -> &'static GaugeVec {
     ISSUER_FLAGS_OK
         .get()
-        .expect("issuer metrics not initialised")
+        .expect("issuer metrics not initialised — call metrics::register_all() at startup")
 }
 
 /// 0.0 = master weight is zero (correct), >0 = master weight non-zero (alert condition).
+#[track_caller]
 pub fn issuer_master_weight() -> &'static GaugeVec {
     ISSUER_MASTER_WEIGHT
         .get()
-        .expect("issuer metrics not initialised")
+        .expect("issuer metrics not initialised — call metrics::register_all() at startup")
 }
 
 /// Register all issuer metrics with the global registry.

--- a/src/services/onramp_quote.rs
+++ b/src/services/onramp_quote.rs
@@ -16,7 +16,7 @@ use bigdecimal::{BigDecimal, Zero};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use tracing::{debug, info};
 use uuid::Uuid;
@@ -125,8 +125,12 @@ fn derive_quote_amounts(
     Ok((amount_ngn_after_fees, amount_cngn))
 }
 
+/// Platform takes 20 % of the fallback onramp fee; provider receives the remaining 80 %.
+static PLATFORM_FEE_RATIO: LazyLock<BigDecimal> =
+    LazyLock::new(|| BigDecimal::from_str("0.2").expect("0.2 is a valid decimal literal"));
+
 fn split_fallback_onramp_fee(total_fee: &BigDecimal) -> (BigDecimal, BigDecimal) {
-    let platform_fee = total_fee * BigDecimal::from_str("0.2").unwrap();
+    let platform_fee = total_fee * &*PLATFORM_FEE_RATIO;
     let provider_fee = total_fee - &platform_fee;
     (platform_fee, provider_fee)
 }

--- a/src/stellar/sequence_coordinator.rs
+++ b/src/stellar/sequence_coordinator.rs
@@ -160,6 +160,10 @@ impl SequenceCoordinator {
 mod tests {
     use super::*;
 
+    // `unwrap()` is intentional throughout these tests: a panic is the correct
+    // failure signal when an operation that must succeed in the given test
+    // scenario returns an error.
+
     #[test]
     fn test_reserve_next_increments() {
         let coordinator = SequenceCoordinator::new(100, 10);


### PR DESCRIPTION
closes #619 
closes #618 
closes #620 
closes #617 


Problem
src/metrics/issuer.rs contains 12 panic-prone calls (unwrap, expect, or panic!).

Evidence
src/metrics/issuer.rs:16 — .expect("issuer metrics not initialised")
src/metrics/issuer.rs:22 — .expect("issuer metrics not initialised")
src/metrics/issuer.rs:28 — .expect("issuer metrics not initialised")
src/metrics/issuer.rs:34 — .expect("issuer metrics not initialised")
src/metrics/issuer.rs:41 — .expect("issuer metrics not initialised")
Proposed fix
Replace non-essential unwrap/expect usages with typed error propagation and contextual logging. Keep explicit panics only where unrecoverable invariants are well-documented.

Acceptance criteria
All avoidable panic-prone calls in this file are removed or justified with comments/tests.
Error paths return typed errors and preserve observability context.
Existing tests pass (or new tests cover changed paths).