### PR TITLE
Fix oracle adapter boxing for trait objects

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1166,16 +1166,16 @@ async fn main() -> anyhow::Result<()> {
     // ── Oracle Price Feed (Issue #1.02 — Sensory System) ─────────────────────
     let oracle_routes = {
         use oracle::{
-            adapters::{BandProtocolAdapter, BinanceAdapter, CoinbaseAdapter},
+            adapters::{BandProtocolAdapter, BinanceAdapter, CoinbaseAdapter, DynPriceAdapter},
             service::OracleService,
         };
 
         let pair = std::env::var("ORACLE_PAIR").unwrap_or_else(|_| "XLM/USD".to_string());
 
-        let adapters: Vec<Box<dyn oracle::adapters::PriceAdapter>> = vec![
-            Box::new(BinanceAdapter::new()),
-            Box::new(CoinbaseAdapter::new()),
-            Box::new(BandProtocolAdapter::new()),
+        let adapters: Vec<DynPriceAdapter> = vec![
+            Box::new(BinanceAdapter::new()) as DynPriceAdapter,
+            Box::new(CoinbaseAdapter::new()) as DynPriceAdapter,
+            Box::new(BandProtocolAdapter::new()) as DynPriceAdapter,
         ];
 
         let svc = std::sync::Arc::new(OracleService::new(adapters, pair.clone(), db_pool.clone()));

--- a/src/oracle/adapters.rs
+++ b/src/oracle/adapters.rs
@@ -5,6 +5,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use tracing::warn;
 
+pub type DynPriceAdapter = Box<dyn PriceAdapter + Send + Sync>;
+
 #[async_trait]
 pub trait PriceAdapter: Send + Sync {
     fn name(&self) -> &str;

--- a/src/oracle/service.rs
+++ b/src/oracle/service.rs
@@ -6,7 +6,7 @@
 //! Price freeze: if ALL sources fail, OracleState transitions to PriceFrozen.
 
 use super::{
-    adapters::PriceAdapter,
+    adapters::{DynPriceAdapter, PriceAdapter},
     aggregator::Aggregator,
     types::{OraclePrice, OracleState, RawPrice, SourceHealth},
 };
@@ -20,13 +20,30 @@ const HEARTBEAT_SECS: u64 = 30;
 const DEVIATION_THRESHOLD_PCT: f64 = 0.5;
 const MAX_SOURCE_FAILURES: u32 = 3;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oracle::adapters::{BandProtocolAdapter, BinanceAdapter, CoinbaseAdapter};
+
+    #[test]
+    fn oracle_service_accepts_boxed_adapters() {
+        let adapters: Vec<DynPriceAdapter> = vec![
+            Box::new(BinanceAdapter::new()) as DynPriceAdapter,
+            Box::new(CoinbaseAdapter::new()) as DynPriceAdapter,
+            Box::new(BandProtocolAdapter::new()) as DynPriceAdapter,
+        ];
+
+        let _service = OracleService::new(adapters, "XLM/USD", None);
+    }
+}
+
 #[derive(Clone)]
 pub struct OracleService {
     inner: Arc<Inner>,
 }
 
 struct Inner {
-    adapters: Vec<Box<dyn PriceAdapter>>,
+    adapters: Vec<DynPriceAdapter>,
     aggregator: Aggregator,
     pair: String,
     state: RwLock<OracleState>,
@@ -37,7 +54,7 @@ struct Inner {
 
 impl OracleService {
     pub fn new(
-        adapters: Vec<Box<dyn PriceAdapter>>,
+        adapters: Vec<DynPriceAdapter>,
         pair: impl Into<String>,
         pool: Option<PgPool>,
     ) -> Self {


### PR DESCRIPTION
closes #545 
closes #546 
closes #547 
closes #548 


## Summary
- unify oracle adapter storage behind an explicit boxed trait-object alias
- update startup wiring to construct adapters with consistent trait-object types
- add a regression test covering OracleService construction with boxed adapters

## Validation
- Branch created and pushed successfully.
- The compile verification attempt was blocked by the container toolchain version, which rejected an edition-2024 dependency in the available Cargo image.