### PR TITLE
docs(tests/cors_security): document intentional unwrap usage in tests

### DIFF
--- a/tests/cors_security_test.rs
+++ b/tests/cors_security_test.rs
@@ -1,6 +1,12 @@
 //! Integration tests for CORS and Security Headers middleware
 //!
 //! Tests the implementation of Issue #86 - CORS and Security Headers
+//!
+//! # Note on unwrap/expect usage
+//! All `unwrap()` calls in this file are intentional test-fixture boilerplate:
+//! building requests, driving `oneshot`, and reading expected response headers.
+//! Panicking on failure is correct in tests — it produces a clear, immediate
+//! error message. No production code paths are involved.
 
 use axum::{
     body::Body,


### PR DESCRIPTION
Audit of 19 panic-prone calls in tests/cors_security_test.rs found all occurrences inside #[tokio::test] functions (request building, oneshot driving, header assertions).

Panicking on test failure is correct and idiomatic Rust. No production code paths use unwrap/expect/panic!.

Adds a module-level doc comment to make this intent explicit and prevent future false-positive lint/audit reports.
closes #591 