### PR TITLE
docs(tests/issuer_account): document intentional unwrap/expect in tests

### DIFF
--- a/tests/issuer_account_integration.rs
+++ b/tests/issuer_account_integration.rs
@@ -5,6 +5,11 @@
 //!   STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org  (optional override)
 //!
 //! Tests that require funded accounts are skipped when the accounts are not funded.
+//!
+//! # Note on unwrap/expect usage
+//! All `unwrap()` and `expect()` calls in this file are intentional test-fixture
+//! boilerplate. Panicking on setup failure is correct in tests — it produces an
+//! immediate, clear failure message. No production code paths are involved.
 
 use Bitmesh_backend::chains::stellar::{
     client::StellarClient,


### PR DESCRIPTION
Audit of panic-prone calls (issue raised against 18 occurrences in tests/issuer_account_integration.rs) confirmed all calls are test-fixture boilerplate inside integration test functions.

Panicking on setup/assertion failure is correct and idiomatic in Rust tests. No production code paths use unwrap/expect/panic!.

Adds a module-level doc comment to make this intent explicit and prevent future false-positive lint/audit reports.
closes #593 