### PR TITLE
fix: reduce panic-prone calls in policy_engine and integration tests

### DIFF
--- a/src/aml/policy_engine.rs
+++ b/src/aml/policy_engine.rs
@@ -83,7 +83,7 @@ impl AMLPolicyEngine {
 
     async fn initialize_rule_cache(&self) -> Result<(), anyhow::Error> {
         let rules = self.load_all_rules().await?;
-        let mut cache = self.rule_cache.write().unwrap();
+        let mut cache = self.rule_cache.write().map_err(|_| anyhow::anyhow!("rule cache lock poisoned"))?;
         
         for rule in rules {
             cache.insert(rule.id, rule);
@@ -95,7 +95,7 @@ impl AMLPolicyEngine {
 
     async fn initialize_policy_set_cache(&self) -> Result<(), anyhow::Error> {
         let policy_sets = self.load_all_policy_sets().await?;
-        let mut cache = self.policy_set_cache.write().unwrap();
+        let mut cache = self.policy_set_cache.write().map_err(|_| anyhow::anyhow!("policy set cache lock poisoned"))?;
         
         for policy_set in policy_sets {
             cache.insert(policy_set.id, policy_set);
@@ -189,7 +189,7 @@ impl AMLPolicyEngine {
     }
 
     async fn get_applicable_policy_set(&self, context: &EvaluationContext) -> Result<PolicySet, anyhow::Error> {
-        let cache = self.policy_set_cache.read().unwrap();
+        let cache = self.policy_set_cache.read().map_err(|_| anyhow::anyhow!("policy set cache lock poisoned"))?;
         
         for policy_set in cache.values() {
             if self.is_policy_set_applicable(policy_set, context) {
@@ -241,7 +241,7 @@ impl AMLPolicyEngine {
 
     async fn get_default_policy_set(&self) -> Result<PolicySet, anyhow::Error> {
         // Try to find a default policy set in cache first
-        let cache = self.policy_set_cache.read().unwrap();
+        let cache = self.policy_set_cache.read().map_err(|_| anyhow::anyhow!("policy set cache lock poisoned"))?;
         
         for policy_set in cache.values() {
             if policy_set.name == "Default" {
@@ -280,16 +280,16 @@ impl AMLPolicyEngine {
     async fn get_default_rule_ids(&self) -> Result<Vec<Uuid>, anyhow::Error> {
         // Return IDs of core AML rules that should be in default policy
         Ok(vec![
-            Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(), // Structuring rule
-            Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap(), // Velocity rule
-            Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap(), // Amount anomaly rule
-            Uuid::parse_str("00000000-0000-0000-0000-000000000004").unwrap(), // Geographic risk rule
-            Uuid::parse_str("00000000-0000-0000-0000-000000000005").unwrap(), // Counterparty risk rule
+            Uuid::parse_str("00000000-0000-0000-0000-000000000001")?, // Structuring rule
+            Uuid::parse_str("00000000-0000-0000-0000-000000000002")?, // Velocity rule
+            Uuid::parse_str("00000000-0000-0000-0000-000000000003")?, // Amount anomaly rule
+            Uuid::parse_str("00000000-0000-0000-0000-000000000004")?, // Geographic risk rule
+            Uuid::parse_str("00000000-0000-0000-0000-000000000005")?, // Counterparty risk rule
         ])
     }
 
     async fn load_applicable_rules(&self, policy_set: &PolicySet) -> Result<Vec<AMLRule>, anyhow::Error> {
-        let cache = self.rule_cache.read().unwrap();
+        let cache = self.rule_cache.read().map_err(|_| anyhow::anyhow!("rule cache lock poisoned"))?;
         let mut rules = Vec::new();
 
         for rule_id in &policy_set.rule_ids {
@@ -300,8 +300,9 @@ impl AMLPolicyEngine {
             }
         }
 
-        // Sort by priority (risk weight descending)
-        rules.sort_by(|a, b| b.risk_weight.partial_cmp(&a.risk_weight).unwrap());
+        // Sort by priority (risk weight descending). risk_weight may be NaN for
+        // malformed rules; treat those as equal rather than panicking.
+        rules.sort_by(|a, b| b.risk_weight.partial_cmp(&a.risk_weight).unwrap_or(std::cmp::Ordering::Equal));
 
         Ok(rules)
     }
@@ -561,9 +562,9 @@ impl AMLPolicyEngine {
         
         // Insert into database
         let inserted_rule = self.insert_rule_into_db(&rule).await?;
-        
+
         // Update cache
-        let mut cache = self.rule_cache.write().unwrap();
+        let mut cache = self.rule_cache.write().map_err(|_| anyhow::anyhow!("rule cache lock poisoned"))?;
         cache.insert(inserted_rule.id, inserted_rule.clone());
         
         // Invalidate evaluation cache
@@ -580,9 +581,9 @@ impl AMLPolicyEngine {
         
         // Update in database
         let updated_rule = self.update_rule_in_db(rule_id, &updates).await?;
-        
+
         // Update cache
-        let mut cache = self.rule_cache.write().unwrap();
+        let mut cache = self.rule_cache.write().map_err(|_| anyhow::anyhow!("rule cache lock poisoned"))?;
         cache.insert(updated_rule.id, updated_rule.clone());
         
         // Invalidate evaluation cache
@@ -611,7 +612,7 @@ impl AMLPolicyEngine {
     }
 
     async fn get_rule_by_id(&self, rule_id: Uuid) -> Result<AMLRule, anyhow::Error> {
-        let cache = self.rule_cache.read().unwrap();
+        let cache = self.rule_cache.read().map_err(|_| anyhow::anyhow!("rule cache lock poisoned"))?;
         cache.get(&rule_id)
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Rule not found: {}", rule_id))
@@ -789,7 +790,7 @@ impl AMLPolicyEngine {
     }
 
     async fn get_policy_set_by_id(&self, policy_set_id: Uuid) -> Result<PolicySet, anyhow::Error> {
-        let cache = self.policy_set_cache.read().unwrap();
+        let cache = self.policy_set_cache.read().map_err(|_| anyhow::anyhow!("policy set cache lock poisoned"))?;
         cache.get(&policy_set_id)
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Policy set not found: {}", policy_set_id))

--- a/tests/api_key_integration.rs
+++ b/tests/api_key_integration.rs
@@ -7,6 +7,12 @@
 //!   - Invalid key rejection
 //!   - Revoked key rejection
 //!   - Max keys per consumer enforcement
+//!
+//! # Note on unwrap/expect usage
+//! All `unwrap()` calls in this file are intentional test-fixture boilerplate:
+//! generating API keys for known-valid inputs. Panicking on failure is
+//! correct and idiomatic in `#[test]` functions — it produces a clear,
+//! immediate error message. No production code paths are involved.
 
 #[cfg(feature = "integration")]
 mod api_key_tests {

--- a/tests/por_integration.rs
+++ b/tests/por_integration.rs
@@ -1,4 +1,11 @@
 //! Integration tests for Proof of Reserves (PoR) and Merkle Tree Engine
+//!
+//! # Note on unwrap/expect usage
+//! All `unwrap()`/`expect()` calls in this file are intentional test-fixture
+//! boilerplate: parsing fixed decimal literals and generating Merkle proofs
+//! for known-valid inputs. Panicking on failure is correct and idiomatic in
+//! `#[test]` functions — it produces a clear, immediate error message. No
+//! production code paths are involved.
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- `src/aml/policy_engine.rs`: replaced all `RwLock` `.unwrap()` calls and `Uuid::parse_str(...).unwrap()` calls with typed error propagation via `anyhow::Error`; guarded the `risk_weight` float sort comparison against `NaN` instead of panicking.
- `tests/por_integration.rs` and `tests/api_key_integration.rs`: added module-level doc comments documenting that the remaining `unwrap()`/`expect()` calls are intentional test-fixture boilerplate — panicking on test failure is correct and idiomatic, and no production code paths are involved.

Closes #608
Closes #609
Closes #600

## Test plan
- [x] Manual review of all 15 panic-prone call sites in `policy_engine.rs` confirmed each containing function already returns `Result<_, anyhow::Error>`, so propagation requires no signature changes.
- [x] Verified brace/paren balance and that `anyhow::anyhow!` is already used elsewhere in the file (no new imports needed).
- [ ] `cargo test` (not run locally — toolchain unavailable in this environment; no logic changes to test files, only documentation added)