### PR TITLE
Fix: use TelemetryConfig in init_tracer to resolve type mismatch

### DIFF
--- a/src/telemetry/tracer.rs
+++ b/src/telemetry/tracer.rs
@@ -8,36 +8,7 @@ use opentelemetry_sdk::{
 };
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
-
-/// Configuration for the OpenTelemetry tracer loaded from environment variables.
-#[derive(Debug, Clone)]
-pub struct TracingConfig {
-    /// Human-readable service name emitted in every span.
-    pub service_name: String,
-    /// Deployment environment (e.g. "development", "staging", "production").
-    pub environment: String,
-    /// Fraction of traces to sample (0.0 – 1.0). Error traces are always sampled.
-    pub sampling_rate: f64,
-    /// OTLP collector endpoint (e.g. "http://localhost:4317").
-    pub otlp_endpoint: String,
-}
-
-impl TracingConfig {
-    /// Build configuration from environment variables with sensible defaults.
-    pub fn from_env() -> Self {
-        Self {
-            service_name: std::env::var("OTEL_SERVICE_NAME")
-                .unwrap_or_else(|_| "aframp-backend".into()),
-            environment: std::env::var("APP_ENV").unwrap_or_else(|_| "development".into()),
-            sampling_rate: std::env::var("OTEL_SAMPLING_RATE")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(1.0),
-            otlp_endpoint: std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
-                .unwrap_or_else(|_| "http://localhost:4317".into()),
-        }
-    }
-}
+use crate::config::TelemetryConfig;
 
 /// Initialise the global OpenTelemetry tracer provider and the `tracing` subscriber.
 ///
@@ -53,7 +24,7 @@ impl TracingConfig {
 ///   downstream processor / collector can apply tail-based sampling if desired.
 ///   Within the SDK we default to `AlwaysOn` when sampling_rate == 1.0 and fall
 ///   back to a `TraceIdRatioBased` sampler wrapped in `ParentBased` otherwise.
-pub fn init_tracer(config: &TracingConfig) -> anyhow::Result<()> {
+pub fn init_tracer(config: &TelemetryConfig) -> anyhow::Result<()> {
     // Register W3C propagator globally so extract/inject helpers work.
     global::set_text_map_propagator(TraceContextPropagator::new());
 


### PR DESCRIPTION
closes #541 
closes #542 
closes #543 
closes #544



Problem
src/main.rs:189 reports expected &TracingConfig, found &TelemetryConfig during init_tracer call.

Why this matters
This currently blocks clean compilation and safe deployment workflows.

Proposed fix
Align tracer init signature and config type usage so startup compiles with telemetry enabled.

Acceptance criteria
Project compiles for the relevant target/feature set.
Startup/worker path behaves as expected under default env settings.
Add/adjust tests where practical.



Align `init_tracer` to accept `TelemetryConfig` from `AppConfig` and remove the duplicate local `TracingConfig` type. This fixes the compile-time type mismatch when telemetry is enabled.

Changes:
- src/telemetry/tracer.rs: import `TelemetryConfig` from crate::config and update `init_tracer` signature.

No behavioral change beyond using the centralized config type.
