### PR TITLE
fix(tests): replace panic-prone unwrap/expect/todo!/panic! with typed…

### DIFF
--- a/src/crypto/tests.rs
+++ b/src/crypto/tests.rs
@@ -23,22 +23,23 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_aes_gcm_round_trip() {
+    fn test_aes_gcm_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         let key = generate_session_key();
         let plaintext = b"sensitive-national-id-12345";
 
-        let (nonce, ct_tag) = aes_gcm_encrypt(&key, plaintext).unwrap();
-        let decrypted = aes_gcm_decrypt(&key, &nonce, &ct_tag).unwrap();
+        let (nonce, ct_tag) = aes_gcm_encrypt(&key, plaintext)?;
+        let decrypted = aes_gcm_decrypt(&key, &nonce, &ct_tag)?;
 
         assert_eq!(decrypted.as_slice(), plaintext);
+        Ok(())
     }
 
     #[test]
-    fn test_aes_gcm_auth_tag_verification_rejects_tampered_ciphertext() {
+    fn test_aes_gcm_auth_tag_verification_rejects_tampered_ciphertext() -> Result<(), Box<dyn std::error::Error>> {
         let key = generate_session_key();
         let plaintext = b"bank-account-number";
 
-        let (nonce, mut ct_tag) = aes_gcm_encrypt(&key, plaintext).unwrap();
+        let (nonce, mut ct_tag) = aes_gcm_encrypt(&key, plaintext)?;
         // Flip a byte in the ciphertext.
         ct_tag[0] ^= 0xFF;
 
@@ -47,14 +48,15 @@ mod tests {
             result,
             Err(EncryptionError::AuthTagVerificationFailed)
         ));
+        Ok(())
     }
 
     #[test]
-    fn test_aes_gcm_auth_tag_verification_rejects_tampered_tag() {
+    fn test_aes_gcm_auth_tag_verification_rejects_tampered_tag() -> Result<(), Box<dyn std::error::Error>> {
         let key = generate_session_key();
         let plaintext = b"iban-value";
 
-        let (nonce, mut ct_tag) = aes_gcm_encrypt(&key, plaintext).unwrap();
+        let (nonce, mut ct_tag) = aes_gcm_encrypt(&key, plaintext)?;
         // Flip a byte in the tag (last 16 bytes).
         let len = ct_tag.len();
         ct_tag[len - 1] ^= 0xFF;
@@ -64,6 +66,7 @@ mod tests {
             result,
             Err(EncryptionError::AuthTagVerificationFailed)
         ));
+        Ok(())
     }
 
     #[test]
@@ -86,41 +89,45 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_key_store_rejects_retired_key_version() {
-        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
-        let retired = PlatformKeyVersion::generate("v2", KeyStatus::Retired).unwrap();
-        let store = KeyStore::new(vec![active, retired]).unwrap();
+    fn test_key_store_rejects_retired_key_version() -> Result<(), Box<dyn std::error::Error>> {
+        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active)?;
+        let retired = PlatformKeyVersion::generate("v2", KeyStatus::Retired)?;
+        let store = KeyStore::new(vec![active, retired])?;
 
         let result = store.get_for_decryption("v2");
         assert!(matches!(result, Err(EncryptionError::KeyVersionRetired(_))));
+        Ok(())
     }
 
     #[test]
-    fn test_key_store_rejects_unknown_key_version() {
-        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
-        let store = KeyStore::new(vec![active]).unwrap();
+    fn test_key_store_rejects_unknown_key_version() -> Result<(), Box<dyn std::error::Error>> {
+        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active)?;
+        let store = KeyStore::new(vec![active])?;
 
         let result = store.get_for_decryption("v99");
         assert!(matches!(
             result,
             Err(EncryptionError::KeyVersionNotFound(_))
         ));
+        Ok(())
     }
 
     #[test]
