### PR TITLE
docs(auth/jwt): document intentional unwrap usage in tests

### DIFF
--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -349,6 +349,9 @@ impl JwtConfig {
 }
 
 #[cfg(test)]
+// unwrap() is intentional in tests — a panic fails the test with a clear message,
+// which is the correct and idiomatic Rust behaviour. All production code paths
+// return typed `JwtError` results; no unwrap/expect/panic! exists outside this module.
 mod tests {
     use super::*;
 


### PR DESCRIPTION
Audit of issue #348 found all 8 flagged unwrap() calls reside inside #[cfg(test)]. Panicking on test failure is correct, idiomatic Rust.

Production code already uses typed JwtError propagation throughout — no unwrap/expect/panic! exists outside the test module.

Adds an inline comment to the test module to make this intent explicit and prevent future false-positive lint/audit reports.
closes #639 