-    fn test_key_store_accepts_transitional_key_version() {
-        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
-        let transitional = PlatformKeyVersion::generate("v2", KeyStatus::Transitional).unwrap();
-        let store = KeyStore::new(vec![active, transitional]).unwrap();
+    fn test_key_store_accepts_transitional_key_version() -> Result<(), Box<dyn std::error::Error>> {
+        let active = PlatformKeyVersion::generate("v1", KeyStatus::Active)?;
+        let transitional = PlatformKeyVersion::generate("v2", KeyStatus::Transitional)?;
+        let store = KeyStore::new(vec![active, transitional])?;
 
         assert!(store.get_for_decryption("v2").is_ok());
+        Ok(())
     }
 
     #[test]
-    fn test_key_store_requires_active_key() {
-        let retired = PlatformKeyVersion::generate("v1", KeyStatus::Retired).unwrap();
+    fn test_key_store_requires_active_key() -> Result<(), Box<dyn std::error::Error>> {
+        let retired = PlatformKeyVersion::generate("v1", KeyStatus::Retired)?;
         let result = KeyStore::new(vec![retired]);
         assert!(result.is_err());
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -183,10 +190,10 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_full_encryption_decryption_round_trip() {
+    fn test_full_encryption_decryption_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         // 1. Platform generates key pair.
-        let platform_key = PlatformKeyVersion::generate("v1", KeyStatus::Active).unwrap();
-        let platform_pub = PublicKey::from_sec1_bytes(&platform_key.public_key_bytes).unwrap();
+        let platform_key = PlatformKeyVersion::generate("v1", KeyStatus::Active)?;
+        let platform_pub = PublicKey::from_sec1_bytes(&platform_key.public_key_bytes)?;
 
         // 2. Consumer side: generate ephemeral key pair.
         let ephemeral_secret = EphemeralSecret::random(&mut OsRng);
@@ -195,16 +202,16 @@ mod tests {
         let epk_b64 = URL_SAFE_NO_PAD.encode(&epk_bytes);
 
         // 3. Consumer derives KEK via ECDH.
-        let kek = ecdh_derive_kek(&ephemeral_secret, &platform_pub).unwrap();
+        let kek = ecdh_derive_kek(&ephemeral_secret, &platform_pub)?;
 
         // 4. Consumer generates session key and wraps it.
         let session_key = generate_session_key();
-        let wrapped_key = aes_kw_wrap(&kek, &session_key).unwrap();
+        let wrapped_key = aes_kw_wrap(&kek, &session_key)?;
         let ek_b64 = URL_SAFE_NO_PAD.encode(&wrapped_key);
 
         // 5. Consumer encrypts the plaintext field.
         let plaintext = b"NG12345678";
-        let (nonce, ct_tag) = aes_gcm_encrypt(&session_key, plaintext).unwrap();
+        let (nonce, ct_tag) = aes_gcm_encrypt(&session_key, plaintext)?;
 
         // Split ct and tag (last 16 bytes are the tag in aes-gcm output).
         let tag_start = ct_tag.len() - 16;
@@ -213,20 +220,21 @@ mod tests {
         let iv_b64 = URL_SAFE_NO_PAD.encode(nonce);
 
         // 6. Server side: unwrap session key and decrypt.
-        let store = KeyStore::new(vec![platform_key]).unwrap();
-        let kv = store.get_for_decryption("v1").unwrap();
-        let decrypted_session_key = kv.unwrap_session_key(&epk_b64, &ek_b64).unwrap();
+        let store = KeyStore::new(vec![platform_key])?;
+        let kv = store.get_for_decryption("v1")?;
+        let decrypted_session_key = kv.unwrap_session_key(&epk_b64, &ek_b64)?;
 
-        let nonce_bytes = decode_nonce(&iv_b64).unwrap();
+        let nonce_bytes = decode_nonce(&iv_b64)?;
         let ct_tag_bytes = {
-            let mut v = URL_SAFE_NO_PAD.decode(&ct_b64).unwrap();
-            v.extend_from_slice(&URL_SAFE_NO_PAD.decode(&tag_b64).unwrap());
+            let mut v = URL_SAFE_NO_PAD.decode(&ct_b64)?;
+            v.extend_from_slice(&URL_SAFE_NO_PAD.decode(&tag_b64)?);
             v
         };
 
         let decrypted =
-            aes_gcm_decrypt(&decrypted_session_key, &nonce_bytes, &ct_tag_bytes).unwrap();
+            aes_gcm_decrypt(&decrypted_session_key, &nonce_bytes, &ct_tag_bytes)?;
         assert_eq!(decrypted.as_slice(), plaintext);
+        Ok(())
     }
 
     // -----------------------------------------------------------------------

--- a/src/security/tests.rs
+++ b/src/security/tests.rs
@@ -16,16 +16,17 @@ mod tests {
     use tokio::time::{sleep, Duration};
     use uuid::Uuid;
 
-    // Test helper to create a test database pool
-    async fn create_test_pool() -> PgPool {
-        // In a real test environment, this would create a test database
-        // For now, we'll use a placeholder
-        todo!("Implement test database setup")
+    // Test helper to create a test database pool.
+    // Requires TEST_DATABASE_URL to be set; skips (returns Err) if unavailable.
+    async fn create_test_pool() -> Result<PgPool, sqlx::Error> {
+        let url = std::env::var("TEST_DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/aframp_test".into());
+        PgPool::connect(&url).await
     }
 
     #[tokio::test]
-    async fn test_velocity_limit_detection() {
-        let pool = create_test_pool().await;
+    async fn test_velocity_limit_detection() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig {
             velocity_limit_ngn: 100_000_000, // 100M NGN
             velocity_window: Duration::from_secs(60),
@@ -40,51 +41,48 @@ mod tests {
 
         // Record multiple mints within the window
         anomaly_service
-            .record_mint_event(30_000_000, &wallet)
-            .await
-            .unwrap(); // 30M
+            .record_mint_event(30_000_000, &wallet) // 30M
+            .await?;
         anomaly_service
-            .record_mint_event(40_000_000, &wallet)
-            .await
-            .unwrap(); // 40M
+            .record_mint_event(40_000_000, &wallet) // 40M
+            .await?;
         anomaly_service
-            .record_mint_event(35_000_000, &wallet)
-            .await
-            .unwrap(); // 35M
+            .record_mint_event(35_000_000, &wallet) // 35M
+            .await?;
 
         // Total: 105M NGN > 100M limit, should trigger circuit breaker
         sleep(Duration::from_millis(100)).await; // Allow async processing
 
         let status = anomaly_service.get_system_status().await;
         assert!(!matches!(status, SystemStatus::Operational));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_negative_delta_detection() {
-        let pool = create_test_pool().await;
+    async fn test_negative_delta_detection() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, config));
 
         // Simulate bank reserves less than on-chain supply beyond tolerance
         let bank_reserves = 950_000_000; // 950M NGN
         let on_chain_supply = 1_000_000_000; // 1B NGN
-        let delta_percentage = (on_chain_supply - bank_reserves) as f64 / on_chain_supply as f64; // 5%
 
         // 5% > 0.01% tolerance, should trigger circuit breaker
         anomaly_service
             .check_reserve_ratio(bank_reserves, on_chain_supply)
-            .await
-            .unwrap();
+            .await?;
 
         sleep(Duration::from_millis(100)).await;
 
         let status = anomaly_service.get_system_status().await;
         assert!(!matches!(status, SystemStatus::Operational));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_unknown_origin_detection() {
-        let pool = create_test_pool().await;
+    async fn test_unknown_origin_detection() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, config));
 
@@ -98,18 +96,18 @@ mod tests {
 
         anomaly_service
             .detect_unknown_origin_mints(unknown_mints)
-            .await
-            .unwrap();
+            .await?;
 
         sleep(Duration::from_millis(100)).await;
 
         let status = anomaly_service.get_system_status().await;
         assert!(!matches!(status, SystemStatus::Operational));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_circuit_breaker_escalation() {
-        let pool = create_test_pool().await;
+    async fn test_circuit_breaker_escalation() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, config));
 
@@ -127,8 +125,7 @@ mod tests {
         };
         anomaly_service
             .trigger_circuit_breaker(anomaly1)
-            .await
-            .unwrap();
+            .await?;
 
         let status1 = anomaly_service.get_system_status().await;
         assert!(matches!(status1, SystemStatus::PartialHalt));
@@ -141,16 +138,16 @@ mod tests {
         };
         anomaly_service
             .trigger_circuit_breaker(anomaly2)
-            .await
-            .unwrap();
+            .await?;
 
         let status2 = anomaly_service.get_system_status().await;
         assert!(matches!(status2, SystemStatus::EmergencyStop));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_manual_emergency_stop() {
-        let pool = create_test_pool().await;
+    async fn test_manual_emergency_stop() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, config));
 
@@ -159,8 +156,7 @@ mod tests {
 
         anomaly_service
             .manual_emergency_stop(reason, authorized_by)
-            .await
-            .unwrap();
+            .await?;
 
         let status = anomaly_service.get_system_status().await;
         assert!(matches!(status, SystemStatus::EmergencyStop));
@@ -168,36 +164,36 @@ mod tests {
         let circuit_state = anomaly_service.get_circuit_breaker_state().await;
         assert!(circuit_state.audit_required);
         assert!(circuit_state.triggered_at.is_some());
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_audit_and_reset() {
-        let pool = create_test_pool().await;
+    async fn test_audit_and_reset() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, config));
 
         // First trigger emergency stop
         anomaly_service
             .manual_emergency_stop("Test", "admin1")
-            .await
-            .unwrap();
+            .await?;
 
-        // Should not be able to reset without audit
-        let result = anomaly_service
+        // Should work in test environment
+        anomaly_service
             .audit_and_reset("auditor1", "auditor2", "test reset")
-            .await;
-        assert!(result.is_ok()); // Should work in test environment
+            .await?;
 
         let status = anomaly_service.get_system_status().await;
         assert!(matches!(status, SystemStatus::Operational));
 
         let circuit_state = anomaly_service.get_circuit_breaker_state().await;
         assert!(!circuit_state.audit_required);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_circuit_breaker_middleware() {
-        let pool = create_test_pool().await;
+    async fn test_circuit_breaker_middleware() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, config));
         let middleware = CircuitBreakerMiddleware::new(anomaly_service.clone());
@@ -208,8 +204,7 @@ mod tests {
         // Trigger emergency stop
         anomaly_service
             .manual_emergency_stop("Test", "admin")
-            .await
-            .unwrap();
+            .await?;
 
         // Should block operations when halted
         let result = middleware.check_operation_allowed().await;
@@ -219,15 +214,18 @@ mod tests {
             crate::error::AppErrorKind::Domain(crate::error::DomainError::SystemHalted {
                 ..
             }) => {
-                // Expected error type
+                // Expected error type — circuit breaker correctly blocked the operation
             }
-            _ => panic!("Expected SystemHalted error"),
+            other => {
+                return Err(format!("Expected SystemHalted error, got: {:?}", other).into());
+            }
         }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_velocity_tracking_cleanup() {
-        let pool = create_test_pool().await;
+    async fn test_velocity_tracking_cleanup() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig {
             velocity_limit_ngn: 100_000_000,
             velocity_window: Duration::from_secs(2), // Short window for testing
@@ -239,12 +237,10 @@ mod tests {
         // Record mints that exceed limit
         anomaly_service
             .record_mint_event(60_000_000, &wallet)
-            .await
-            .unwrap();
+            .await?;
         anomaly_service
-            .record_mint_event(60_000_000, &wallet)
-            .await
-            .unwrap(); // Total: 120M
+            .record_mint_event(60_000_000, &wallet) // Total: 120M
+            .await?;
 
         sleep(Duration::from_millis(100)).await;
         assert!(!matches!(
@@ -258,18 +254,18 @@ mod tests {
         // Record new mint (should not trigger as old events expired)
         anomaly_service
             .record_mint_event(30_000_000, &wallet)
-            .await
-            .unwrap();
+            .await?;
         sleep(Duration::from_millis(100)).await;
 
         // System should still be halted (no auto-recovery)
         let status = anomaly_service.get_system_status().await;
         assert!(!matches!(status, SystemStatus::Operational));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_multiple_wallet_velocity_tracking() {
-        let pool = create_test_pool().await;
+    async fn test_multiple_wallet_velocity_tracking() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, config));
 
@@ -278,13 +274,11 @@ mod tests {
 
         // Each wallet under limit individually
         anomaly_service
-            .record_mint_event(300_000_000, &wallet1)
-            .await
-            .unwrap(); // 300M
+            .record_mint_event(300_000_000, &wallet1) // 300M
+            .await?;
         anomaly_service
-            .record_mint_event(300_000_000, &wallet2)
-            .await
-            .unwrap(); // 300M
+            .record_mint_event(300_000_000, &wallet2) // 300M
+            .await?;
 
         sleep(Duration::from_millis(100)).await;
 
@@ -296,9 +290,8 @@ mod tests {
 
         // One wallet exceeds limit
         anomaly_service
-            .record_mint_event(300_000_000, &wallet1)
-            .await
-            .unwrap(); // Total: 600M
+            .record_mint_event(300_000_000, &wallet1) // Total: 600M
+            .await?;
 
         sleep(Duration::from_millis(100)).await;
 
@@ -307,11 +300,12 @@ mod tests {
             anomaly_service.get_system_status().await,
             SystemStatus::Operational
         ));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_reserve_ratio_tolerance() {
-        let pool = create_test_pool().await;
+    async fn test_reserve_ratio_tolerance() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig {
             negative_delta_tolerance: 0.01, // 1% tolerance
             ..Default::default()
@@ -324,8 +318,7 @@ mod tests {
 
         anomaly_service
             .check_reserve_ratio(bank_reserves, on_chain_supply)
-            .await
-            .unwrap();
+            .await?;
 
         sleep(Duration::from_millis(100)).await;
 
@@ -340,8 +333,7 @@ mod tests {
 
         anomaly_service
             .check_reserve_ratio(bank_reserves_2, on_chain_supply)
-            .await
-            .unwrap();
+            .await?;
 
         sleep(Duration::from_millis(100)).await;
 
@@ -350,11 +342,12 @@ mod tests {
             anomaly_service.get_system_status().await,
             SystemStatus::Operational
         ));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_circuit_state_persistence() {
-        let pool = create_test_pool().await;
+    async fn test_circuit_state_persistence() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let config = AnomalyDetectionConfig::default();
 
         // Create two service instances to test persistence
@@ -364,14 +357,14 @@ mod tests {
         // Trigger emergency stop on service1
         service1
             .manual_emergency_stop("Test", "admin")
-            .await
-            .unwrap();
+            .await?;
 
         // Service2 should see the updated state (from database)
         sleep(Duration::from_millis(200)).await;
 
         let status2 = service2.get_system_status().await;
         assert!(matches!(status2, SystemStatus::EmergencyStop));
+        Ok(())
     }
 }
 
@@ -390,9 +383,15 @@ mod api_tests {
     use serde_json::json;
     use tower::ServiceExt;
 
+    async fn create_test_pool() -> Result<sqlx::PgPool, sqlx::Error> {
+        let url = std::env::var("TEST_DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/aframp_test".into());
+        sqlx::PgPool::connect(&url).await
+    }
+
     #[tokio::test]
-    async fn test_circuit_breaker_status_endpoint() {
-        let pool = create_test_pool().await;
+    async fn test_circuit_breaker_status_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, Default::default()));
 
         let app = Router::new().nest(
@@ -403,16 +402,16 @@ mod api_tests {
         // Test status endpoint
         let request = Request::builder()
             .uri("/api/admin/circuit-breaker/status")
-            .body(Body::empty())
-            .unwrap();
+            .body(Body::empty())?;
 
-        let response = app.oneshot(request).await.unwrap();
+        let response = app.oneshot(request).await?;
         assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_emergency_stop_endpoint() {
-        let pool = create_test_pool().await;
+    async fn test_emergency_stop_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, Default::default()));
 
         let app = Router::new().nest(
@@ -430,18 +429,18 @@ mod api_tests {
             .method("POST")
             .uri("/api/admin/circuit-breaker/emergency-stop")
             .header("Content-Type", "application/json")
-            .body(Body::from(emergency_request.to_string()))
-            .unwrap();
+            .body(Body::from(emergency_request.to_string()))?;
 
-        let response = app.oneshot(request).await.unwrap();
+        let response = app.oneshot(request).await?;
 
         // In development mode without auth codes, this should succeed
         assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_dashboard_status_endpoint() {
-        let pool = create_test_pool().await;
+    async fn test_dashboard_status_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = create_test_pool().await?;
         let anomaly_service = Arc::new(AnomalyDetectionService::new(pool, Default::default()));
 
         let app = Router::new().nest(
@@ -451,10 +450,10 @@ mod api_tests {
 
         let request = Request::builder()
             .uri("/api/admin/dashboard/status")
-            .body(Body::empty())
-            .unwrap();
+            .body(Body::empty())?;
 
-        let response = app.oneshot(request).await.unwrap();
+        let response = app.oneshot(request).await?;
         assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
     }
 }

--- a/tests/commission_engine_test.rs
+++ b/tests/commission_engine_test.rs
@@ -11,13 +11,13 @@ mod unit {
     use std::str::FromStr;
     use uuid::Uuid;
 
-    fn make_structure(ct: CommissionType, rate: Option<&str>, fixed: Option<i64>) -> CommissionStructure {
-        CommissionStructure {
+    fn make_structure(ct: CommissionType, rate: Option<&str>, fixed: Option<i64>) -> Result<CommissionStructure, Box<dyn std::error::Error>> {
+        Ok(CommissionStructure {
             id: Uuid::new_v4(),
             partner_id: Uuid::new_v4(),
             name: "test".into(),
             commission_type: ct,
-            percentage_rate: rate.map(|r| BigDecimal::from_str(r).unwrap()),
+            percentage_rate: rate.map(|r| BigDecimal::from_str(r)).transpose()?,
             fixed_stroops: fixed,
             tiers: None,
             min_volume_stroops: 0,
@@ -29,53 +29,58 @@ mod unit {
             created_by: Uuid::new_v4(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
-        }
+        })
     }
 
     #[test]
-    fn percentage_splits_correctly() {
-        let s = make_structure(CommissionType::Percentage, Some("0.35"), None);
-        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+    fn percentage_splits_correctly() -> Result<(), Box<dyn std::error::Error>> {
+        let s = make_structure(CommissionType::Percentage, Some("0.35"), None)?;
+        let (c, _) = compute_commission(&s, 10_000_000, 0)?;
         assert_eq!(c, 3_500_000);
+        Ok(())
     }
 
     #[test]
-    fn seven_decimal_precision() {
-        let s = make_structure(CommissionType::Percentage, Some("0.1234567"), None);
-        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+    fn seven_decimal_precision() -> Result<(), Box<dyn std::error::Error>> {
+        let s = make_structure(CommissionType::Percentage, Some("0.1234567"), None)?;
+        let (c, _) = compute_commission(&s, 10_000_000, 0)?;
         assert_eq!(c, 1_234_567);
+        Ok(())
     }
 
     #[test]
-    fn fixed_fiat_basic() {
-        let s = make_structure(CommissionType::FixedFiat, None, Some(500_000));
-        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+    fn fixed_fiat_basic() -> Result<(), Box<dyn std::error::Error>> {
+        let s = make_structure(CommissionType::FixedFiat, None, Some(500_000))?;
+        let (c, _) = compute_commission(&s, 10_000_000, 0)?;
         assert_eq!(c, 500_000);
+        Ok(())
     }
 
     #[test]
-    fn fixed_fiat_capped_at_gross() {
-        let s = make_structure(CommissionType::FixedFiat, None, Some(20_000_000));
-        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+    fn fixed_fiat_capped_at_gross() -> Result<(), Box<dyn std::error::Error>> {
+        let s = make_structure(CommissionType::FixedFiat, None, Some(20_000_000))?;
+        let (c, _) = compute_commission(&s, 10_000_000, 0)?;
         assert_eq!(c, 10_000_000);
+        Ok(())
     }
 
     #[test]
-    fn tiered_selects_correct_tier() {
+    fn tiered_selects_correct_tier() -> Result<(), Box<dyn std::error::Error>> {
         let tiers = serde_json::json!([
             {"min_volume_stroops": 0, "max_volume_stroops": 1_000_000_000_i64, "rate": 0.30},
             {"min_volume_stroops": 1_000_000_000_i64, "max_volume_stroops": null, "rate": 0.20},
         ]);
-        let mut s = make_structure(CommissionType::Tiered, None, None);
+        let mut s = make_structure(CommissionType::Tiered, None, None)?;
         s.tiers = Some(tiers);
         // Volume in tier 0
-        let (c0, idx0) = compute_commission(&s, 10_000_000, 500_000_000).unwrap();
+        let (c0, idx0) = compute_commission(&s, 10_000_000, 500_000_000)?;
         assert_eq!(c0, 3_000_000);
         assert_eq!(idx0, Some(0));
         // Volume in tier 1
-        let (c1, idx1) = compute_commission(&s, 10_000_000, 2_000_000_000).unwrap();
+        let (c1, idx1) = compute_commission(&s, 10_000_000, 2_000_000_000)?;
         assert_eq!(c1, 2_000_000);
         assert_eq!(idx1, Some(1));
+        Ok(())
     }
 
     #[test]
@@ -112,23 +117,26 @@ mod unit {
     }
 
     #[test]
-    fn zero_rate_gives_zero_commission() {
-        let s = make_structure(CommissionType::Percentage, Some("0.0"), None);
-        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+    fn zero_rate_gives_zero_commission() -> Result<(), Box<dyn std::error::Error>> {
+        let s = make_structure(CommissionType::Percentage, Some("0.0"), None)?;
+        let (c, _) = compute_commission(&s, 10_000_000, 0)?;
         assert_eq!(c, 0);
+        Ok(())
     }
 
     #[test]
-    fn full_rate_gives_full_gross() {
-        let s = make_structure(CommissionType::Percentage, Some("1.0"), None);
-        let (c, _) = compute_commission(&s, 10_000_000, 0).unwrap();
+    fn full_rate_gives_full_gross() -> Result<(), Box<dyn std::error::Error>> {
+        let s = make_structure(CommissionType::Percentage, Some("1.0"), None)?;
+        let (c, _) = compute_commission(&s, 10_000_000, 0)?;
         assert_eq!(c, 10_000_000);
+        Ok(())
     }
 
     #[test]
-    fn overflow_does_not_panic() {
-        let s = make_structure(CommissionType::Percentage, Some("0.5"), None);
+    fn overflow_does_not_panic() -> Result<(), Box<dyn std::error::Error>> {
+        let s = make_structure(CommissionType::Percentage, Some("0.5"), None)?;
         assert!(compute_commission(&s, i64::MAX / 2, 0).is_ok());
+        Ok(())
     }
 }
 
@@ -141,15 +149,15 @@ mod integration {
     use sqlx::PgPool;
     use uuid::Uuid;
 
-    async fn pool() -> PgPool {
+    async fn pool() -> Result<PgPool, sqlx::Error> {
         let url = std::env::var("TEST_DATABASE_URL")
             .unwrap_or_else(|_| "postgres://localhost/aframp_test".into());
-        PgPool::connect(&url).await.expect("test db connection")
+        PgPool::connect(&url).await
     }
 
     #[tokio::test]
-    async fn test_ledger_atomic_write_and_balance() {
-        let pool = pool().await;
+    async fn test_ledger_atomic_write_and_balance() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = pool().await?;
         let svc = CommissionService::new(pool.clone());
 
         // Insert a minimal partner for the test
@@ -157,11 +165,10 @@ mod integration {
             "INSERT INTO partners (name, finance_email) VALUES ('TestPa', 'test@pa.io') RETURNING id",
         )
         .fetch_one(&pool)
-        .await
-        .unwrap();
+        .await?;
 
         // Create a commission structure
-        let structure = svc
+        let _structure = svc
             .configure_structure(CreateCommissionStructureInput {
                 partner_id,
                 name: "35pct".into(),
@@ -176,14 +183,12 @@ mod integration {
                 effective_to: None,
                 created_by: Uuid::nil(),
             })
-            .await
-            .unwrap();
+            .await?;
 
         let tx_id = Uuid::new_v4();
         let entries = svc
             .record_transaction_commissions(tx_id, 10_000_000, None, 0)
-            .await
-            .unwrap();
+            .await?;
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].amount_stroops, 3_500_000);
@@ -195,7 +200,7 @@ mod integration {
             "invariant must hold in persisted entry"
         );
 
-        let stmt = svc.revenue_statement(partner_id, 10, 0).await.unwrap();
+        let stmt = svc.revenue_statement(partner_id, 10, 0).await?;
         assert_eq!(stmt.accrued_stroops, 3_500_000);
         assert_eq!(stmt.unpaid_stroops, 3_500_000);
 
@@ -203,36 +208,33 @@ mod integration {
         sqlx::query("DELETE FROM partner_revenue_ledger WHERE partner_id = $1")
             .bind(partner_id)
             .execute(&pool)
-            .await
-            .unwrap();
+            .await?;
         sqlx::query("DELETE FROM partner_commission_balances WHERE partner_id = $1")
             .bind(partner_id)
             .execute(&pool)
-            .await
-            .unwrap();
+            .await?;
         sqlx::query("DELETE FROM commission_structures WHERE partner_id = $1")
             .bind(partner_id)
             .execute(&pool)
-            .await
-            .unwrap();
+            .await?;
         sqlx::query("DELETE FROM partners WHERE id = $1")
             .bind(partner_id)
             .execute(&pool)
-            .await
-            .unwrap();
+            .await?;
+
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_manual_adjustment_narrative_required() {
-        let pool = pool().await;
+    async fn test_manual_adjustment_narrative_required() -> Result<(), Box<dyn std::error::Error>> {
+        let pool = pool().await?;
         let svc = CommissionService::new(pool.clone());
 
         let partner_id: Uuid = sqlx::query_scalar(
             "INSERT INTO partners (name, finance_email) VALUES ('AdjPa', 'adj@pa.io') RETURNING id",
         )
         .fetch_one(&pool)
-        .await
-        .unwrap();
+        .await?;
 
         let entry = svc
             .manual_adjustment(ManualAdjustmentInput {
@@ -245,18 +247,19 @@ mod integration {
                 narrative: "Correction for over-deduction on 2026-06-01".into(),
                 initiated_by: Uuid::new_v4(),
             })
-            .await
-            .unwrap();
+            .await?;
 
         assert!(entry.narrative.contains("MANUAL ADJUSTMENT"));
         assert_eq!(entry.amount_stroops, 1_000_000);
 
         // Cleanup
         sqlx::query("DELETE FROM partner_revenue_ledger WHERE partner_id = $1")
-            .bind(partner_id).execute(&pool).await.unwrap();
+            .bind(partner_id).execute(&pool).await?;
         sqlx::query("DELETE FROM partner_commission_balances WHERE partner_id = $1")
-            .bind(partner_id).execute(&pool).await.unwrap();
+            .bind(partner_id).execute(&pool).await?;
         sqlx::query("DELETE FROM partners WHERE id = $1")
-            .bind(partner_id).execute(&pool).await.unwrap();
+            .bind(partner_id).execute(&pool).await?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
closes #579 
closes #582 
closes #584 


… error propagation

Addresses issues in three test files that contained a combined 74 panic-prone calls (unwrap, expect, panic!, todo!):

- tests/commission_engine_test.rs (23 occurrences)
  - make_structure() now returns Result<CommissionStructure, Box<dyn Error>> using .transpose()? instead of .unwrap() on BigDecimal::from_str
  - All unit test fns return Result<(), Box<dyn Error>>, propagating errors from compute_commission() with ? instead of .unwrap()
  - Integration test pool() returns Result<PgPool, sqlx::Error>; all DB calls propagate with ? instead of .unwrap()

- src/crypto/tests.rs (25 occurrences)
  - All test fns return Result<(), Box<dyn Error>>
  - Crypto operations (aes_gcm_encrypt, aes_gcm_decrypt, PlatformKeyVersion::generate, KeyStore::new, ecdh_derive_kek, aes_kw_wrap, kv.unwrap_session_key, decode_nonce, URL_SAFE_NO_PAD.decode, PublicKey::from_sec1_bytes) now propagate with ? instead of .unwrap()

- src/security/tests.rs (26 occurrences)
  - create_test_pool() replaced todo!() with proper Result-returning DB connect; tests that cannot connect will fail with a descriptive error rather than a compile-time unimplemented panic
  - All async test fns return Result<(), Box<dyn Error>>, propagating service call errors with ?
  - panic!("Expected SystemHalted error") in match arm replaced with typed Err(format!(...).into()) for proper error propagation

No logic changes — assertions and test intent are preserved.