### PR TITLE
Add Horizon health tracking, Redis pool metrics, cache invalidation, …

### DIFF
--- a/monitoring/prometheus/rules/aframp_alerts.yml
+++ b/monitoring/prometheus/rules/aframp_alerts.yml
@@ -141,6 +141,23 @@ groups:
             This may indicate Redis unavailability or cache invalidation issues.
           runbook: "https://runbooks.aframp.io/cache-miss-rate"
 
+      # Redis bb8 pool exhaustion — connection acquisitions blocked waiting on the pool
+      - alert: RedisPoolExhaustion
+        expr: |
+          aframp_redis_pool_pending > 10
+        for: 2m
+        labels:
+          severity: warning
+          team: engineering
+        annotations:
+          summary: "Redis connection pool exhausted ({{ $value }} pending acquisitions)"
+          description: >
+            {{ $value }} requests are currently blocked waiting for a Redis connection on
+            instance {{ $labels.instance }}. Pool size and idle connections are exposed via
+            aframp_redis_pool_size / aframp_redis_pool_idle. Consider raising
+            REDIS_MAX_CONNECTIONS or investigating slow/stuck Redis operations.
+          runbook: "https://runbooks.aframp.io/redis-pool-exhaustion"
+
   # ===========================================================================
   # Transaction Failure Alerts
   # ===========================================================================

--- a/src/api/onramp/initiate.rs
+++ b/src/api/onramp/initiate.rs
@@ -1,9 +1,9 @@
 use crate::cache::cache::Cache;
 use crate::cache::keys::onramp::QuoteKey;
 use crate::cache::RedisCache;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
-// REMOVED: use crate::chains::stellar::trustline::CngnTrustlineManager;
-// REMOVED: use crate::chains::stellar::types::is_valid_stellar_address;
+use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::trustline::CngnTrustlineManager;
+use crate::chains::stellar::types::is_valid_stellar_address;
 use crate::database::repository::Repository;
 use crate::database::transaction_repository::TransactionRepository;
 use crate::error::{

--- a/src/api/onramp/quote.rs
+++ b/src/api/onramp/quote.rs
@@ -1,9 +1,9 @@
 use super::models::*;
 use crate::cache::cache::Cache;
 use crate::cache::keys::onramp::QuoteKey;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
-// REMOVED: use crate::chains::stellar::trustline::CngnTrustlineManager;
-// REMOVED: use crate::chains::stellar::types::is_valid_stellar_address;
+use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::trustline::CngnTrustlineManager;
+use crate::chains::stellar::types::is_valid_stellar_address;
 use crate::error::{AppError, AppErrorKind, ValidationError};
 use crate::services::exchange_rate::{ConversionDirection, ConversionRequest, ExchangeRateService};
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};

--- a/src/api/onramp/status.rs
+++ b/src/api/onramp/status.rs
@@ -1,6 +1,6 @@
 use crate::cache::cache::Cache;
 use crate::cache::RedisCache;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::database::repository::Repository;
 use crate::database::transaction_repository::TransactionRepository;
 use crate::error::{AppError, AppErrorKind, DomainError, ValidationError};

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -61,20 +61,36 @@ pub trait Cache<T: Serialize + DeserializeOwned + Send + Sync + 'static> {
 #[derive(Debug, Clone)]
 pub struct RedisCache {
     pub pool: RedisPool,
+    /// Number of `get_connection` calls currently waiting on the pool
+    /// (i.e. blocked because all connections are checked out). Sampled by
+    /// `CacheStatsWorker` into the `aframp_redis_pool_pending` gauge.
+    pending: std::sync::Arc<std::sync::atomic::AtomicI64>,
 }
 
 impl RedisCache {
     /// Create a new Redis cache instance
     pub fn new(pool: RedisPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            pending: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0)),
+        }
     }
 
     /// Get a connection from the pool with error handling
     pub async fn get_connection(&self) -> CacheResult<RedisConnection<'_>> {
-        self.pool.get().await.map_err(|e| {
+        self.pending.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let result = self.pool.get().await.map_err(|e| {
             warn!("Failed to get Redis connection: {}", e);
             e.into()
-        })
+        });
+        self.pending.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        result
+    }
+
+    /// Current number of in-flight `get_connection` acquisitions (a proxy
+    /// for requests waiting on the pool).
+    pub fn pending_acquisitions(&self) -> i64 {
+        self.pending.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 

--- a/src/cache/l1.rs
+++ b/src/cache/l1.rs
@@ -131,6 +131,21 @@ impl L1Shard {
     pub fn entry_count(&self) -> u64 {
         self.inner.entry_count()
     }
+
+    /// Keys currently in this shard that start with `prefix`.
+    /// Used for admin-triggered prefix invalidation.
+    pub fn keys_with_prefix(&self, prefix: &str) -> Vec<String> {
+        self.inner
+            .iter()
+            .filter_map(|(k, _v)| {
+                if k.starts_with(prefix) {
+                    Some((*k).clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 /// The full L1 cache, composed of per-category shards.

--- a/src/cache/multi_level.rs
+++ b/src/cache/multi_level.rs
@@ -157,6 +157,78 @@ impl MultiLevelCache {
         info!(l1_key, l2_key, "Both cache levels invalidated");
     }
 
+    /// Invalidate every L1 (across all shards) and L2 key whose key starts
+    /// with `key_prefix`. Returns the total number of keys removed.
+    ///
+    /// Intended for admin-triggered invalidation when fee structures,
+    /// corridor configs, or provider settings are mutated — since the
+    /// mutating handler may not know which cache level(s) or exact key
+    /// currently hold the stale value, this covers all three L1 shards plus
+    /// an L2 `SCAN`-based pattern delete.
+    pub async fn invalidate_prefix(&self, key_prefix: &str) -> u64 {
+        let mut removed: u64 = 0;
+
+        for shard in [
+            &self.l1.fee_structures,
+            &self.l1.currency_configs,
+            &self.l1.provider_lists,
+        ] {
+            for key in shard.keys_with_prefix(key_prefix) {
+                shard.invalidate(&key).await;
+                removed += 1;
+            }
+        }
+
+        let l2_pattern = format!("{}*", key_prefix);
+        match CacheTrait::<serde_json::Value>::delete_pattern(&self.l2, &l2_pattern).await {
+            Ok(n) => removed += n,
+            Err(e) => debug!(pattern = %l2_pattern, error = %e, "L2 prefix invalidation failed (degraded)"),
+        }
+
+        info!(key_prefix, removed, "Prefix cache invalidation complete");
+        removed
+    }
+
+    /// [`invalidate_prefix`] plus an audit row in `cache_invalidation_logs`
+    /// and the `aframp_cache_invalidation_total{reason}` metric — the entry
+    /// point admin mutation handlers should call.
+    ///
+    /// [`invalidate_prefix`]: MultiLevelCache::invalidate_prefix
+    pub async fn invalidate_prefix_logged(
+        &self,
+        pool: &sqlx::PgPool,
+        key_prefix: &str,
+        initiator_id: Option<uuid::Uuid>,
+        initiator_role: &str,
+        reason: &str,
+    ) -> u64 {
+        let removed = self.invalidate_prefix(key_prefix).await;
+
+        let pattern = format!("{}*", key_prefix);
+        if let Err(e) = sqlx::query(
+            r#"INSERT INTO cache_invalidation_logs
+               (initiator_id, initiator_role, target_namespace, pattern_used, keys_deleted, reason)
+               VALUES ($1, $2, $3, $4, $5, $6)"#,
+        )
+        .bind(initiator_id)
+        .bind(initiator_role)
+        .bind(key_prefix)
+        .bind(&pattern)
+        .bind(removed as i64)
+        .bind(reason)
+        .execute(pool)
+        .await
+        {
+            debug!(error = %e, "Failed to write cache_invalidation_logs row (degraded)");
+        }
+
+        crate::metrics::cache::cache_invalidation_total()
+            .with_label_values(&[reason])
+            .inc();
+
+        removed
+    }
+
     // -------------------------------------------------------------------------
     // Single-flight get-or-rebuild (stampede protection)
     // -------------------------------------------------------------------------
@@ -228,5 +300,101 @@ impl MultiLevelCache {
             L1Category::CurrencyConfigs => &self.l1.currency_configs,
             L1Category::ProviderLists => &self.l1.provider_lists,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::l1::L1Cache;
+    use prometheus::Registry;
+
+    async fn test_cache() -> MultiLevelCache {
+        let registry = Registry::new();
+        let l1_metrics = crate::cache::metrics::L1Metrics::new(&registry);
+        let l2_metrics = crate::cache::metrics::L2Metrics::new(&registry);
+        let size_metrics = crate::cache::metrics::CacheSizeMetrics::new(&registry);
+        let l1 = L1Cache::new(l1_metrics.clone());
+
+        // Deliberately unreachable — L2 operations degrade gracefully to no-ops,
+        // which is fine since this test only exercises L1 prefix matching.
+        let manager = bb8_redis::RedisConnectionManager::new("redis://127.0.0.1:1").unwrap();
+        let pool = bb8::Pool::builder()
+            .max_size(1)
+            .connection_timeout(std::time::Duration::from_millis(50))
+            .build_unchecked(manager);
+        let redis = RedisCache::new(pool);
+
+        MultiLevelCache::new(l1, redis, l1_metrics.clone(), l2_metrics, size_metrics)
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_prefix_removes_matching_l1_keys_only() {
+        let cache = test_cache().await;
+
+        cache
+            .l1_insert(L1Category::FeeStructures, "corridor:ng-us:v1".to_string(), &1)
+            .await;
+        cache
+            .l1_insert(L1Category::FeeStructures, "corridor:ng-us:v2".to_string(), &2)
+            .await;
+        cache
+            .l1_insert(L1Category::FeeStructures, "corridor:gh-ng:v1".to_string(), &3)
+            .await;
+        cache
+            .l1_insert(L1Category::CurrencyConfigs, "corridor:ng-us:currency".to_string(), &4)
+            .await;
+        cache
+            .l1_insert(L1Category::FeeStructures, "unrelated:key".to_string(), &5)
+            .await;
+
+        let removed = cache.invalidate_prefix("corridor:ng-us").await;
+        assert_eq!(removed, 3, "should remove the 3 keys matching the prefix across shards");
+
+        assert_eq!(
+            cache
+                .l1_get::<i32>(L1Category::FeeStructures, "corridor:ng-us:v1")
+                .await,
+            None
+        );
+        assert_eq!(
+            cache
+                .l1_get::<i32>(L1Category::FeeStructures, "corridor:ng-us:v2")
+                .await,
+            None
+        );
+        assert_eq!(
+            cache
+                .l1_get::<i32>(L1Category::CurrencyConfigs, "corridor:ng-us:currency")
+                .await,
+            None
+        );
+
+        // Non-matching keys survive.
+        assert_eq!(
+            cache
+                .l1_get::<i32>(L1Category::FeeStructures, "corridor:gh-ng:v1")
+                .await,
+            Some(3)
+        );
+        assert_eq!(
+            cache.l1_get::<i32>(L1Category::FeeStructures, "unrelated:key").await,
+            Some(5)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_prefix_no_match_removes_nothing() {
+        let cache = test_cache().await;
+        cache
+            .l1_insert(L1Category::ProviderLists, "provider:a".to_string(), &1)
+            .await;
+
+        let removed = cache.invalidate_prefix("nonexistent:").await;
+        assert_eq!(removed, 0);
+        assert_eq!(
+            cache.l1_get::<i32>(L1Category::ProviderLists, "provider:a").await,
+            Some(1)
+        );
     }
 }

--- a/src/cache/single_flight.rs
+++ b/src/cache/single_flight.rs
@@ -4,13 +4,25 @@
 //! only one rebuild is triggered. All other waiters receive the same result
 //! once the rebuild completes, preventing a thundering-herd against the DB.
 
+use futures::FutureExt;
+use std::any::Any;
 use std::collections::HashMap;
 use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{broadcast, Mutex};
-use tracing::{debug, info};
+use tokio::time::timeout;
+use tracing::{debug, error, info, warn};
 
 type SharedResult<T> = Arc<Result<T, String>>;
+
+/// How long a waiter blocks on an in-flight rebuild before giving up on the
+/// leader and self-healing by clearing the stale entry. Guards against a
+/// leader that hangs (deadlock, unbounded await) without panicking — a
+/// panicking leader is handled immediately via `catch_unwind`, without
+/// needing to wait out this timeout.
+const DEFAULT_IN_FLIGHT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A map of in-flight rebuild operations keyed by cache key.
 pub struct SingleFlight<T: Clone + Send + 'static> {
@@ -26,7 +38,11 @@ impl<T: Clone + Send + 'static> SingleFlight<T> {
 
     /// Execute `rebuild` for `key`, or wait for an in-flight rebuild to finish.
     ///
-    /// Returns `Ok(value)` on success, `Err(msg)` if the rebuild failed.
+    /// Returns `Ok(value)` on success, `Err(msg)` if the rebuild failed or
+    /// panicked. A panic inside `rebuild` is caught so it can never leave the
+    /// key permanently stuck in the in-flight map; a leader that hangs
+    /// without panicking is bounded by [`DEFAULT_IN_FLIGHT_TIMEOUT`] on the
+    /// waiter side.
     pub async fn get_or_rebuild<F, Fut>(&self, key: &str, rebuild: F) -> Result<T, String>
     where
         F: FnOnce() -> Fut,
@@ -41,12 +57,24 @@ impl<T: Clone + Send + 'static> SingleFlight<T> {
                 drop(map); // release lock before awaiting
 
                 debug!(key, "single-flight: waiting for in-flight rebuild");
-                match rx.recv().await {
-                    Ok(result) => {
+                match timeout(DEFAULT_IN_FLIGHT_TIMEOUT, rx.recv()).await {
+                    Ok(Ok(result)) => {
                         return (*result).clone().map_err(|e| e.clone());
                     }
-                    Err(_) => {
+                    Ok(Err(_)) => {
                         // Sender dropped without sending — treat as miss and rebuild.
+                    }
+                    Err(_) => {
+                        // The leader has been rebuilding longer than the
+                        // self-heal timeout. Clear the stale entry so this
+                        // (and any subsequent) caller can take over as leader
+                        // instead of waiting on it forever.
+                        warn!(
+                            key,
+                            timeout_secs = DEFAULT_IN_FLIGHT_TIMEOUT.as_secs(),
+                            "single-flight: in-flight rebuild timed out; self-healing"
+                        );
+                        self.in_flight.lock().await.remove(key);
                     }
                 }
             }
@@ -59,16 +87,155 @@ impl<T: Clone + Send + 'static> SingleFlight<T> {
         drop(map); // release lock before doing the expensive rebuild
 
         info!(key, "single-flight: leader rebuilding cache entry");
-        let result = rebuild().await;
-        let shared: SharedResult<T> = Arc::new(result.clone().map_err(|e| e.to_string()));
+        let result: Result<T, String> = match AssertUnwindSafe(rebuild()).catch_unwind().await {
+            Ok(result) => result,
+            Err(panic) => {
+                let msg = panic_message(panic.as_ref());
+                error!(key, error = %msg, "single-flight: rebuilder panicked");
+                Err(format!("rebuild panicked: {}", msg))
+            }
+        };
+
+        let shared: SharedResult<T> = Arc::new(result.clone());
 
         // Broadcast result to all waiters (ignore send errors — no subscribers is fine).
         let _ = tx.send(shared);
 
-        // Remove from in-flight map.
+        // Remove from in-flight map — always, whether the rebuild succeeded,
+        // returned Err, or panicked, so the key is never stuck.
         let mut map = self.in_flight.lock().await;
         map.remove(key);
 
         result
+    }
+}
+
+/// Best-effort extraction of a human-readable message from a caught panic
+/// payload (`std::panic::catch_unwind`'s `Box<dyn Any + Send>`).
+fn panic_message(panic: &(dyn Any + Send)) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_successful_rebuild_returns_value() {
+        let sf: Arc<SingleFlight<i32>> = SingleFlight::new();
+        let result = sf.get_or_rebuild("k", || async { Ok(42) }).await;
+        assert_eq!(result, Ok(42));
+    }
+
+    #[tokio::test]
+    async fn test_failed_rebuild_returns_err_and_clears_entry() {
+        let sf: Arc<SingleFlight<i32>> = SingleFlight::new();
+        let result = sf
+            .get_or_rebuild("k", || async { Err::<i32, _>("boom".to_string()) })
+            .await;
+        assert_eq!(result, Err("boom".to_string()));
+
+        // Entry must not be stuck — a subsequent call for the same key succeeds.
+        let result = sf.get_or_rebuild("k", || async { Ok(7) }).await;
+        assert_eq!(result, Ok(7));
+    }
+
+    #[tokio::test]
+    async fn test_panic_in_rebuilder_does_not_permanently_block_key() {
+        let sf: Arc<SingleFlight<i32>> = SingleFlight::new();
+
+        // Leader panics mid-rebuild.
+        let result = sf
+            .get_or_rebuild("panicky-key", || async {
+                panic!("rebuilder blew up");
+                #[allow(unreachable_code)]
+                Ok(0)
+            })
+            .await;
+        assert!(result.is_err(), "a panicking rebuild must surface as Err, not hang");
+        assert!(result.unwrap_err().contains("panicked"));
+
+        // The in-flight map entry must have been cleared by the leader itself
+        // (via catch_unwind), so the very next call succeeds immediately —
+        // it must NOT need to wait out DEFAULT_IN_FLIGHT_TIMEOUT.
+        let start = std::time::Instant::now();
+        let result = sf.get_or_rebuild("panicky-key", || async { Ok(99) }).await;
+        assert_eq!(result, Ok(99));
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "post-panic retry should be immediate, not blocked on the in-flight entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_waiters_all_receive_panic_result() {
+        let sf: Arc<SingleFlight<i32>> = SingleFlight::new();
+
+        let leader = {
+            let sf = sf.clone();
+            tokio::spawn(async move {
+                sf.get_or_rebuild("shared-key", || async {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    panic!("leader panicked");
+                    #[allow(unreachable_code)]
+                    Ok::<i32, String>(0)
+                })
+                .await
+            })
+        };
+
+        // Give the leader time to register itself as in-flight before waiters subscribe.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let waiter = {
+            let sf = sf.clone();
+            tokio::spawn(async move {
+                sf.get_or_rebuild("shared-key", || async { Ok(123) }).await
+            })
+        };
+
+        let (leader_result, waiter_result) = tokio::join!(leader, waiter);
+        assert!(leader_result.unwrap().is_err());
+        assert!(
+            waiter_result.unwrap().is_err(),
+            "a waiter subscribed to a panicking leader must see the same Err, not hang"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_self_heals_stuck_leader() {
+        let sf: Arc<SingleFlight<i32>> = SingleFlight::new();
+
+        // Leader hangs forever without panicking or completing.
+        let _leader = {
+            let sf = sf.clone();
+            tokio::spawn(async move {
+                sf.get_or_rebuild("stuck-key", || async {
+                    std::future::pending::<()>().await;
+                    Ok::<i32, String>(0)
+                })
+                .await
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // A waiter should time out after DEFAULT_IN_FLIGHT_TIMEOUT and, on
+        // timing out, clear the stale entry so it can take over as leader.
+        let sf2 = sf.clone();
+        let waiter = tokio::spawn(async move {
+            sf2.get_or_rebuild("stuck-key", || async { Ok(55) }).await
+        });
+
+        tokio::time::advance(DEFAULT_IN_FLIGHT_TIMEOUT + Duration::from_secs(1)).await;
+
+        let result = waiter.await.unwrap();
+        assert_eq!(result, Ok(55), "waiter should self-heal and become leader after the timeout");
     }
 }

--- a/src/cache/stats_worker.rs
+++ b/src/cache/stats_worker.rs
@@ -12,6 +12,7 @@ use tracing::{info, warn};
 
 const POLL_INTERVAL_SECS: u64 = 60;
 const MEMORY_ALERT_PCT: f64 = 90.0;
+const PENDING_ALERT_THRESHOLD: i64 = 10;
 
 pub struct CacheStatsWorker {
     cache: Arc<MultiLevelCache>,
@@ -39,6 +40,34 @@ impl CacheStatsWorker {
 
         // Fetch and check Redis memory
         self.check_redis_memory().await;
+
+        // Update bb8 pool gauges and check for exhaustion
+        self.check_pool_stats();
+    }
+
+    fn check_pool_stats(&self) {
+        let state = self.redis.pool.state();
+        let pending = self.redis.pending_acquisitions();
+
+        crate::metrics::cache::redis_pool_size()
+            .with_label_values(&["primary"])
+            .set(state.connections as f64);
+        crate::metrics::cache::redis_pool_idle()
+            .with_label_values(&["primary"])
+            .set(state.idle_connections as f64);
+        crate::metrics::cache::redis_pool_pending()
+            .with_label_values(&["primary"])
+            .set(pending as f64);
+
+        if pending > PENDING_ALERT_THRESHOLD {
+            warn!(
+                pending,
+                threshold = PENDING_ALERT_THRESHOLD,
+                pool_size = state.connections,
+                idle = state.idle_connections,
+                "ALERT: Redis pool has {} connections pending — pool may be exhausted", pending
+            );
+        }
     }
 
     async fn check_redis_memory(&self) {

--- a/src/chains/mod.rs
+++ b/src/chains/mod.rs
@@ -1,0 +1,17 @@
+//! Compatibility shim for the historical `chains::stellar` client API.
+//!
+//! `chains::stellar::client::StellarClient` was the shared Stellar client
+//! type used throughout the codebase before a partial migration toward the
+//! leaner `stellar::horizon::HorizonClient`. The migration commented out
+//! imports of the old type across ~30 files but never replaced the type
+//! itself, leaving the crate unable to compile at all. This module restores
+//! a minimal `StellarClient` wrapping `stellar::horizon::HorizonClient`
+//! (plus a couple of direct Horizon HTTP calls for endpoints
+//! `HorizonClient` doesn't expose) so those files resolve again.
+//!
+//! This was reconstructed by reading call sites, without a compiler to
+//! verify against — it restores the type-level contract (method names,
+//! argument/return shapes) with real Horizon-backed behavior where the
+//! mapping was unambiguous. Treat it as a reviewed-on-paper, not
+//! compiler-verified, follow-up.
+pub mod stellar;

--- a/src/chains/stellar/client.rs
+++ b/src/chains/stellar/client.rs
@@ -1,0 +1,229 @@
+//! Compatibility shim for the historical `chains::stellar::client::StellarClient`.
+//!
+//! Wraps [`crate::stellar::horizon::HorizonClient`] and, for endpoints that
+//! client doesn't expose, talks to Horizon directly. See [`super`] for
+//! background on why this exists.
+
+use super::config::StellarConfig;
+use super::errors::StellarError;
+use crate::stellar::horizon::HorizonClient;
+use crate::stellar::models::HorizonTransaction;
+use serde::Deserialize;
+use std::time::Instant;
+
+#[derive(Debug, Clone)]
+pub struct StellarHealthStatus {
+    pub is_healthy: bool,
+    pub response_time_ms: u64,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StellarBalance {
+    pub balance: String,
+    pub asset_type: String,
+    #[serde(default)]
+    pub asset_code: Option<String>,
+    #[serde(default)]
+    pub asset_issuer: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StellarAccount {
+    pub account_id: String,
+    #[serde(deserialize_with = "deserialize_sequence")]
+    pub sequence: i64,
+    #[serde(default)]
+    pub balances: Vec<StellarBalance>,
+}
+
+fn deserialize_sequence<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    s.parse::<i64>().map_err(serde::de::Error::custom)
+}
+
+/// Alias used by some older call sites for the transaction record type.
+pub type HorizonTransactionRecord = HorizonTransaction;
+
+#[derive(Clone)]
+pub struct StellarClient {
+    horizon: HorizonClient,
+    config: StellarConfig,
+    http: reqwest::Client,
+}
+
+impl StellarClient {
+    pub fn new(config: StellarConfig) -> anyhow::Result<Self> {
+        let horizon = HorizonClient::new(config.horizon_url.clone())
+            .with_timeout(config.request_timeout);
+        Ok(Self {
+            horizon,
+            config,
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub fn network(&self) -> &str {
+        &self.config.network
+    }
+
+    pub fn config(&self) -> &StellarConfig {
+        &self.config
+    }
+
+    /// Lightweight reachability check against Horizon's root endpoint.
+    pub async fn health_check(&self) -> anyhow::Result<StellarHealthStatus> {
+        let start = Instant::now();
+        let url = format!("{}/", self.config.horizon_url.trim_end_matches('/'));
+        match self
+            .http
+            .get(&url)
+            .timeout(self.config.request_timeout)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => Ok(StellarHealthStatus {
+                is_healthy: true,
+                response_time_ms: start.elapsed().as_millis() as u64,
+                error_message: None,
+            }),
+            Ok(resp) => Ok(StellarHealthStatus {
+                is_healthy: false,
+                response_time_ms: start.elapsed().as_millis() as u64,
+                error_message: Some(format!("Horizon returned {}", resp.status())),
+            }),
+            Err(e) => Ok(StellarHealthStatus {
+                is_healthy: false,
+                response_time_ms: start.elapsed().as_millis() as u64,
+                error_message: Some(e.to_string()),
+            }),
+        }
+    }
+
+    pub async fn account_exists(&self, address: &str) -> anyhow::Result<bool> {
+        match self.horizon.get_account_sequence(address).await {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+
+    pub async fn get_account(&self, address: &str) -> Result<StellarAccount, StellarError> {
+        let url = format!(
+            "{}/accounts/{}",
+            self.config.horizon_url.trim_end_matches('/'),
+            address
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .timeout(self.config.request_timeout)
+            .send()
+            .await
+            .map_err(|e| StellarError::network_error(e.to_string()))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(StellarError::AccountNotFound {
+                address: address.to_string(),
+            });
+        }
+        if !resp.status().is_success() {
+            return Err(StellarError::network_error(format!(
+                "Horizon returned {}",
+                resp.status()
+            )));
+        }
+
+        resp.json::<StellarAccount>()
+            .await
+            .map_err(|e| StellarError::Other(format!("failed to parse account response: {}", e)))
+    }
+
+    pub async fn get_transaction_by_hash(
+        &self,
+        hash: &str,
+    ) -> Result<HorizonTransaction, StellarError> {
+        match self.horizon.get_transaction(hash).await {
+            Ok(Some(tx)) => Ok(tx),
+            Ok(None) => Err(StellarError::TransactionFailed {
+                reason: "transaction not found".to_string(),
+            }),
+            Err(e) => Err(StellarError::TransactionFailed {
+                reason: e.to_string(),
+            }),
+        }
+    }
+
+    /// Alias — some callers use the `_details` name for the same lookup.
+    pub async fn get_transaction_details(
+        &self,
+        hash: &str,
+    ) -> Result<HorizonTransaction, StellarError> {
+        self.get_transaction_by_hash(hash).await
+    }
+
+    /// Raw operation records for a transaction (Horizon's `/transactions/{hash}/operations`).
+    /// Returned as untyped JSON since callers pick out individual fields
+    /// (`type`, `to`, `asset_code`, `asset_issuer`, ...) rather than a fixed struct.
+    pub async fn get_transaction_operations(
+        &self,
+        hash: &str,
+    ) -> anyhow::Result<Vec<serde_json::Value>> {
+        #[derive(Deserialize)]
+        struct OperationsResponse {
+            #[serde(rename = "_embedded")]
+            embedded: OperationsEmbedded,
+        }
+        #[derive(Deserialize)]
+        struct OperationsEmbedded {
+            records: Vec<serde_json::Value>,
+        }
+
+        let url = format!(
+            "{}/transactions/{}/operations",
+            self.config.horizon_url.trim_end_matches('/'),
+            hash
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .timeout(self.config.request_timeout)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("Horizon returned {} for transaction operations", resp.status());
+        }
+
+        let parsed: OperationsResponse = resp.json().await?;
+        Ok(parsed.embedded.records)
+    }
+
+    /// Balance of `asset_code` (optionally scoped to `asset_issuer`) on `address`,
+    /// as Horizon's raw decimal string, or `None` if the trustline doesn't exist.
+    pub async fn get_asset_balance(
+        &self,
+        address: &str,
+        asset_code: &str,
+        asset_issuer: Option<&str>,
+    ) -> anyhow::Result<Option<String>> {
+        let account = self
+            .get_account(address)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        let balance = account.balances.into_iter().find(|b| {
+            let code_matches = b.asset_code.as_deref() == Some(asset_code)
+                || (asset_code.eq_ignore_ascii_case("xlm") && b.asset_type == "native");
+            let issuer_matches = match asset_issuer {
+                Some(issuer) => b.asset_issuer.as_deref() == Some(issuer),
+                None => true,
+            };
+            code_matches && issuer_matches
+        });
+
+        Ok(balance.map(|b| b.balance))
+    }
+}

--- a/src/chains/stellar/config.rs
+++ b/src/chains/stellar/config.rs
@@ -1,0 +1,52 @@
+//! Configuration for the [`super::client::StellarClient`] compatibility shim.
+
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct StellarConfig {
+    pub network: String,
+    pub horizon_url: String,
+    pub request_timeout: Duration,
+    pub max_retries: u32,
+}
+
+impl StellarConfig {
+    pub fn from_env() -> anyhow::Result<Self> {
+        let network = std::env::var("STELLAR_NETWORK").unwrap_or_else(|_| "testnet".to_string());
+        let horizon_url = std::env::var("STELLAR_HORIZON_URL").unwrap_or_else(|_| {
+            if network == "mainnet" || network == "public" {
+                "https://horizon.stellar.org".to_string()
+            } else {
+                "https://horizon-testnet.stellar.org".to_string()
+            }
+        });
+        let request_timeout = Duration::from_secs(
+            std::env::var("STELLAR_REQUEST_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(15),
+        );
+        let max_retries = std::env::var("STELLAR_MAX_RETRIES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3);
+
+        Ok(Self {
+            network,
+            horizon_url,
+            request_timeout,
+            max_retries,
+        })
+    }
+}
+
+impl Default for StellarConfig {
+    fn default() -> Self {
+        Self {
+            network: "testnet".to_string(),
+            horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+            request_timeout: Duration::from_secs(15),
+            max_retries: 3,
+        }
+    }
+}

--- a/src/chains/stellar/errors.rs
+++ b/src/chains/stellar/errors.rs
@@ -1,0 +1,60 @@
+//! Error type for the [`super::client::StellarClient`] compatibility shim.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StellarError {
+    #[error("transaction not found or failed: {reason}")]
+    TransactionFailed { reason: String },
+
+    #[error("account not found: {address}")]
+    AccountNotFound { address: String },
+
+    #[error("invalid Stellar address: {address}")]
+    InvalidAddress { address: String },
+
+    #[error("Horizon network error: {message}")]
+    NetworkError { message: String },
+
+    #[error("Horizon request timed out: {message}")]
+    TimeoutError { message: String },
+
+    #[error("Horizon rate limit exceeded")]
+    RateLimitError,
+
+    #[error("transaction signing error: {0}")]
+    SigningError(String),
+
+    #[error("Stellar client error: {0}")]
+    Other(String),
+}
+
+impl StellarError {
+    pub fn transaction_failed(reason: impl Into<String>) -> Self {
+        StellarError::TransactionFailed {
+            reason: reason.into(),
+        }
+    }
+
+    pub fn signing_error(message: impl Into<String>) -> Self {
+        StellarError::SigningError(message.into())
+    }
+
+    pub fn network_error(message: impl Into<String>) -> Self {
+        StellarError::NetworkError {
+            message: message.into(),
+        }
+    }
+
+    pub fn invalid_address(address: impl Into<String>) -> Self {
+        StellarError::InvalidAddress {
+            address: address.into(),
+        }
+    }
+}
+
+impl From<crate::stellar::error::SubmissionError> for StellarError {
+    fn from(err: crate::stellar::error::SubmissionError) -> Self {
+        StellarError::Other(err.to_string())
+    }
+}

--- a/src/chains/stellar/mod.rs
+++ b/src/chains/stellar/mod.rs
@@ -1,0 +1,8 @@
+pub mod client;
+pub mod config;
+pub mod errors;
+pub mod types;
+
+pub use client::StellarClient;
+pub use config::StellarConfig;
+pub use errors::StellarError;

--- a/src/chains/stellar/types.rs
+++ b/src/chains/stellar/types.rs
@@ -1,0 +1,29 @@
+//! Type aliases for the historical `chains::stellar::types` names, mapped
+//! onto the compatibility shim's structs in [`super::client`].
+
+pub type AssetBalance = super::client::StellarBalance;
+pub type StellarAccountInfo = super::client::StellarAccount;
+
+/// Basic Stellar public-key address format check: `G` prefix, 56 chars,
+/// base32 alphabet (A-Z, 2-7). Does not verify the ed25519 checksum.
+pub fn is_valid_stellar_address(address: &str) -> bool {
+    address.len() == 56
+        && address.starts_with('G')
+        && address
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || ('2'..='7').contains(&c))
+}
+
+/// Find `asset_code` "cNGN" (case-insensitive) in `balances`, optionally
+/// scoped to `issuer`, and parse its balance as `f64`. Returns `0.0` if no
+/// matching trustline is found.
+pub fn extract_cngn_balance(balances: &[AssetBalance], issuer: Option<&str>) -> f64 {
+    balances
+        .iter()
+        .find(|b| {
+            b.asset_code.as_deref().map(|c| c.eq_ignore_ascii_case("cNGN")) == Some(true)
+                && issuer.map_or(true, |i| b.asset_issuer.as_deref() == Some(i))
+        })
+        .and_then(|b| b.balance.parse::<f64>().ok())
+        .unwrap_or(0.0)
+}

--- a/src/corridors/router/handlers.rs
+++ b/src/corridors/router/handlers.rs
@@ -1,5 +1,6 @@
 //! HTTP handlers for the Corridor Router API.
 
+use crate::cache::multi_level::MultiLevelCache;
 use crate::corridors::router::models::*;
 use crate::corridors::router::service::{CorridorRouterService, RouterError};
 use axum::{
@@ -13,6 +14,21 @@ use uuid::Uuid;
 
 pub struct CorridorRouterState {
     pub service: Arc<CorridorRouterService>,
+    /// Optional — when present, corridor create/update/toggle mutations
+    /// invalidate the `corridor:` cache prefix and log to
+    /// `cache_invalidation_logs` (Issue: admin cache invalidation).
+    pub cache: Option<Arc<MultiLevelCache>>,
+    pub pool: Option<Arc<sqlx::PgPool>>,
+}
+
+/// Best-effort cache invalidation after a corridor mutation — logged but
+/// never fails the request if the cache/pool aren't configured.
+async fn invalidate_corridor_cache(state: &CorridorRouterState, reason: &str) {
+    if let (Some(cache), Some(pool)) = (&state.cache, &state.pool) {
+        cache
+            .invalidate_prefix_logged(pool, "corridor:", None, "system", reason)
+            .await;
+    }
 }
 
 // ── Generic wrappers ──────────────────────────────────────────────────────────
@@ -135,12 +151,17 @@ pub async fn create_corridor_handler(
     State(state): State<Arc<CorridorRouterState>>,
     Json(req): Json<CreateCorridorConfigRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<CorridorConfig>>), (StatusCode, Json<ApiError>)> {
-    state
+    let result = state
         .service
         .create_corridor(&req, None, None)
         .await
         .map(|c| (StatusCode::CREATED, ok_msg(c, "Corridor created")))
-        .map_err(map_error)
+        .map_err(map_error);
+
+    if result.is_ok() {
+        invalidate_corridor_cache(&state, "corridor_created").await;
+    }
+    result
 }
 
 /// PATCH /api/admin/corridors/:id
@@ -150,12 +171,17 @@ pub async fn update_corridor_handler(
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateCorridorConfigRequest>,
 ) -> Result<Json<ApiResponse<CorridorConfig>>, (StatusCode, Json<ApiError>)> {
-    state
+    let result = state
         .service
         .update_corridor(id, &req, None, None)
         .await
         .map(ok)
-        .map_err(map_error)
+        .map_err(map_error);
+
+    if result.is_ok() {
+        invalidate_corridor_cache(&state, "corridor_updated").await;
+    }
+    result
 }
 
 /// POST /api/admin/corridors/:id/toggle
@@ -171,7 +197,7 @@ pub async fn toggle_corridor_handler(
         "Corridor suspended (kill-switch activated)"
     };
 
-    state
+    let result = state
         .service
         .toggle_corridor(id, &req, None)
         .await
@@ -182,5 +208,10 @@ pub async fn toggle_corridor_handler(
                 message: Some(msg.to_string()),
             })
         })
-        .map_err(map_error)
+        .map_err(map_error);
+
+    if result.is_ok() {
+        invalidate_corridor_cache(&state, "corridor_toggled").await;
+    }
+    result
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[cfg(feature = "database")]
-// REMOVED: use crate::chains::stellar::errors::StellarError;
+use crate::chains::stellar::errors::StellarError;
 
 /// CNGN-specific error codes for programmatic handling
 #[cfg(feature = "database")]

--- a/src/health.rs
+++ b/src/health.rs
@@ -9,7 +9,7 @@ use tracing::{error, info};
 
 use crate::cache::warmer::WarmingState;
 use crate::cache::RedisCache;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 
 /// Health status response
 #[derive(Debug, Serialize, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,14 @@
 // Module declarations
 mod api;
 mod api_keys;
+mod aml;
 mod analytics;
-mod app_state;
 mod audit;
 mod auth;
+mod banking;
 mod cache;
+mod chains;
+mod compliance_effectiveness;
 mod config;
 mod config_validation;
 mod corridors;
@@ -19,6 +22,7 @@ mod ddos;
 // REMOVED: mod developer_portal;
 // REMOVED: mod distributed_api;
 mod error;
+mod event_bus;
 mod health;
 mod liquidity;
 mod logging;
@@ -29,10 +33,6 @@ mod multisig;
 // REMOVED: mod peg_monitor;
 // REMOVED: mod pep;
 mod developer_portal;
-mod error;
-mod health;
-mod logging;
-mod metrics;
 mod middleware;
 mod oauth;
 mod oracle;
@@ -41,9 +41,12 @@ mod payments;
 mod pentest;
 // REMOVED: mod pos;
 mod recurring;
+mod reporting;
 mod routes;
+mod sanctions;
+mod security;
 mod services;
-mod startup;
+mod stellar;
 mod telemetry;
 mod verification;
 mod wallet;
@@ -51,57 +54,430 @@ mod wallet_provisioning;
 mod workers;
 
 // External imports
+use std::sync::Arc;
+use crate::config::AppConfig;
+use crate::health::{HealthChecker, HealthStatus};
+use crate::telemetry::tracer::{init_tracer, shutdown_tracer};
+use crate::payments::factory::PaymentProviderFactory;
+use crate::payments::types::{
+    CustomerContact, Money, PaymentMethod, PaymentRequest as ProviderPaymentRequest, ProviderName,
+};
+use axum::{
+    routing::{delete, get, patch, post},
+    Json, Router,
+};
+use cache::{init_cache_pool, build_multi_level_cache, CacheConfig, RedisCache};
+use cache::warmer::{warm_caches, WarmingState};
+use chains::stellar::client::StellarClient;
+use chains::stellar::config::StellarConfig;
+use database::{init_pool, PoolConfig};
 use dotenv::dotenv;
-use tracing::{error, info};
+use middleware::logging::{request_logging_middleware, UuidRequestId};
+use middleware::metrics::metrics_middleware;
+use middleware::cors::{cors_middleware, CorsConfig};
+use middleware::security::security_headers_middleware;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::time::Duration;
+use tokio::signal;
+use tokio::sync::watch;
+use tower::ServiceBuilder;
+use tower_http::request_id::{PropagateRequestIdLayer, SetRequestIdLayer};
+use tracing::{error, info, warn};
+use uuid::Uuid;
 
-/// Main entry point
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    // Load environment variables
-    dotenv().ok();
-    
-    // Load application configuration
-    let app_config = load_app_config()?;
-    
-    // Validate production configuration
-    validate_production_config()?;
-    
-    // Start the application
-    match startup::start_app(app_config).await {
-        Ok(_) => {
-            info!("👋 Application shutdown completed successfully");
-            Ok(())
+/// Graceful shutdown signal handler
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = signal::ctrl_c().await {
+            error!("failed to install Ctrl+C handler: {}", e);
         }
-        Err(e) => {
-            error!("❌ Application failed to start: {}", e);
-            Err(e)
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match signal::unix::signal(signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => {
+                error!("failed to install signal handler: {}", e);
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    info!("Shutdown signal received, starting graceful shutdown");
+}
+
+async fn shutdown_signal_with_notify(shutdown_tx: watch::Sender<bool>) {
+    shutdown_signal().await;
+    let _ = shutdown_tx.send(true);
+}
+
+/// Validate production configuration — fatal outside development, warning-only in development.
+fn validate_production_config() -> anyhow::Result<()> {
+    info!("🔍 Validating production configuration...");
+
+    if let Err(e) = config_validation::validate_production_config() {
+        let app_env = std::env::var("APP_ENV").unwrap_or_else(|_| "development".into());
+        if app_env != "development" {
+            error!("❌ {}", e);
+            std::process::exit(1);
+        } else {
+            info!("⚠️  Config warnings (non-fatal in development):\n{}", e);
         }
     }
+
+    Ok(())
 }
 
 /// Load application configuration from environment
 fn load_app_config() -> anyhow::Result<config::AppConfig> {
     info!("📝 Loading application configuration...");
-    
+
     let app_config = config::AppConfig::from_env().map_err(|e| {
         error!("❌ Failed to load application configuration: {}", e);
         anyhow::anyhow!("Configuration error: {}", e)
     })?;
-    
+
     app_config.validate().map_err(|e| {
         error!("❌ Configuration validation failed: {}", e);
         anyhow::anyhow!("Configuration validation error: {}", e)
     })?;
-    
+
     info!(
         version = env!("CARGO_PKG_VERSION"),
         environment = %app_config.telemetry.environment,
         service = %app_config.telemetry.service_name,
         "✅ Configuration loaded successfully"
     );
-    
+
     Ok(app_config)
 }
+
+/// Main entry point
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialise advanced tracing
+    logging::init_tracing();
+
+    // Initialise Prometheus metrics registry
+    let _ = metrics::registry();
+
+    // Load environment variables
+    dotenv().ok();
+
+    // Load application configuration
+    let app_config = load_app_config()?;
+
+    // Validate production configuration
+    validate_production_config()?;
+
+    // -------------------------------------------------------------------------
+    // Initialise OpenTelemetry tracer provider.   (Issue #104)
+    // -------------------------------------------------------------------------
+    init_tracer(&app_config.telemetry).map_err(|e| {
+        error!("❌ Failed to initialise OpenTelemetry tracer: {}", e);
+        anyhow::anyhow!("Tracer initialisation error: {}", e)
+    })?;
+
+    let skip_externals = std::env::var("SKIP_EXTERNALS")
+        .unwrap_or_else(|_| "false".to_string())
+        .to_lowercase()
+        == "true";
+
+    info!(
+        version = env!("CARGO_PKG_VERSION"),
+        environment = %app_config.telemetry.environment,
+        service = %app_config.telemetry.service_name,
+        sampling_rate = app_config.telemetry.sampling_rate,
+        "🚀 Starting Aframp backend service"
+    );
+
+    let server_host = std::env::var("SERVER_HOST")
+        .or_else(|_| std::env::var("HOST"))
+        .unwrap_or_else(|_| "127.0.0.1".to_string());
+    let server_port = std::env::var("SERVER_PORT")
+        .or_else(|_| std::env::var("PORT"))
+        .unwrap_or_else(|_| "8000".to_string());
+
+    info!(
+        host = %server_host,
+        port = %server_port,
+        "Server configuration loaded"
+    );
+
+    // Initialize database connection pool
+    let db_pool = if skip_externals {
+        info!("⏭️  Skipping database initialization (SKIP_EXTERNALS=true)");
+        None
+    } else {
+        info!("📊 Initializing database connection pool...");
+        let database_url =
+            std::env::var("DATABASE_URL").map_err(|_| anyhow::anyhow!("DATABASE_URL not set"))?;
+        let db_pool_config = PoolConfig {
+            max_connections: std::env::var("DB_MAX_CONNECTIONS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(20),
+            min_connections: std::env::var("DB_MIN_CONNECTIONS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5),
+            connection_timeout: Duration::from_secs(
+                std::env::var("DB_CONNECTION_TIMEOUT")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30),
+            ),
+            idle_timeout: Duration::from_secs(
+                std::env::var("DB_IDLE_TIMEOUT")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(600),
+            ),
+            max_lifetime: Duration::from_secs(
+                std::env::var("DB_MAX_LIFETIME")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(1800),
+            ),
+        };
+
+        let db_pool = init_pool(&database_url, Some(db_pool_config.clone()))
+            .await
+            .map_err(|e| {
+                error!("Failed to initialize database pool: {}", e);
+                e
+            })?;
+
+        if let Some(replica_url) = app_config.database.read_replica_url.clone() {
+            match init_pool(&replica_url, Some(db_pool_config.clone())).await {
+                Ok(replica_pool) => {
+                    database::set_global_read_replica_pool(replica_pool.clone());
+                    info!(replica_url=%replica_url, "✅ Read replica pool configured");
+                }
+                Err(e) => {
+                    warn!(read_replica_url=%replica_url, error=%e, "Failed to initialize read replica pool, continuing with primary only")
+                }
+            }
+        }
+
+        if !app_config.database.shard_configs.is_empty() {
+            let shards = app_config
+                .database
+                .shard_configs
+                .iter()
+                .map(|cfg| database::ha_pool::ShardConfig {
+                    shard_id: cfg.shard_id,
+                    primary_url: cfg.primary_url.clone(),
+                    replica_urls: cfg.replica_urls.clone(),
+                    max_connections: cfg
+                        .max_connections
+                        .unwrap_or(db_pool_config.max_connections),
+                    min_connections: cfg
+                        .min_connections
+                        .unwrap_or(db_pool_config.min_connections),
+                    connection_timeout: Duration::from_secs(
+                        cfg.connection_timeout_secs
+                            .unwrap_or(db_pool_config.connection_timeout.as_secs()),
+                    ),
+                })
+                .collect();
+            let ha_config = database::ha_pool::HaPoolConfig {
+                shards,
+                checksum_interval: Duration::from_secs(app_config.database.shard_checksum_interval_secs),
+            };
+            match database::ha_pool::HaPoolManager::new(&ha_config).await {
+                Ok(manager) => {
+                    database::set_global_ha_pool(manager.clone());
+                    info!(shard_count = manager.shard_count.load(std::sync::atomic::Ordering::Relaxed), "✅ HA shard manager configured");
+                }
+                Err(e) => {
+                    warn!(error=%e, "Failed to initialize HA shard manager, continuing without sharding");
+                }
+            }
+        }
+
+        info!(
+            max_connections = db_pool.options().get_max_connections(),
+            "✅ Database connection pool initialized"
+        );
+        Some(db_pool)
+    };
+
+    // ── Initialize Security Anomaly Detection & Circuit Breaker (Issue #297) ──
+    let (anomaly_service, circuit_breaker) = if let Some(ref pool) = db_pool {
+        let sec_config = crate::security::AnomalyDetectionConfig::from_env();
+        let service = std::sync::Arc::new(crate::security::AnomalyDetectionService::new(
+            pool.clone(),
+            sec_config,
+        ));
+        let middleware = std::sync::Arc::new(crate::security::CircuitBreakerMiddleware::new(
+            service.clone(),
+        ));
+        info!("✅ AnomalyDetectionService and CircuitBreakerMiddleware initialized");
+        (Some(service), Some(middleware))
+    } else {
+        (None, None)
+    };
+
+    // Initialize cache connection pool
+    let redis_cache = if skip_externals {
+        info!("⏭️  Skipping Redis initialization (SKIP_EXTERNALS=true)");
+        None
+    } else {
+        info!("🔄 Initializing Redis cache connection pool...");
+        let redis_url =
+            std::env::var("REDIS_URL").map_err(|_| anyhow::anyhow!("REDIS_URL not set"))?;
+
+        let cache_config = CacheConfig {
+            redis_url: redis_url.clone(),
+            max_connections: std::env::var("CACHE_MAX_CONNECTIONS")
+                .or_else(|_| std::env::var("REDIS_MAX_CONNECTIONS"))
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(20),
+            min_idle: std::env::var("REDIS_MIN_IDLE")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5),
+            connection_timeout: Duration::from_secs(
+                std::env::var("REDIS_CONNECTION_TIMEOUT")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(5),
+            ),
+            max_lifetime: Duration::from_secs(
+                std::env::var("REDIS_MAX_LIFETIME")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(300),
+            ),
+            idle_timeout: Duration::from_secs(
+                std::env::var("REDIS_IDLE_TIMEOUT")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(60),
+            ),
+            health_check_interval: Duration::from_secs(
+                std::env::var("REDIS_HEALTH_CHECK_INTERVAL")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30),
+            ),
+        };
+
+        let cache_pool = init_cache_pool(cache_config).await.map_err(|e| {
+            error!("Failed to initialize cache pool: {}", e);
+            e
+        })?;
+
+        let redis_cache = RedisCache::new(cache_pool);
+        info!(redis_url = %redis_url, "✅ Cache connection pool initialized");
+        Some(redis_cache)
+    };
+
+    // Initialize Stellar client.
+    //
+    // NOTE: `chains::stellar::client::StellarClient` is a compatibility shim
+    // (see src/chains/) wrapping the newer `stellar::horizon::HorizonClient`.
+    // It restores enough of the historical API surface for this crate to
+    // compile against the ~30 files that reference it, but has NOT been
+    // exhaustively verified against every call site's exact behavior — some
+    // methods are best-effort. Treat as a known follow-up, not load-bearing
+    // for correctness-critical paths until reviewed with a compiler at hand.
+    let stellar_client = if skip_externals {
+        info!("⏭️  Skipping Stellar initialization (SKIP_EXTERNALS=true)");
+        None
+    } else {
+        info!("⭐ Initializing Stellar client...");
+        let stellar_config = StellarConfig::from_env().map_err(|e| {
+            error!("❌ Failed to load Stellar configuration: {}", e);
+            e
+        })?;
+
+        info!(
+            network = ?stellar_config.network,
+            timeout_secs = stellar_config.request_timeout.as_secs(),
+            max_retries = stellar_config.max_retries,
+            "Stellar configuration loaded"
+        );
+
+        match StellarClient::new(stellar_config) {
+            Ok(stellar_client) => {
+                info!("✅ Stellar client initialized successfully");
+                Some(stellar_client)
+            }
+            Err(e) => {
+                error!("❌ Failed to initialize Stellar client: {}", e);
+                None
+            }
+        }
+    };
+
+    // Initialize health checker
+    info!("🏥 Initializing health checker...");
+    let warming_state = WarmingState::new();
+    let health_checker =
+        HealthChecker::new(db_pool.clone(), redis_cache.clone(), stellar_client.clone())
+            .with_warming_state(warming_state.clone());
+
+    // Spawn background task to update DB pool connection gauge every 15 seconds
+    if let Some(pool) = db_pool.clone() {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(15));
+            loop {
+                ticker.tick().await;
+                let stats = database::get_pool_stats(&pool);
+                metrics::database::connections_active()
+                    .with_label_values(&["primary"])
+                    .set((stats.size - stats.num_idle) as f64);
+            }
+        });
+    }
+
+    // Initialize notification service
+    let notification_service = std::sync::Arc::new(services::notification::NotificationService::new());
+
+    // ── Audit logging system (Issue #183) ─────────────────────────────────────
+    let audit_writer = if let (Some(ref pool), Some(ref redis_pool)) = (&db_pool, &redis_cache) {
+        let audit_repo = std::sync::Arc::new(audit::repository::AuditLogRepository::new(pool.clone()));
+        let audit_streamer = std::sync::Arc::new(audit::streaming::AuditStreamer::new(redis_pool.pool.clone()));
+        let buffer_size: usize = std::env::var("AUDIT_WRITER_BUFFER_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(4096);
+        let (writer, rx) = audit::writer::AuditWriter::new(
+            audit_repo.clone(),
+            audit_streamer.clone(),
+            Some(buffer_size),
+        );
+        let writer = std::sync::Arc::new(writer);
+        tokio::spawn(audit::writer::run_writer_task(audit_repo, audit_streamer, rx));
+        info!("✅ Audit logging writer started (buffer={})", buffer_size);
+        Some(writer)
+    } else {
+        info!("⏭️  Skipping audit writer (no database/redis)");
+        None
+    };
+
+    let mint_audit_store = std::sync::Arc::new(
+        crate::audit::MintAuditStore::from_env().map_err(|e| {
+            error!("Mint audit store initialization failed: {}", e);
+            anyhow::anyhow!("Mint audit store initialization failed: {}", e)
+        })?,
+    );
 
     // ── Multi-level cache — built ONCE, shared by warming, admin, CDN, pipelines ──
     let shared_ml_cache: Option<std::sync::Arc<cache::MultiLevelCache>> =
@@ -681,19 +1057,6 @@ fn load_app_config() -> anyhow::Result<config::AppConfig> {
             .merge(lp_onboarding::routes::webhook_routes(svc))
     } else {
         info!("⏭️  Skipping LP onboarding routes (no database)");
-        Router::new()
-    };
-
-    // ── Merchant Multi-Sig & Treasury Controls (Issue #336) ──────────────────
-    let merchant_multisig_routes = if let Some(pool) = db_pool.clone() {
-        let svc = std::sync::Arc::new(merchant_multisig::MerchantMultisigService::new(
-            pool,
-            audit_writer.clone(),
-        ));
-        info!("✅ Merchant Multi-Sig routes enabled");
-        merchant_multisig::merchant_multisig_routes(svc)
-    } else {
-        info!("⏭️  Skipping merchant multisig routes (no database)");
         Router::new()
     };
 
@@ -1285,19 +1648,6 @@ fn load_app_config() -> anyhow::Result<config::AppConfig> {
             );
             tokio::spawn(worker.run(worker_shutdown_rx.clone()));
             info!("✅ IP detection worker started");
-/// Validate production configuration
-fn validate_production_config() -> anyhow::Result<()> {
-    info!("🔍 Validating production configuration...");
-    
-    if let Err(e) = config_validation::validate_production_config() {
-        let app_env = std::env::var("APP_ENV").unwrap_or_else(|_| "development".into());
-        if app_env != "development" {
-            error!("❌ {}", e);
-            std::process::exit(1);
-        } else {
-            info!("⚠️  Config warnings (non-fatal in development):\n{}", e);
-        }
-    }
 
     // ── Batch transaction routes (Issue #125) ────────────────────────────────
     let batch_routes = if let Some(pool) = db_pool.clone() {
@@ -1455,149 +1805,6 @@ fn validate_production_config() -> anyhow::Result<()> {
         Router::new()
     };
 
-    // ── Security compliance admin routes ──────────────────────────────────────
-    let security_compliance_routes = if let Some(ref pool) = db_pool {
-        let sec_cfg = crate::security_compliance::config::SecurityComplianceConfig::from_env();
-        let sec_repo = crate::security_compliance::repository::SecurityComplianceRepository::new(pool.clone());
-        let sec_state = crate::security_compliance::handlers::SecurityComplianceState {
-            repo: std::sync::Arc::new(sec_repo),
-            config: std::sync::Arc::new(sec_cfg),
-        };
-        Router::new()
-            .route(
-                "/api/admin/security/vulnerabilities",
-                get(crate::security_compliance::handlers::list_vulnerabilities),
-            )
-            .route(
-                "/api/admin/security/vulnerabilities/:vuln_id",
-                get(crate::security_compliance::handlers::get_vulnerability),
-            )
-            .route(
-                "/api/admin/security/vulnerabilities/:vuln_id/acknowledge",
-                post(crate::security_compliance::handlers::acknowledge_vulnerability),
-            )
-            .route(
-                "/api/admin/security/vulnerabilities/:vuln_id/resolve",
-                post(crate::security_compliance::handlers::resolve_vulnerability),
-            )
-            .route(
-                "/api/admin/security/vulnerabilities/:vuln_id/accept-risk",
-                post(crate::security_compliance::handlers::accept_risk),
-            )
-            .route(
-                "/api/admin/security/compliance/posture",
-                get(crate::security_compliance::handlers::get_posture),
-            )
-            .route(
-                "/api/admin/security/findings/ingest",
-                post(crate::security_compliance::handlers::ingest_finding),
-            )
-            .route(
-                "/api/admin/security/allowlist",
-                get(crate::security_compliance::handlers::list_allowlist)
-                    .post(crate::security_compliance::handlers::add_allowlist_entry),
-            )
-            .route(
-                "/api/admin/security/reports",
-                get(crate::security_compliance::handlers::list_reports),
-            )
-            .with_state(sec_state)
-    } else {
-        Router::new()
-    };
-
-    // ── mTLS certificate lifecycle — Issue #204 ───────────────────────────────
-    // Provision the intermediate CA and start the lifecycle worker.
-    // The admin routes are always available (they operate on the in-memory store).
-    let mtls_admin_routes = {
-        use mtls::{
-            MtlsConfig, IntermediateCa, CertificateStore, CertificateProvisioner,
-            RevocationService, CertLifecycleWorker,
-        };        use mtls::revocation::RevocationList;
-        use mtls::admin::{MtlsAdminState, mtls_admin_routes};
-
-        let mtls_config = MtlsConfig::from_env().unwrap_or_else(|e| {
-            tracing::warn!("mTLS config error (using defaults): {}", e);
-            MtlsConfig::from_env().unwrap_or_else(|_| MtlsConfig {
-                service_name: "aframp-backend".to_string(),
-                environment: std::env::var("APP_ENV").unwrap_or_else(|_| "development".to_string()),
-                leaf_cert_validity: std::time::Duration::from_secs(90 * 86400),
-                intermediate_cert_validity: std::time::Duration::from_secs(730 * 86400),
-                rotation_threshold_days: 14,
-                alert_threshold_days: 7,
-                intermediate_ca_cert_pem: String::new(),
-                intermediate_ca_key_pem: String::new(),
-                root_ca_cert_pem: String::new(),
-                ca_distribution_url: String::new(),
-                enforce_mtls: false,
-            })
-        });
-
-        // Register mTLS Prometheus metrics
-        mtls::metrics::register(prometheus::default_registry());
-
-        let cert_store = CertificateStore::new();
-        let crl = RevocationList::new();
-        let revocation_svc = std::sync::Arc::new(RevocationService::new(crl, cert_store.clone()));
-
-        // Only start the CA and provisioner if the intermediate CA PEM is configured.
-        let provisioner = if !mtls_config.intermediate_ca_cert_pem.is_empty() {
-            match IntermediateCa::from_pem(&mtls_config) {
-                Ok(ca) => {
-                    let ca = std::sync::Arc::new(ca);
-                    let p = std::sync::Arc::new(CertificateProvisioner::new(
-                        ca,
-                        cert_store.clone(),
-                        revocation_svc.clone(),
-                        mtls_config.clone(),
-                    ));
-                    // Provision all registered services at startup
-                    for &svc in mtls::cert::REGISTERED_SERVICES {
-                        match p.provision_at_startup(svc) {
-                            Ok(cert) => info!(
-                                service = svc,
-                                serial = %cert.serial,
-                                expires_at = %cert.expires_at,
-                                "mTLS: startup certificate provisioned"
-                            ),
-                            Err(e) => tracing::warn!(service = svc, error = %e, "mTLS: startup provisioning failed"),
-                        }
-                    }
-                    // Start the lifecycle worker (14-day rotation sweep)
-                    let worker = CertLifecycleWorker::new(p.clone(), cert_store.clone(), mtls_config.clone());
-                    tokio::spawn(worker.run(worker_shutdown_rx.clone()));
-                    info!("✅ mTLS certificate lifecycle worker started");
-                    p
-                }
-                Err(e) => {
-                    tracing::warn!("mTLS: intermediate CA not loaded ({}); admin endpoints available but no auto-provisioning", e);
-                    std::sync::Arc::new(CertificateProvisioner::without_ca(
-                        cert_store.clone(),
-                        revocation_svc.clone(),
-                        mtls_config.clone(),
-                    ))
-                }
-            }
-        } else {
-            info!("mTLS: MTLS_INTERMEDIATE_CA_CERT_PEM not set — certificate auto-provisioning disabled");
-            std::sync::Arc::new(CertificateProvisioner::without_ca(
-                cert_store.clone(),
-                revocation_svc.clone(),
-                mtls_config.clone(),
-            ))
-        };
-
-        let mtls_state = std::sync::Arc::new(MtlsAdminState {
-            store: cert_store,
-            provisioner,
-            revocation: revocation_svc,
-        });
-
-        mtls_admin_routes()
-            .with_state(mtls_state)
-            .route_layer(axum::middleware::from_fn(security_headers_middleware))
-    };
-
     // ── DDoS protection state and admin routes ────────────────────────────────
     // ── Audit log query routes (Issue #183) ──────────────────────────────────
     let audit_routes = if let Some(ref pool) = db_pool {
@@ -1628,42 +1835,6 @@ fn validate_production_config() -> anyhow::Result<()> {
                 .route_layer(axum::middleware::from_fn(extract_identity)),
         )
     } else {
-        Router::new()
-    };
-
-    // ── External Auditor Portal ───────────────────────────────────────────────
-    let auditor_portal_routes = if let Some(ref pool) = db_pool {
-        let audit_repo = std::sync::Arc::new(audit::repository::AuditLogRepository::new(pool.clone()));
-        let auditor_repo = std::sync::Arc::new(auditor_portal::repository::AuditorRepository::new(pool.clone()));
-        let auditor_service = std::sync::Arc::new(auditor_portal::service::AuditorService::new(
-            auditor_repo,
-            audit_repo,
-        ));
-        let state = std::sync::Arc::new(auditor_portal::handlers::AuditorPortalState {
-            service: auditor_service,
-        });
-        info!("🔍 External auditor portal routes enabled");
-        auditor_portal::routes::auditor_routes(state.clone())
-            .merge(auditor_portal::routes::admin_auditor_routes(state))
-    } else {
-        info!("⏭️  Skipping auditor portal routes (no database)");
-        Router::new()
-    };
-
-    // ── Regulatory Examination Support & Evidence Package ─────────────────────
-    let regulatory_evidence_routes = if let (Some(ref pool), Some(ref writer)) = (db_pool.as_ref(), audit_writer.as_ref()) {
-        let reg_repo = std::sync::Arc::new(regulatory_evidence::RegulatoryEvidenceRepository::new(pool.clone()));
-        let reg_service = std::sync::Arc::new(regulatory_evidence::RegulatoryEvidenceService::new(
-            reg_repo,
-            writer.clone(),
-        ));
-        let reg_state = std::sync::Arc::new(regulatory_evidence::RegulatoryEvidenceState {
-            service: reg_service,
-        });
-        info!("📋 Regulatory evidence package routes enabled");
-        regulatory_evidence::regulatory_evidence_routes(reg_state)
-    } else {
-        info!("⏭️  Skipping regulatory evidence routes (no database)");
         Router::new()
     };
 
@@ -2050,36 +2221,6 @@ fn validate_production_config() -> anyhow::Result<()> {
         Router::new()
     };
 
-    // ── Bug Bounty Programme ──────────────────────────────────────────────────
-    let bug_bounty_routes = if let Some(pool) = db_pool.clone() {
-        let repo = std::sync::Arc::new(bug_bounty::BugBountyRepository::new(pool));
-        let config = bug_bounty::BugBountyConfig::default();
-        let registry = prometheus::default_registry();
-        let metrics = std::sync::Arc::new(
-            bug_bounty::metrics::BugBountyMetrics::new(registry).unwrap_or_else(|e| {
-                tracing::warn!("Bug bounty metrics registration failed ({}); using fallback", e);
-                bug_bounty::metrics::BugBountyMetrics::new(&prometheus::Registry::new())
-                    .expect("fallback registry must succeed")
-            }),
-        );
-        let notification_dispatcher = std::sync::Arc::new(
-            bug_bounty::notifications::NotificationDispatcher::new(repo.clone()),
-        );
-        let svc = std::sync::Arc::new(bug_bounty::BugBountyService::new(
-            repo,
-            notification_dispatcher,
-            config.clone(),
-            metrics,
-        ));
-        // Spawn SLA polling worker
-        bug_bounty::SlaPollingWorker::spawn(svc.clone(), &config);
-        info!("🐛 Bug bounty programme routes enabled");
-        bug_bounty::bug_bounty_routes(svc)
-    } else {
-        info!("⏭️  Skipping bug bounty routes (no database)");
-        Router::new()
-    };
-
     // Setup OAuth 2.0 routes
     let oauth_routes = if let (Some(pool), Some(cache)) = (db_pool.clone(), redis_cache.clone()) {
         match oauth::RsaKeyPair::from_env() {
@@ -2106,28 +2247,6 @@ fn validate_production_config() -> anyhow::Result<()> {
         }
     } else {
         info!("⏭️  Skipping OAuth routes (missing database or cache)");
-        Router::new()
-    };
-
-    // ── Dispute Resolution & Clawback Management (Issue #337) ────────────────
-    let dispute_routes = if let Some(pool) = db_pool.clone() {
-        let repo = std::sync::Arc::new(dispute::DisputeRepository::new(pool));
-        let svc = std::sync::Arc::new(dispute::DisputeService::new(repo.clone()));
-        // Spawn background worker to escalate overdue disputes every 5 minutes.
-        {
-            let svc_clone = svc.clone();
-            tokio::spawn(async move {
-                let mut ticker = tokio::time::interval(std::time::Duration::from_secs(300));
-                loop {
-                    ticker.tick().await;
-                    let _ = svc_clone.escalate_overdue_disputes().await;
-                }
-            });
-        }
-        info!("⚖️  Dispute resolution routes enabled");
-        dispute::dispute_routes().with_state(svc)
-    } else {
-        info!("⏭️  Skipping dispute routes (no database)");
         Router::new()
     };
 
@@ -2170,64 +2289,6 @@ fn validate_production_config() -> anyhow::Result<()> {
         (Router::new(), Router::new())
     };
 
-    // ── CBDC Interoperability & Sandbox Bridge (Issue #499) ─────────────────
-    let (cbdc_routes, cbdc_admin_route, cbdc_worker_handle) = if let (Some(pool), Some(redis)) =
-        (db_pool.clone(), redis_cache.clone())
-    {
-        use cbdc::*;
-
-        let repo = std::sync::Arc::new(CbdcRepository::new(pool.clone()));
-        let config = CbdcWorkerConfig::from_env();
-        let hsm_config = hsm::HsmClientConfig::default();
-        let hsm_client = std::sync::Arc::new(hsm::HsmClient::new(hsm_config));
-        let validator = std::sync::Arc::new(SwapValidator::new());
-        let gateway_pool = std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new()));
-
-        let two_pc = std::sync::Arc::new(TwoPhaseCommitManager::new(
-            repo.clone(),
-            redis.pool.clone(),
-            &config,
-        ));
-
-        let settlement_worker = std::sync::Arc::new(SettlementWorker::new(
-            repo.clone(),
-            two_pc.clone(),
-            validator.clone(),
-            gateway_pool.clone(),
-            config.clone(),
-        ));
-
-        let reversal_engine = std::sync::Arc::new(ReversalEngine::new(
-            repo.clone(),
-            config.clone(),
-        ));
-
-        // Spawn settlement worker
-        let settlement_shutdown_rx = worker_shutdown_rx.clone();
-        let settlement_handle = tokio::spawn(async move {
-            settlement_worker.run(settlement_shutdown_rx).await;
-        });
-
-        // Spawn reversal engine
-        let reversal_shutdown_rx = worker_shutdown_rx.clone();
-        let reversal_handle = tokio::spawn(async move {
-            reversal_engine.run(reversal_shutdown_rx).await;
-        });
-
-        info!("✅ CBDC Interoperability workers started (settlement + reversal)");
-
-        let handler_state = std::sync::Arc::new(CbdcHandlerState::new(repo));
-
-        (
-            cbdc_api_routes(handler_state.clone()),
-            cbdc_admin_routes(handler_state),
-            Some((settlement_handle, reversal_handle)),
-        )
-    } else {
-        info!("⏭️  Skipping CBDC routes (missing database or redis)");
-        (Router::new(), Router::new(), None)
-    };
-
     // ── Multi-Sig Governance routes (Issue: Multi-Sig Governance) ────────────
     let governance_routes = if let Some(pool) = db_pool.clone() {
         let horizon_url = std::env::var("STELLAR_HORIZON_URL")
@@ -2266,223 +2327,6 @@ fn validate_production_config() -> anyhow::Result<()> {
         Router::new()
     };
 
-    // ── Peg Integrity Monitor ─────────────────────────────────────────────────
-    let peg_monitor_routes = if let (Some(pool), Some(client)) =
-        (db_pool.clone(), stellar_client.clone())
-    {
-        let peg_repo = std::sync::Arc::new(peg_monitor::PegMonitorRepository::new(pool));
-        let asset_code = std::env::var("CNGN_ASSET_CODE").unwrap_or_else(|_| "cNGN".to_string());
-        let asset_issuer = std::env::var("CNGN_ISSUER_ADDRESS")
-            .or_else(|_| std::env::var("CNGN_ISSUER_MAINNET"))
-            .unwrap_or_default();
-
-        let peg_enabled = std::env::var("PEG_MONITOR_ENABLED")
-            .unwrap_or_else(|_| "true".to_string())
-            .to_lowercase()
-            != "false";
-
-        if peg_enabled && !asset_issuer.is_empty() {
-            let worker = peg_monitor::PegMonitorWorker::new(
-                peg_repo.clone(),
-                client,
-                asset_code,
-                asset_issuer,
-            );
-            tokio::spawn(worker.run(worker_shutdown_rx.clone()));
-            info!("✅ Peg Integrity Monitor worker started");
-        } else {
-            info!("⏭️  Peg monitor worker skipped (disabled or missing CNGN_ISSUER_ADDRESS)");
-        }
-
-        peg_monitor::peg_monitor_routes(peg_repo)
-    } else {
-        info!("⏭️  Skipping peg monitor routes (missing database or stellar client)");
-        Router::new()
-    };
-
-    // ── POS QR Payment System ─────────────────────────────────────────────────
-    let pos_routes = if let (Some(pool), Some(client)) = (db_pool.clone(), stellar_client.clone()) {
-        let cngn_issuer = std::env::var("CNGN_ISSUER_ADDRESS")
-            .or_else(|_| std::env::var("CNGN_ISSUER_MAINNET"))
-            .unwrap_or_else(|_| "GXXXXDEFAULTISSUERXXXX".to_string());
-
-        let qr_generator = std::sync::Arc::new(pos::QrGenerator::new(cngn_issuer));
-        let payment_intent_service = std::sync::Arc::new(pos::payment_intent::PaymentIntentService::new(
-            pool.clone(),
-            qr_generator.clone(),
-        ));
-
-        let lobby_service = std::sync::Arc::new(pos::lobby_service::LobbyService::new(
-            pool.clone(),
-            std::sync::Arc::new(client),
-            5, // Poll interval in seconds
-        ));
-
-        // Start lobby service polling worker
-        let lobby_clone = lobby_service.clone();
-        tokio::spawn(async move {
-            lobby_clone.start_polling_worker().await;
-        });
-
-        let legacy_bridge = std::sync::Arc::new(pos::legacy_bridge::LegacyBridge::new(
-            payment_intent_service.clone(),
-        ));
-
-        let verification_secret = std::env::var("POS_VERIFICATION_SECRET")
-            .unwrap_or_else(|_| "default-secret-change-in-production".to_string());
-        let proof_of_payment = std::sync::Arc::new(pos::proof_of_payment::ProofOfPayment::new(
-            pool.clone(),
-            verification_secret,
-        ));
-
-        let pos_state = pos::handlers::PosState {
-            payment_intent_service,
-            lobby_service,
-            legacy_bridge,
-            proof_of_payment,
-        };
-
-        info!("💳 POS QR payment system routes enabled");
-        pos::routes::pos_routes(pos_state)
-    } else {
-        info!("⏭️  Skipping POS routes (missing database or stellar client)");
-        Router::new()
-    };
-    // ── Agent CFO — In-House Treasury for Autonomous Agents ─────────────────
-    let agent_cfo_routes = if let Some(pool) = db_pool.clone() {
-        let engine = std::sync::Arc::new(agent_cfo::engine::AgentCfoEngine::new(pool.clone()));
-        let ledger = engine.ledger();
-        let cfo_state = agent_cfo::handlers::CfoState {
-            engine,
-            ledger,
-            db: pool.clone(),
-        };
-        // Start burn-rate watchdog
-        let watchdog = agent_cfo::watchdog::BurnRateWatchdog::new(
-            pool,
-            agent_cfo::watchdog::WatchdogConfig::from_env(),
-        );
-        tokio::spawn(watchdog.run(worker_shutdown_rx.clone()));
-        info!("✅ Agent CFO watchdog started");
-        agent_cfo::routes::agent_cfo_routes(cfo_state)
-    } else {
-        info!("⏭️  Skipping Agent CFO routes (no database)");
-        Router::new()
-    };
-
-    // ── Agent Swarm Intelligence ──────────────────────────────────────────────
-    let agent_swarm_routes = if let Some(pool) = db_pool.clone() {
-        use agent_swarm::{
-            consensus::ConsensusEngine,
-            delegation::DelegationEngine,
-            discovery::PeerDiscovery,
-            gossip::GossipStore,
-            handlers::SwarmState,
-            settlement::SettlementEngine,
-        };
-        let swarm_state = SwarmState {
-            discovery: std::sync::Arc::new(PeerDiscovery::new(pool.clone())),
-            delegation: std::sync::Arc::new(DelegationEngine::new(pool.clone())),
-            consensus: std::sync::Arc::new(ConsensusEngine::new(pool.clone())),
-            gossip: std::sync::Arc::new(GossipStore::new(pool.clone())),
-            settlement: std::sync::Arc::new(SettlementEngine::new(pool.clone())),
-            db: pool.clone(),
-        };
-        tokio::spawn(PeerDiscovery::run_heartbeat_sweep(pool.clone(), worker_shutdown_rx.clone()));
-        tokio::spawn(GossipStore::run_eviction_worker(pool, worker_shutdown_rx.clone()));
-        info!("✅ Agent Swarm Intelligence routes enabled");
-        agent_swarm::routes::agent_swarm_routes(swarm_state)
-    } else {
-        info!("⏭️  Skipping Agent Swarm routes (no database)");
-        Router::new()
-    };
-
-    // ── Agent Admin Dashboard — HITL control system ───────────────────────
-    let agent_dashboard_routes = if let Some(pool) = db_pool.clone() {
-        let svc = std::sync::Arc::new(agent_dashboard::service::AgentDashboardService::new(pool));
-        info!("✅ Agent Admin Dashboard routes enabled");
-        agent_dashboard::routes::agent_dashboard_routes(svc)
-    } else {
-        info!("⏭️  Skipping Agent Dashboard routes (no database)");
-        Router::new()
-    };
-
-    // ── Performance SLA Management & Breach Response (Issue #405) ────────────
-    let sla_routes = if let Some(pool) = db_pool.clone() {
-        let http = reqwest::Client::new();
-        let sla_state = std::sync::Arc::new(sla::SlaState {
-            repo: std::sync::Arc::new(sla::SlaRepository::new(pool.clone())),
-            pool: pool.clone(),
-        });
-
-        // SLA monitor worker — evaluates SLOs every 60 seconds
-        let monitor = sla::SlaMonitorWorker::new(pool.clone(), http);
-        tokio::spawn(monitor.run(worker_shutdown_rx.clone()));
-        info!("✅ SLA monitor worker started (60s interval)");
-
-        // Monthly compliance report worker
-        let report_worker = sla::SlaReportWorker::new(pool);
-        tokio::spawn(report_worker.run(worker_shutdown_rx.clone()));
-        info!("✅ SLA report worker started");
-
-        sla::sla_routes(sla_state)
-    } else {
-        info!("⏭️  Skipping SLA routes (no database)");
-        Router::new()
-    };
-
-    // PEP Screening & Monitoring Engine — Issue #348
-    let pep_routes = if let (Some(pool), Some(cache)) = (db_pool.clone(), redis_cache.clone()) {
-        let repo = std::sync::Arc::new(pep::PepRepository::new(pool));
-        let config = pep::PepScreeningConfig {
-            provider_api_key: std::env::var("PEP_PROVIDER_API_KEY").unwrap_or_default(),
-            provider_base_url: std::env::var("PEP_PROVIDER_BASE_URL")
-                .unwrap_or_else(|_| "https://api.dowjones.com/risk-and-compliance/v1".into()),
-            ..Default::default()
-        };
-        let screening = std::sync::Arc::new(pep::PepScreeningService::new(
-            config,
-            cache,
-            repo.clone(),
-        ));
-        let monitoring = std::sync::Arc::new(pep::PepMonitoringService::new(
-            screening.clone(),
-            repo.clone(),
-        ));
-
-        // Spawn nightly re-screening worker
-        let worker = std::sync::Arc::new(pep::PepRescreeningWorker::new(monitoring));
-        pep::PepRescreeningWorker::spawn(worker);
-        info!("✅ PEP nightly re-screening worker started (24h interval)");
-
-        pep::handlers::pep_routes(pep::handlers::PepState { screening, repo })
-    } else {
-        info!("⏭️  Skipping PEP routes (no database or cache)");
-        Router::new()
-    };
-
-    // DeFi Analytics & Yield Performance Dashboard — Issue #348
-    let defi_analytics_routes = if let Some(pool) = db_pool.clone() {
-        let repo = std::sync::Arc::new(
-            defi::analytics::DefiAnalyticsRepository::new(std::sync::Arc::new(pool.clone()))
-        );
-        let svc = std::sync::Arc::new(defi::analytics::DefiAnalyticsService::new(repo));
-
-        // Spawn background snapshot worker
-        let worker_svc = svc.clone();
-        let worker_config = defi::analytics::worker::DefiAnalyticsWorkerConfig::default();
-        tokio::spawn(
-            defi::analytics::worker::DefiAnalyticsWorker::new(worker_svc, worker_config)
-                .run(worker_shutdown_rx.clone())
-        );
-        info!("✅ DeFi analytics snapshot worker started");
-
-        defi::analytics::defi_analytics_routes(svc)
-    } else {
-        info!("⏭️  Skipping DeFi analytics routes (no database)");
-        Router::new()
-    };
-
     let app = Router::new()
         .route("/", get(root))
         .route("/health", get(health))
@@ -2503,20 +2347,14 @@ fn validate_production_config() -> anyhow::Result<()> {
             get(list_trustline_operations_by_wallet),
         )
         .route("/api/fees/calculate", post(calculate_fee))
-        .route("/api/cngn/trustlines/check", post(check_cngn_trustline))
-        .route(
-            "/api/cngn/trustlines/preflight",
-            post(preflight_cngn_trustline),
-        )
-        .route("/api/cngn/trustlines/build", post(build_cngn_trustline))
-        .route("/api/cngn/trustlines/submit", post(submit_cngn_trustline))
-        .route(
-            "/api/cngn/trustlines/retry/{id}",
-            post(retry_cngn_trustline),
-        )
-        .route("/api/cngn/payments/build", post(build_cngn_payment))
-        .route("/api/cngn/payments/sign", post(sign_cngn_payment))
-        .route("/api/cngn/payments/submit", post(submit_cngn_payment))
+        // NOTE: cNGN trustline build/submit/retry and cNGN payment build/sign/submit
+        // routes are intentionally omitted — their handlers depend on
+        // chains::stellar::trustline / chains::stellar::payment, a transaction-building
+        // subsystem that doesn't exist anywhere in this codebase (only a thin
+        // compatibility shim for the client/config/error types was reconstructed;
+        // see src/chains/). Reconstructing real XDR transaction-building logic for a
+        // payments system without a spec or compiler was judged too risky to guess at.
+        // check_cngn_trustline and preflight_cngn_trustline are omitted for the same reason.
         .route("/api/payments/initiate", post(initiate_payment))
         .merge(onramp_routes)
         .merge(offramp_routes)
@@ -2532,9 +2370,7 @@ fn validate_production_config() -> anyhow::Result<()> {
         .merge(admin_routes)
         .merge(adaptive_rl_admin_routes)
         .merge(audit_routes)
-        .merge(auditor_portal_routes)
         .merge(sar_routes)
-        .merge(regulatory_evidence_routes)
         .merge(compliance_effectiveness_routes)
         .merge(stellar_throughput_routes)
         .merge(kyb_routes)
@@ -2545,38 +2381,23 @@ fn validate_production_config() -> anyhow::Result<()> {
         .merge(recurring_routes)
         .merge(developer_routes)
         .merge(oauth_routes)
-        .merge(peg_monitor_routes)
         .merge(ddos_admin_routes)
         .merge(pentest_routes)
         .merge(liquidity_routes)
         .merge(transparency_routes)
         .merge(por_routes)
-        .merge(bug_bounty_routes)
         .merge(developer_portal::routes::register_developer_portal_routes(
             Router::new(),
             db_pool.clone(),
         ))
-        .merge(Router::new().nest("/api/admin/security", mtls_admin_routes))
-        .merge(security_compliance_routes)
         .merge(lp_payout_routes)
-        .merge(merchant_multisig_routes)
         .merge(oracle_routes)
         .merge(governance_routes)
         .merge(lp_onboarding_routes)
         .merge(partner_hub_routes)
         .merge(partner_routes)
-        .merge(agent_cfo_routes)
-        .merge(agent_swarm_routes)
-        .merge(agent_dashboard_routes)
-        .merge(pos_routes)
-        .merge(dispute_routes)
         .merge(banking_routes)
         .merge(banking_webhook_routes)
-        .merge(cbdc_routes)
-        .merge(cbdc_admin_route)
-        .merge(sla_routes)
-        .merge(pep_routes)
-        .merge(defi_analytics_routes)
         .with_state(AppState {
             db_pool,
             redis_cache,
@@ -2879,22 +2700,630 @@ fn validate_production_config() -> anyhow::Result<()> {
         }
     }
 
-    if let Some((settlement_handle, reversal_handle)) = cbdc_worker_handle {
-        if let Err(e) = tokio::time::timeout(std::time::Duration::from_secs(5), settlement_handle).await {
-            error!(error = %e, "Timed out waiting for CBDC settlement worker shutdown");
-        }
-        if let Err(e) = tokio::time::timeout(std::time::Duration::from_secs(5), reversal_handle).await {
-            error!(error = %e, "Timed out waiting for CBDC reversal engine shutdown");
-        }
-    }
-
     info!("👋 Server shutdown complete");
     // Flush all buffered spans to the OTLP exporter before the process exits.
     // Must be the very last call so no spans are lost during shutdown.   (Issue #104)
     // -------------------------------------------------------------------------
     shutdown_tracer();
 
-    
-    info!("✅ Production configuration validated");
     Ok(())
+}
+
+// Application state
+#[derive(Clone)]
+struct AppState {
+    db_pool: Option<sqlx::PgPool>,
+    redis_cache: Option<RedisCache>,
+    stellar_client: Option<StellarClient>,
+    health_checker: HealthChecker,
+    warming_state: Option<WarmingState>,
+    ha_pool: Option<std::sync::Arc<database::ha_pool::HaPoolManager>>,
+}
+
+// Handlers
+async fn root() -> &'static str {
+    info!("📍 Root endpoint accessed");
+    "Welcome to Aframp Backend API"
+}
+
+async fn health(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Result<Json<HealthStatus>, (axum::http::StatusCode, String)> {
+    info!("🏥 Health check requested");
+    let health_status = state.health_checker.check_health().await;
+
+    // Return 503 if any component is unhealthy
+    if matches!(health_status.status, crate::health::HealthState::Unhealthy) {
+        error!("❌ Health check failed - service unhealthy");
+        Err((
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "Service Unavailable".to_string(),
+        ))
+    } else {
+        info!("✅ Health check passed");
+        Ok(Json(health_status))
+    }
+}
+
+/// Readiness probe - checks if the service is ready to accept traffic
+async fn readiness(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Result<Json<HealthStatus>, (axum::http::StatusCode, String)> {
+    info!("🔍 Readiness probe requested");
+    let result = health(axum::extract::State(state)).await;
+    if result.is_ok() {
+        info!("✅ Readiness check passed");
+    } else {
+        error!("❌ Readiness check failed");
+    }
+    result
+}
+
+/// Liveness probe - checks if the service is alive (basic check)
+async fn liveness() -> Result<&'static str, (axum::http::StatusCode, String)> {
+    info!("💓 Liveness probe requested");
+    info!("✅ Liveness check passed");
+    Ok("OK")
+}
+
+async fn get_stellar_account(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(address): axum::extract::Path<String>,
+) -> Result<String, (axum::http::StatusCode, String)> {
+    info!(address = %address, "🔍 Stellar account lookup requested");
+
+    let stellar_client = match state.stellar_client.as_ref() {
+        Some(client) => client,
+        None => {
+            return Err((
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "Stellar client disabled by configuration".to_string(),
+            ))
+        }
+    };
+
+    match stellar_client.account_exists(&address).await {
+        Ok(exists) => {
+            if exists {
+                info!(address = %address, "✅ Account exists, fetching details");
+                match stellar_client.get_account(&address).await {
+                    Ok(account) => {
+                        info!(
+                            address = %address,
+                            balances = account.balances.len(),
+                            "✅ Account details fetched successfully"
+                        );
+                        Ok(format!(
+                            "Account: {}, Balances: {}",
+                            account.account_id,
+                            account.balances.len()
+                        ))
+                    }
+                    Err(e) => {
+                        error!(address = %address, error = %e, "❌ Failed to fetch account details");
+                        Err((
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Failed to fetch account: {}", e),
+                        ))
+                    }
+                }
+            } else {
+                info!(address = %address, "ℹ️  Account not found");
+                Err((
+                    axum::http::StatusCode::NOT_FOUND,
+                    "Account not found".to_string(),
+                ))
+            }
+        }
+        Err(e) => {
+            error!(address = %address, error = %e, "❌ Error checking account existence");
+            Err((
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Error checking account: {}", e),
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TrustlineOperationRequest {
+    wallet_address: String,
+    asset_code: String,
+    issuer: Option<String>,
+    operation_type: TrustlineOperationType,
+    status: TrustlineOperationStatus,
+    transaction_hash: Option<String>,
+    error_message: Option<String>,
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TrustlineOperationStatusUpdate {
+    status: TrustlineOperationStatus,
+    transaction_hash: Option<String>,
+    error_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TrustlineOperationQuery {
+    limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TrustlineOperationType {
+    Create,
+    Update,
+    Remove,
+}
+
+impl TrustlineOperationType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            TrustlineOperationType::Create => "create",
+            TrustlineOperationType::Update => "update",
+            TrustlineOperationType::Remove => "remove",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TrustlineOperationStatus {
+    Pending,
+    Completed,
+    Failed,
+}
+
+impl TrustlineOperationStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            TrustlineOperationStatus::Pending => "pending",
+            TrustlineOperationStatus::Completed => "completed",
+            TrustlineOperationStatus::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct FeeCalculationRequest {
+    fee_type: FeeType,
+    amount: String,
+    currency: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum FeeType {
+    Onramp,
+    Offramp,
+    BillPayment,
+    Exchange,
+    Transfer,
+}
+
+impl FeeType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FeeType::Onramp => "onramp",
+            FeeType::Offramp => "offramp",
+            FeeType::BillPayment => "bill_payment",
+            FeeType::Exchange => "exchange",
+            FeeType::Transfer => "transfer",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FeeCalculationResponse {
+    fee: String,
+    rate_bps: i32,
+    flat_fee: String,
+    min_fee: Option<String>,
+    max_fee: Option<String>,
+    currency: Option<String>,
+    structure_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct InitiatePaymentApiRequest {
+    amount: String,
+    currency: Option<String>,
+    email: Option<String>,
+    phone: Option<String>,
+    payment_method: Option<String>,
+    callback_url: Option<String>,
+    transaction_reference: String,
+    metadata: Option<serde_json::Value>,
+    provider: Option<String>,
+}
+
+async fn create_trustline_operation(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<TrustlineOperationRequest>,
+) -> Result<
+    Json<crate::database::trustline_operation_repository::TrustlineOperation>,
+    (
+        axum::http::StatusCode,
+        Json<crate::middleware::error::ErrorResponse>,
+    ),
+> {
+    let request_id = crate::middleware::error::get_request_id_from_headers(&headers);
+    let pool = match state.db_pool.as_ref() {
+        Some(pool) => pool,
+        None => {
+            return Err(crate::middleware::error::json_error_response(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "Database disabled by configuration",
+                request_id,
+            ))
+        }
+    };
+
+    if payload.wallet_address.trim().is_empty() {
+        return Err(crate::middleware::error::json_error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            "wallet_address is required",
+            request_id,
+        ));
+    }
+    if payload.asset_code.trim().is_empty() {
+        return Err(crate::middleware::error::json_error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            "asset_code is required",
+            request_id,
+        ));
+    }
+
+    let repo = crate::database::trustline_operation_repository::TrustlineOperationRepository::new(
+        pool.clone(),
+    );
+    let service = crate::services::trustline_operation::TrustlineOperationService::new(repo);
+
+    let input = crate::services::trustline_operation::TrustlineOperationInput {
+        wallet_address: payload.wallet_address,
+        asset_code: payload.asset_code,
+        issuer: payload.issuer,
+        operation_type: payload.operation_type.as_str().to_string(),
+        status: payload.status.as_str().to_string(),
+        transaction_hash: payload.transaction_hash,
+        error_message: payload.error_message,
+        metadata: payload.metadata.unwrap_or_else(|| serde_json::json!({})),
+    };
+
+    let result = match payload.operation_type {
+        TrustlineOperationType::Create => service.record_create(input).await,
+        TrustlineOperationType::Update => service.record_update(input).await,
+        TrustlineOperationType::Remove => service.record_remove(input).await,
+    };
+
+    result.map(Json).map_err(|e| {
+        crate::middleware::error::json_error_response(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            e.to_string(),
+            request_id,
+        )
+    })
+}
+
+async fn initiate_payment(
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<InitiatePaymentApiRequest>,
+) -> Result<
+    Json<crate::payments::types::PaymentResponse>,
+    (
+        axum::http::StatusCode,
+        Json<crate::middleware::error::ErrorResponse>,
+    ),
+> {
+    let request_id = crate::middleware::error::get_request_id_from_headers(&headers);
+
+    if payload.transaction_reference.trim().is_empty() {
+        return Err(crate::middleware::error::json_error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            "transaction_reference is required",
+            request_id,
+        ));
+    }
+    if payload.email.as_deref().unwrap_or("").trim().is_empty() {
+        return Err(crate::middleware::error::json_error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            "email is required for payment initialization",
+            request_id,
+        ));
+    }
+
+    let payment_method = match payload
+        .payment_method
+        .as_deref()
+        .unwrap_or("card")
+        .trim()
+        .to_lowercase()
+        .as_str()
+    {
+        "card" => PaymentMethod::Card,
+        "bank_transfer" | "bank" => PaymentMethod::BankTransfer,
+        "mobile_money" => PaymentMethod::MobileMoney,
+        "ussd" => PaymentMethod::Ussd,
+        "wallet" => PaymentMethod::Wallet,
+        _ => PaymentMethod::Other,
+    };
+
+    let provider_request = ProviderPaymentRequest {
+        amount: Money {
+            amount: payload.amount,
+            currency: payload.currency.unwrap_or_else(|| "NGN".to_string()),
+        },
+        customer: CustomerContact {
+            email: payload.email,
+            phone: payload.phone,
+        },
+        payment_method,
+        callback_url: payload.callback_url,
+        transaction_reference: payload.transaction_reference,
+        metadata: payload.metadata,
+    };
+
+    let factory = PaymentProviderFactory::from_env().map_err(|e| {
+        crate::middleware::error::json_error_response(
+            axum::http::StatusCode::from_u16(e.http_status_code())
+                .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR),
+            e.user_message(),
+            request_id.clone(),
+        )
+    })?;
+
+    let provider = match payload.provider {
+        Some(provider_name) => {
+            let provider = ProviderName::from_str(&provider_name).map_err(|e| {
+                crate::middleware::error::json_error_response(
+                    axum::http::StatusCode::from_u16(e.http_status_code())
+                        .unwrap_or(axum::http::StatusCode::BAD_REQUEST),
+                    e.user_message(),
+                    request_id.clone(),
+                )
+            })?;
+            factory.get_provider(provider)
+        }
+        None => factory.get_default_provider(),
+    }
+    .map_err(|e| {
+        crate::middleware::error::json_error_response(
+            axum::http::StatusCode::from_u16(e.http_status_code())
+                .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR),
+            e.user_message(),
+            request_id.clone(),
+        )
+    })?;
+
+    let response = provider
+        .initiate_payment(provider_request)
+        .await
+        .map_err(|e| {
+            crate::middleware::error::json_error_response(
+                axum::http::StatusCode::from_u16(e.http_status_code())
+                    .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR),
+                e.user_message(),
+                request_id.clone(),
+            )
+        })?;
+
+    Ok(Json(response))
+}
+
+async fn update_trustline_operation_status(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<TrustlineOperationStatusUpdate>,
+) -> Result<
+    Json<crate::database::trustline_operation_repository::TrustlineOperation>,
+    (
+        axum::http::StatusCode,
+        Json<crate::middleware::error::ErrorResponse>,
+    ),
+> {
+    let request_id = crate::middleware::error::get_request_id_from_headers(&headers);
+    let pool = match state.db_pool.as_ref() {
+        Some(pool) => pool,
+        None => {
+            return Err(crate::middleware::error::json_error_response(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "Database disabled by configuration",
+                request_id,
+            ))
+        }
+    };
+
+    let uuid = Uuid::parse_str(&id).map_err(|e| {
+        crate::middleware::error::json_error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            format!("Invalid UUID: {}", e),
+            request_id.clone(),
+        )
+    })?;
+
+    let repo = crate::database::trustline_operation_repository::TrustlineOperationRepository::new(
+        pool.clone(),
+    );
+    let service = crate::services::trustline_operation::TrustlineOperationService::new(repo);
+
+    service
+        .update_status(
+            uuid,
+            payload.status.as_str(),
+            payload.transaction_hash.as_deref(),
+            payload.error_message.as_deref(),
+        )
+        .await
+        .map(Json)
+        .map_err(|e| {
+            crate::middleware::error::json_error_response(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+                request_id.clone(),
+            )
+        })
+}
+
+async fn list_trustline_operations_by_wallet(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(address): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    axum::extract::Query(query): axum::extract::Query<TrustlineOperationQuery>,
+) -> Result<
+    Json<Vec<crate::database::trustline_operation_repository::TrustlineOperation>>,
+    (
+        axum::http::StatusCode,
+        Json<crate::middleware::error::ErrorResponse>,
+    ),
+> {
+    let request_id = crate::middleware::error::get_request_id_from_headers(&headers);
+    let pool = match state.db_pool.as_ref() {
+        Some(pool) => pool,
+        None => {
+            return Err(crate::middleware::error::json_error_response(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "Database disabled by configuration",
+                request_id,
+            ))
+        }
+    };
+
+    if address.trim().is_empty() {
+        return Err(crate::middleware::error::json_error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            "wallet address is required",
+            request_id,
+        ));
+    }
+
+    let repo = crate::database::trustline_operation_repository::TrustlineOperationRepository::new(
+        pool.clone(),
+    );
+
+    let limit = query.limit.unwrap_or(50).clamp(1, 200);
+    repo.find_by_wallet(&address, limit)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            crate::middleware::error::json_error_response(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+                request_id,
+            )
+        })
+}
+
+async fn calculate_fee(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<FeeCalculationRequest>,
+) -> Result<
+    Json<FeeCalculationResponse>,
+    (
+        axum::http::StatusCode,
+        Json<crate::middleware::error::ErrorResponse>,
+    ),
+> {
+    let request_id = crate::middleware::error::get_request_id_from_headers(&headers);
+    let pool = match state.db_pool.as_ref() {
+        Some(pool) => pool,
+        None => {
+            return Err(crate::middleware::error::json_error_response(
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "Database disabled by configuration",
+                request_id,
+            ))
+        }
+    };
+
+    let repo = crate::database::fee_structure_repository::FeeStructureRepository::new(pool.clone());
+    let service = crate::services::fee_structure::FeeStructureService::new(repo);
+
+    let amount = crate::services::fee_structure::parse_amount(&payload.amount);
+    if amount <= bigdecimal::BigDecimal::from(0) {
+        return Err(crate::middleware::error::json_error_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            "amount must be greater than 0",
+            request_id,
+        ));
+    }
+
+    let result = service
+        .calculate_fee(crate::services::fee_structure::FeeCalculationInput {
+            fee_type: payload.fee_type.as_str().to_string(),
+            amount,
+            currency: payload.currency,
+            at_time: None,
+        })
+        .await
+        .map_err(|e| {
+            crate::middleware::error::json_error_response(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+                request_id.clone(),
+            )
+        })?;
+
+    match result {
+        Some(calc) => Ok(Json(FeeCalculationResponse {
+            fee: calc.fee.to_string(),
+            rate_bps: calc.rate_bps,
+            flat_fee: calc.flat_fee.to_string(),
+            min_fee: calc.min_fee.map(|v| v.to_string()),
+            max_fee: calc.max_fee.map(|v| v.to_string()),
+            currency: calc.currency,
+            structure_id: calc.structure_id.to_string(),
+        })),
+        None => Err(crate::middleware::error::json_error_response(
+            axum::http::StatusCode::NOT_FOUND,
+            "No active fee structure found",
+            request_id.clone(),
+        )),
+    }
+}
+
+fn app_error_response(
+    err: crate::error::AppError,
+    request_id: Option<String>,
+) -> (
+    axum::http::StatusCode,
+    Json<crate::middleware::error::ErrorResponse>,
+) {
+    let err = match request_id {
+        Some(req_id) => err.with_request_id(req_id),
+        None => err,
+    };
+    let status = axum::http::StatusCode::from_u16(err.status_code())
+        .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    (
+        status,
+        Json(crate::middleware::error::ErrorResponse::from_app_error(
+            &err,
+        )),
+    )
+}
+
+async fn create_onramp_quote(
+    axum::extract::State(quote_service): axum::extract::State<
+        std::sync::Arc<services::onramp_quote::OnrampQuoteService>,
+    >,
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<services::onramp_quote::OnrampQuoteRequest>,
+) -> Result<
+    Json<services::onramp_quote::OnrampQuoteResponse>,
+    (
+        axum::http::StatusCode,
+        Json<middleware::error::ErrorResponse>,
+    ),
+> {
+    let request_id = middleware::error::get_request_id_from_headers(&headers);
+
+    quote_service
+        .create_quote(payload)
+        .await
+        .map(Json)
+        .map_err(|e| app_error_response(e, request_id))
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -434,6 +434,57 @@ pub mod stellar {
 }
 
 // ---------------------------------------------------------------------------
+// Stellar Horizon endpoint health metrics
+// ---------------------------------------------------------------------------
+
+pub mod stellar_horizon {
+    use super::*;
+
+    static HORIZON_ENDPOINT_SUCCESS_RATE: OnceLock<GaugeVec> = OnceLock::new();
+    static HORIZON_ENDPOINT_HEALTHY: OnceLock<GaugeVec> = OnceLock::new();
+
+    /// EWMA success rate (0.0-1.0) per Horizon/RPC endpoint.
+    pub fn endpoint_success_rate() -> &'static GaugeVec {
+        HORIZON_ENDPOINT_SUCCESS_RATE
+            .get()
+            .expect("metrics not initialised")
+    }
+
+    /// Whether an endpoint is currently in rotation (1) or circuit-broken out (0).
+    pub fn endpoint_healthy() -> &'static GaugeVec {
+        HORIZON_ENDPOINT_HEALTHY
+            .get()
+            .expect("metrics not initialised")
+    }
+
+    pub(super) fn register(r: &Registry) {
+        HORIZON_ENDPOINT_SUCCESS_RATE
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_horizon_endpoint_success_rate",
+                    "EWMA success rate (0.0-1.0) per Horizon/RPC endpoint",
+                    &["endpoint"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        HORIZON_ENDPOINT_HEALTHY
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_horizon_endpoint_healthy",
+                    "Whether a Horizon/RPC endpoint is in rotation (1) or circuit-broken out (0)",
+                    &["endpoint"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Background worker metrics
 // ---------------------------------------------------------------------------
 
@@ -531,6 +582,10 @@ pub mod cache {
     static CDN_CACHE_STATUS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
     static REDIS_MEMORY_USED_BYTES: OnceLock<GaugeVec> = OnceLock::new();
     static REDIS_MAXMEMORY_BYTES: OnceLock<GaugeVec> = OnceLock::new();
+    static REDIS_POOL_SIZE: OnceLock<GaugeVec> = OnceLock::new();
+    static REDIS_POOL_IDLE: OnceLock<GaugeVec> = OnceLock::new();
+    static REDIS_POOL_PENDING: OnceLock<GaugeVec> = OnceLock::new();
+    static CACHE_INVALIDATION_TOTAL: OnceLock<CounterVec> = OnceLock::new();
 
     pub fn redis_memory_used_bytes() -> &'static GaugeVec {
         REDIS_MEMORY_USED_BYTES.get().expect("metrics not initialised")
@@ -538,6 +593,30 @@ pub mod cache {
 
     pub fn redis_maxmemory_bytes() -> &'static GaugeVec {
         REDIS_MAXMEMORY_BYTES.get().expect("metrics not initialised")
+    }
+
+    /// Total bb8 pool connections (in-use + idle).
+    pub fn redis_pool_size() -> &'static GaugeVec {
+        REDIS_POOL_SIZE.get().expect("metrics not initialised")
+    }
+
+    /// Idle (checked-in, available) bb8 pool connections.
+    pub fn redis_pool_idle() -> &'static GaugeVec {
+        REDIS_POOL_IDLE.get().expect("metrics not initialised")
+    }
+
+    /// Connection acquisitions currently blocked waiting on the pool (all
+    /// connections busy). Sustained values > 10 indicate pool exhaustion —
+    /// see the RedisPoolExhaustion alert rule.
+    pub fn redis_pool_pending() -> &'static GaugeVec {
+        REDIS_POOL_PENDING.get().expect("metrics not initialised")
+    }
+
+    /// Cache invalidations triggered by admin mutations, by reason.
+    pub fn cache_invalidation_total() -> &'static CounterVec {
+        CACHE_INVALIDATION_TOTAL
+            .get()
+            .expect("metrics not initialised")
     }
 
     pub fn hits_total() -> &'static CounterVec {
@@ -645,6 +724,54 @@ pub mod cache {
                     "aframp_redis_maxmemory_bytes",
                     "Redis maxmemory configured limit in bytes (0 = unlimited)",
                     &["instance"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        REDIS_POOL_SIZE
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_redis_pool_size",
+                    "Total bb8 Redis pool connections (in-use + idle)",
+                    &["instance"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        REDIS_POOL_IDLE
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_redis_pool_idle",
+                    "Idle (checked-in) bb8 Redis pool connections",
+                    &["instance"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        REDIS_POOL_PENDING
+            .set(
+                register_gauge_vec_with_registry!(
+                    "aframp_redis_pool_pending",
+                    "Connection acquisitions currently blocked waiting on the Redis pool",
+                    &["instance"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        CACHE_INVALIDATION_TOTAL
+            .set(
+                register_counter_vec_with_registry!(
+                    "aframp_cache_invalidation_total",
+                    "Total cache invalidations by reason",
+                    &["reason"],
                     r
                 )
                 .unwrap(),
@@ -925,6 +1052,7 @@ fn register_all(r: &Registry) {
     cngn::register(r);
     payment::register(r);
     stellar::register(r);
+    stellar_horizon::register(r);
     worker::register(r);
     cache::register(r);
     database::register(r);

--- a/src/middleware/request_integrity/field_validation.rs
+++ b/src/middleware/request_integrity/field_validation.rs
@@ -7,7 +7,7 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::cache::cache::Cache;
-// REMOVED: use crate::chains::stellar::types::is_valid_stellar_address;
+use crate::chains::stellar::types::is_valid_stellar_address;
 use crate::database::provider_config_repository::ProviderConfigRepository;
 use crate::services::onramp_quote::StoredQuote;
 

--- a/src/services/balance.rs
+++ b/src/services/balance.rs
@@ -1,5 +1,5 @@
 use crate::cache::{cache::Cache, keys::wallet::BalanceKey, RedisCache};
-// REMOVED: use crate::chains::stellar::{client::StellarClient, errors::StellarError, types::AssetBalance};
+use crate::chains::stellar::{client::StellarClient, errors::StellarError, types::AssetBalance};
 use chrono::Utc;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};

--- a/src/services/onramp_quote.rs
+++ b/src/services/onramp_quote.rs
@@ -6,9 +6,9 @@
 use crate::cache::cache::Cache;
 use crate::cache::keys::onramp::QuoteKey;
 use crate::cache::RedisCache;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
-// REMOVED: use crate::chains::stellar::trustline::CngnTrustlineManager;
-// REMOVED: use crate::chains::stellar::types::{extract_cngn_balance, is_valid_stellar_address};
+use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::trustline::CngnTrustlineManager;
+use crate::chains::stellar::types::{extract_cngn_balance, is_valid_stellar_address};
 use crate::error::{AppError, AppErrorKind, DomainError, ValidationError};
 use crate::services::exchange_rate::{ConversionDirection, ConversionRequest, ExchangeRateService};
 use crate::services::fee_structure::{FeeCalculationInput, FeeStructureService};

--- a/src/services/reconciliation.rs
+++ b/src/services/reconciliation.rs
@@ -1,4 +1,4 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::database::reconciliation_repository::{ReconciliationReport, ReconciliationRepository};
 use crate::payments::factory::PaymentProviderFactory;
 use crate::payments::types::ProviderName;

--- a/src/services/redemption_service.rs
+++ b/src/services/redemption_service.rs
@@ -1,5 +1,5 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
-// REMOVED: use crate::chains::stellar::errors::StellarError;
+use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::errors::StellarError;
 use crate::database::models::redemption::{
     CreateRedemptionRequest, RedemptionConfig, RedemptionError, RedemptionRequest,
     RedemptionRequestResponse, RedemptionStatusResponse,

--- a/src/stellar/horizon.rs
+++ b/src/stellar/horizon.rs
@@ -2,13 +2,58 @@
 use crate::stellar::error::{HorizonErrorCode, SubmissionError, SubmissionResult};
 use crate::stellar::models::HorizonTransaction;
 use serde::Deserialize;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tracing::{info, warn};
+
+/// EWMA smoothing factor applied to each success/failure sample.
+const EWMA_ALPHA: f64 = 0.2;
+/// Minimum number of samples before an endpoint is eligible to be tripped
+/// or recovered — avoids flapping a fresh endpoint on a single bad request.
+const MIN_SAMPLES_BEFORE_TRIP: u32 = 5;
+/// EWMA success rate below which a healthy endpoint is circuit-broken out
+/// of rotation.
+const UNHEALTHY_THRESHOLD: f64 = 0.5;
+/// EWMA success rate at/above which a circuit-broken endpoint is re-added
+/// to rotation.
+const RECOVERY_THRESHOLD: f64 = 0.8;
+/// How often the background prober re-checks circuit-broken endpoints.
+const RECOVERY_PROBE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Per-endpoint health tracking state.
+struct EndpointHealthState {
+    /// Exponential moving average of the success rate, in `[0.0, 1.0]`.
+    /// Starts optimistic (1.0) so a fresh endpoint isn't penalized before
+    /// it has served any traffic.
+    ewma_success_rate: f64,
+    samples: u32,
+    healthy: bool,
+    consecutive_failures: u32,
+}
+
+impl EndpointHealthState {
+    fn new() -> Self {
+        Self {
+            ewma_success_rate: 1.0,
+            samples: 0,
+            healthy: true,
+            consecutive_failures: 0,
+        }
+    }
+}
+
+fn new_health_states(count: usize) -> Arc<Vec<Mutex<EndpointHealthState>>> {
+    Arc::new((0..count).map(|_| Mutex::new(EndpointHealthState::new())).collect())
+}
 
 #[derive(Clone)]
 pub struct HorizonClient {
     base_url: String,
     rpc_endpoints: std::sync::Arc<Vec<String>>,
     rr_index: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    /// Per-endpoint health state, indexed identically to `rpc_endpoints`.
+    endpoint_health: Arc<Vec<Mutex<EndpointHealthState>>>,
     client: reqwest::Client,
     request_timeout: Duration,
 }
@@ -31,10 +76,12 @@ pub struct TransactionsResponse {
 impl HorizonClient {
     pub fn new(base_url: String) -> Self {
         let endpoints = vec![base_url.clone()];
+        let endpoint_health = new_health_states(endpoints.len());
         Self {
             base_url,
             rpc_endpoints: std::sync::Arc::new(endpoints),
             rr_index: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            endpoint_health,
             client: reqwest::Client::new(),
             request_timeout: Duration::from_secs(15),
         }
@@ -43,21 +90,165 @@ impl HorizonClient {
     pub fn with_rpc_endpoints(mut self, endpoints: Vec<String>) -> Self {
         if !endpoints.is_empty() {
             self.base_url = endpoints[0].clone();
+            self.endpoint_health = new_health_states(endpoints.len());
             self.rpc_endpoints = std::sync::Arc::new(endpoints);
+            self.rr_index.store(0, Ordering::Relaxed);
+
+            if self.rpc_endpoints.len() > 1 {
+                self.spawn_recovery_prober();
+            }
         }
         self
     }
 
-    fn pick_endpoint(&self) -> String {
+    /// Pick the next endpoint for round-robin dispatch, skipping any endpoint
+    /// whose circuit breaker is open. Returns the endpoint's index (for
+    /// recording the outcome via [`record_result`]) and URL.
+    ///
+    /// [`record_result`]: HorizonClient::record_result
+    fn pick_endpoint(&self) -> (usize, String) {
         let endpoints = self.rpc_endpoints.as_ref();
         if endpoints.is_empty() {
-            return self.base_url.clone();
+            return (0, self.base_url.clone());
         }
-        let idx = self
-            .rr_index
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            % endpoints.len();
-        endpoints[idx].clone()
+        if endpoints.len() == 1 {
+            return (0, endpoints[0].clone());
+        }
+
+        let mut candidates: Vec<usize> = self
+            .endpoint_health
+            .iter()
+            .enumerate()
+            .filter_map(|(i, h)| match h.lock() {
+                Ok(state) if state.healthy => Some(i),
+                _ => None,
+            })
+            .collect();
+
+        if candidates.is_empty() {
+            // Every endpoint is circuit-broken. Fail open across the full
+            // set rather than hard-failing every submission — a total
+            // Horizon outage should degrade, not stop, traffic.
+            warn!("All Horizon RPC endpoints are circuit-broken; failing open across the full set");
+            candidates = (0..endpoints.len()).collect();
+        }
+
+        let pick = self.rr_index.fetch_add(1, Ordering::Relaxed) % candidates.len();
+        let idx = candidates[pick];
+        (idx, endpoints[idx].clone())
+    }
+
+    /// Record the outcome of a request against `endpoint_idx`, updating its
+    /// EWMA success rate and the Prometheus gauge, and flipping its circuit
+    /// breaker open/closed as thresholds are crossed.
+    fn record_result(&self, endpoint_idx: usize, success: bool) {
+        let Some(slot) = self.endpoint_health.get(endpoint_idx) else {
+            return;
+        };
+        let endpoint_label = self
+            .rpc_endpoints
+            .get(endpoint_idx)
+            .cloned()
+            .unwrap_or_else(|| self.base_url.clone());
+
+        let (rate, healthy, just_tripped, just_recovered) = {
+            let Ok(mut state) = slot.lock() else {
+                return;
+            };
+
+            let sample = if success { 1.0 } else { 0.0 };
+            state.ewma_success_rate =
+                EWMA_ALPHA * sample + (1.0 - EWMA_ALPHA) * state.ewma_success_rate;
+            state.samples = state.samples.saturating_add(1);
+            state.consecutive_failures = if success {
+                0
+            } else {
+                state.consecutive_failures.saturating_add(1)
+            };
+
+            let mut just_tripped = false;
+            let mut just_recovered = false;
+
+            if state.healthy
+                && state.samples >= MIN_SAMPLES_BEFORE_TRIP
+                && state.ewma_success_rate < UNHEALTHY_THRESHOLD
+            {
+                state.healthy = false;
+                just_tripped = true;
+            } else if !state.healthy && state.ewma_success_rate >= RECOVERY_THRESHOLD {
+                state.healthy = true;
+                state.consecutive_failures = 0;
+                just_recovered = true;
+            }
+
+            (state.ewma_success_rate, state.healthy, just_tripped, just_recovered)
+        };
+
+        crate::metrics::stellar_horizon::endpoint_success_rate()
+            .with_label_values(&[&endpoint_label])
+            .set(rate);
+        crate::metrics::stellar_horizon::endpoint_healthy()
+            .with_label_values(&[&endpoint_label])
+            .set(if healthy { 1.0 } else { 0.0 });
+
+        if just_tripped {
+            warn!(
+                endpoint = %endpoint_label,
+                success_rate = rate,
+                "Horizon endpoint circuit-broken; excluded from rotation"
+            );
+        }
+        if just_recovered {
+            info!(
+                endpoint = %endpoint_label,
+                success_rate = rate,
+                "Horizon endpoint recovered; re-added to rotation"
+            );
+        }
+    }
+
+    /// Spawn a background task that periodically probes circuit-broken
+    /// endpoints with a lightweight GET, re-admitting them to rotation once
+    /// their EWMA success rate recovers above [`RECOVERY_THRESHOLD`].
+    fn spawn_recovery_prober(&self) {
+        let handle = self.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(RECOVERY_PROBE_INTERVAL);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                handle.run_recovery_probe_cycle().await;
+            }
+        });
+    }
+
+    async fn run_recovery_probe_cycle(&self) {
+        let endpoints = self.rpc_endpoints.clone();
+        for (idx, endpoint) in endpoints.iter().enumerate() {
+            let is_unhealthy = self
+                .endpoint_health
+                .get(idx)
+                .and_then(|m| m.lock().ok())
+                .map(|state| !state.healthy)
+                .unwrap_or(false);
+
+            if !is_unhealthy {
+                continue;
+            }
+
+            let probe_url = format!("{}/", endpoint.trim_end_matches('/'));
+            let ok = self
+                .client
+                .get(&probe_url)
+                .timeout(Duration::from_secs(5))
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false);
+
+            debug_assert!(idx < endpoints.len());
+            self.record_result(idx, ok);
+        }
     }
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
@@ -70,7 +261,8 @@ impl HorizonClient {
         &self,
         tx_envelope: &str,
     ) -> SubmissionResult<HorizonTransaction> {
-        let url = format!("{}/transactions", self.pick_endpoint());
+        let (endpoint_idx, endpoint) = self.pick_endpoint();
+        let url = format!("{}/transactions", endpoint);
 
         let mut params = std::collections::HashMap::new();
         params.insert("tx", tx_envelope);
@@ -83,10 +275,15 @@ impl HorizonClient {
             .send()
             .await
             .map_err(|e| {
+                self.record_result(endpoint_idx, false);
                 SubmissionError::HorizonApi(format!("POST /transactions failed: {}", e))
             })?;
 
         let status = response.status();
+        // A response — even an application-level error like tx_bad_seq —
+        // means the endpoint itself is up. Only network failures and 5xx
+        // responses count against the endpoint's health.
+        self.record_result(endpoint_idx, !status.is_server_error());
 
         if status.is_success() {
             let tx: HorizonTransaction = response.json().await.map_err(|e| {
@@ -134,7 +331,8 @@ impl HorizonClient {
         &self,
         tx_hash: &str,
     ) -> SubmissionResult<Option<HorizonTransaction>> {
-        let url = format!("{}/transactions/{}", self.pick_endpoint(), tx_hash);
+        let (endpoint_idx, endpoint) = self.pick_endpoint();
+        let url = format!("{}/transactions/{}", endpoint, tx_hash);
 
         let response = self
             .client
@@ -143,8 +341,11 @@ impl HorizonClient {
             .send()
             .await
             .map_err(|e| {
+                self.record_result(endpoint_idx, false);
                 SubmissionError::HorizonApi(format!("GET /transactions/{{}} failed: {}", e))
             })?;
+
+        self.record_result(endpoint_idx, !response.status().is_server_error());
 
         if response.status() == 404 {
             return Ok(None);
@@ -165,7 +366,8 @@ impl HorizonClient {
 
     /// Get account details including current sequence
     pub async fn get_account_sequence(&self, account_id: &str) -> SubmissionResult<i64> {
-        let url = format!("{}/accounts/{}", self.pick_endpoint(), account_id);
+        let (endpoint_idx, endpoint) = self.pick_endpoint();
+        let url = format!("{}/accounts/{}", endpoint, account_id);
 
         #[derive(Deserialize)]
         struct AccountResponse {
@@ -179,8 +381,11 @@ impl HorizonClient {
             .send()
             .await
             .map_err(|e| {
+                self.record_result(endpoint_idx, false);
                 SubmissionError::HorizonApi(format!("failed to fetch account sequence: {}", e))
             })?;
+
+        self.record_result(endpoint_idx, !response.status().is_server_error());
 
         if response.status().is_success() {
             let account: AccountResponse = response.json().await.map_err(|e| {
@@ -243,5 +448,89 @@ mod tests {
         let client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
             .with_timeout(Duration::from_secs(30));
         assert_eq!(client.request_timeout, Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_circuit_breaks_after_repeated_failures() {
+        let client = HorizonClient::new("https://a.example.com".to_string()).with_rpc_endpoints(
+            vec!["https://a.example.com".to_string(), "https://b.example.com".to_string()],
+        );
+
+        for _ in 0..MIN_SAMPLES_BEFORE_TRIP {
+            client.record_result(0, false);
+        }
+
+        assert!(!client.endpoint_health[0].lock().unwrap().healthy);
+        assert!(client.endpoint_health[1].lock().unwrap().healthy);
+
+        // Rotation must now exclusively favor the healthy endpoint.
+        for _ in 0..10 {
+            let (idx, _) = client.pick_endpoint();
+            assert_eq!(idx, 1, "unhealthy endpoint 0 must be excluded from rotation");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_recovers_after_success_streak() {
+        let client = HorizonClient::new("https://a.example.com".to_string()).with_rpc_endpoints(
+            vec!["https://a.example.com".to_string(), "https://b.example.com".to_string()],
+        );
+
+        for _ in 0..MIN_SAMPLES_BEFORE_TRIP {
+            client.record_result(0, false);
+        }
+        assert!(!client.endpoint_health[0].lock().unwrap().healthy);
+
+        for _ in 0..10 {
+            client.record_result(0, true);
+        }
+
+        assert!(
+            client.endpoint_health[0].lock().unwrap().healthy,
+            "endpoint should recover once its EWMA success rate crosses the recovery threshold"
+        );
+
+        // Both endpoints should now be eligible for rotation.
+        let mut seen_zero = false;
+        for _ in 0..20 {
+            let (idx, _) = client.pick_endpoint();
+            if idx == 0 {
+                seen_zero = true;
+            }
+        }
+        assert!(seen_zero, "recovered endpoint should be back in rotation");
+    }
+
+    #[tokio::test]
+    async fn test_fails_open_when_all_endpoints_unhealthy() {
+        let client = HorizonClient::new("https://a.example.com".to_string()).with_rpc_endpoints(
+            vec!["https://a.example.com".to_string(), "https://b.example.com".to_string()],
+        );
+
+        for idx in 0..2 {
+            for _ in 0..MIN_SAMPLES_BEFORE_TRIP {
+                client.record_result(idx, false);
+            }
+        }
+        assert!(!client.endpoint_health[0].lock().unwrap().healthy);
+        assert!(!client.endpoint_health[1].lock().unwrap().healthy);
+
+        // Every endpoint is circuit-broken — must fail open rather than panic
+        // or return an invalid index.
+        let (idx, _) = client.pick_endpoint();
+        assert!(idx < 2);
+    }
+
+    #[test]
+    fn test_single_endpoint_never_excluded_from_rotation() {
+        let client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string());
+        for _ in 0..MIN_SAMPLES_BEFORE_TRIP {
+            client.record_result(0, false);
+        }
+        // A lone endpoint can't be rotated away from — pick_endpoint must
+        // still return it.
+        let (idx, url) = client.pick_endpoint();
+        assert_eq!(idx, 0);
+        assert_eq!(url, "https://horizon-testnet.stellar.org");
     }
 }

--- a/src/stellar/mod.rs
+++ b/src/stellar/mod.rs
@@ -26,3 +26,7 @@ pub use error::{SubmissionError, SubmissionResult};
 pub use models::*;
 pub use retry_state_machine::RetryStateMachine;
 
+/// Re-export so `crate::stellar::StellarClient` (used by workers/reconciliation.rs)
+/// resolves to the same compatibility shim as `crate::chains::stellar::client::StellarClient`.
+pub use crate::chains::stellar::client::StellarClient;
+

--- a/src/verification/engine.rs
+++ b/src/verification/engine.rs
@@ -2,7 +2,7 @@
 ///
 /// Compares on-chain cNGN supply (Stellar) against off-chain fiat reserves (bank accounts).
 /// Generates HMAC-signed PoR snapshots and alerts on under-collateralisation.
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::verification::repository::VerificationRepository;
 use chrono::Utc;
 use hmac::{Hmac, Mac};

--- a/src/wallet/history.rs
+++ b/src/wallet/history.rs
@@ -1,4 +1,4 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::wallet::repository::{InsertHistoryEntry, TransactionHistoryRepository};
 use anyhow::Result;
 use sqlx::types::BigDecimal;

--- a/src/wallet/portfolio.rs
+++ b/src/wallet/portfolio.rs
@@ -1,4 +1,4 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::wallet::repository::{InsertPortfolioSnapshot, PortfolioRepository};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};

--- a/src/wallet_provisioning/service.rs
+++ b/src/wallet_provisioning/service.rs
@@ -1,6 +1,6 @@
 //! Business logic for Wallet Creation & Stellar Account Provisioning (Issue #322).
 
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::error::Error;
 use crate::wallet_provisioning::{
     bip44::{

--- a/src/workers/bill_processor/refund_handler.rs
+++ b/src/workers/bill_processor/refund_handler.rs
@@ -1,5 +1,5 @@
 use super::types::ProcessingError;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use tracing::{debug, info};
 use uuid::Uuid;
 

--- a/src/workers/bill_processor/worker.rs
+++ b/src/workers/bill_processor/worker.rs
@@ -1,4 +1,4 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::database::bill_payment_repository::{BillPayment, BillPaymentRepository};
 use crate::database::repository::Repository;
 use crate::database::transaction_repository::TransactionRepository;

--- a/src/workers/merchant_payment_monitor.rs
+++ b/src/workers/merchant_payment_monitor.rs
@@ -2,7 +2,7 @@
 //! Monitors Stellar blockchain for incoming payments to merchant addresses
 //! Matches payments to payment intents via memo field
 
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 // REMOVED: use crate::merchant_gateway::repository::PaymentIntentRepository;
 // REMOVED: use crate::merchant_gateway::service::MerchantGatewayService;
 use rust_decimal::Decimal;

--- a/src/workers/offramp_processor.rs
+++ b/src/workers/offramp_processor.rs
@@ -1,5 +1,5 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
-// REMOVED: use crate::chains::stellar::payment::{CngnMemo, CngnPaymentBuilder};
+use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::payment::{CngnMemo, CngnPaymentBuilder};
 use crate::database::error::DatabaseError;
 use crate::database::transaction_repository::{Transaction, TransactionRepository};
 use crate::payments::error::PaymentError;

--- a/src/workers/onramp_processor.rs
+++ b/src/workers/onramp_processor.rs
@@ -15,10 +15,10 @@
 //! optimistic locking (WHERE status = '<expected>').
 
 use crate::audit::mint_log::MintAuditStore;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
-// REMOVED: use crate::chains::stellar::errors::StellarError;
-// REMOVED: use crate::chains::stellar::payment::{CngnMemo, CngnPaymentBuilder};
-// REMOVED: use crate::chains::stellar::trustline::CngnTrustlineManager;
+use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::errors::StellarError;
+use crate::chains::stellar::payment::{CngnMemo, CngnPaymentBuilder};
+use crate::chains::stellar::trustline::CngnTrustlineManager;
 use crate::database::transaction_repository::{Transaction, TransactionRepository};
 use crate::payments::factory::PaymentProviderFactory;
 use crate::payments::types::{PaymentState, ProviderName, StatusRequest};

--- a/src/workers/por_worker.rs
+++ b/src/workers/por_worker.rs
@@ -12,7 +12,7 @@
 
 use crate::audit::models::{AuditActorType, AuditEventCategory, AuditOutcome, PendingAuditEntry};
 use crate::audit::writer::AuditWriter;
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::security::{AnomalyDetectionService, AnomalyType, TenantBalance, MerkleTree};
 use crate::metrics::por::{
     merkle_tree_construction_duration_seconds, proof_anchoring_failures_total,

--- a/src/workers/reconciliation_worker.rs
+++ b/src/workers/reconciliation_worker.rs
@@ -24,7 +24,7 @@ use tokio::time::interval;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 
 // ── Configuration ─────────────────────────────────────────────────────────────
 

--- a/src/workers/stellar_confirmation_worker.rs
+++ b/src/workers/stellar_confirmation_worker.rs
@@ -4,7 +4,7 @@
 //! transitions state to `completed` or `failed`, fires webhook events on every
 //! transition, detects stale transactions, and exposes Prometheus metrics.
 
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::database::webhook_repository::WebhookRepository;
 use prometheus::{register_counter_vec, register_gauge, CounterVec, Gauge, Registry};
 use serde_json::{json, Value as JsonValue};

--- a/src/workers/stellar_submitter_worker.rs
+++ b/src/workers/stellar_submitter_worker.rs
@@ -1,5 +1,5 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
-// REMOVED: use crate::chains::stellar::payment::{CngnMemo, CngnPaymentBuilder};
+use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::payment::{CngnMemo, CngnPaymentBuilder};
 use crate::database::transaction_repository::TransactionRepository;
 use crate::services::mint_queue::{MintQueueService, MintRequest};
 use bigdecimal::BigDecimal;

--- a/src/workers/supply_monitor_worker.rs
+++ b/src/workers/supply_monitor_worker.rs
@@ -1,4 +1,4 @@
-// REMOVED: use crate::chains::stellar::client::StellarClient;
+use crate::chains::stellar::client::StellarClient;
 use crate::services::notification::{NotificationService, NotificationType};
 use sqlx::{types::BigDecimal, PgPool};
 use std::str::FromStr;

--- a/src/workers/transaction_monitor.rs
+++ b/src/workers/transaction_monitor.rs
@@ -1,4 +1,4 @@
-// REMOVED: use crate::chains::stellar::client::{HorizonTransactionRecord, StellarClient};
+use crate::chains::stellar::client::{HorizonTransactionRecord, StellarClient};
 use crate::database::repository::Repository;
 use crate::database::transaction_repository::TransactionRepository;
 use crate::database::webhook_repository::WebhookRepository;


### PR DESCRIPTION
closes #741 
closes #745 
closes #746 
closes #747 




…single-flight panic recovery; restore broken main.rs

Four backlog items:
- stellar/horizon.rs: per-endpoint EWMA success-rate circuit breaking with background recovery probe and aframp_horizon_endpoint_success_rate/healthy metrics, so a failing Horizon node is rotated out instead of continuing to receive traffic.
- cache/: bb8 Redis pool size/idle/pending gauges wired into CacheStatsWorker, a RedisPoolExhaustion alert rule, and pending-connection tracking in RedisCache::get_connection.
- cache/multi_level.rs: MultiLevelCache::invalidate_prefix(_logged) (L1 all shards + L2 SCAN, cache_invalidation_logs audit row, aframp_cache_invalidation_total metric), wired into the corridor admin handlers.
- cache/single_flight.rs: rebuilder wrapped in catch_unwind so a panic can no longer leave a cache key permanently stuck; 30s timeout self-heals a hung (non-panicking) leader.

Unrelated but required prerequisite: src/main.rs did not compile at all before this change (duplicate mod declarations, ~2800 lines of main()'s body sitting outside any function after a bad merge, 7 modules used but undeclared, ~13 blocks of route-wiring for features whose source directories no longer exist). Restored main()'s structure and handler functions from main.rs.backup, and removed the dead route blocks.

Also discovered chains::stellar::client::StellarClient — used by main.rs and 30+ other files — doesn't exist anywhere in the repo. Added a compatibility shim (src/chains/) wrapping stellar::horizon::HorizonClient covering the client/config/error/type surface for ~19 of those files. Deliberately did not attempt to reconstruct chains::stellar::{trustline, payment, burn_transaction_builder} (real XDR transaction-building/signing logic) without a spec or compiler to verify against; the corresponding cNGN trustline/payment routes were removed from main.rs's router since no working handler exists for them yet. Known remaining gap, not resolved here: services/cngn_trustline.rs, services/cngn_payment_builder.rs, services/burn_service.rs, services/batch_processor.rs, api/mint/handler.rs, api/mint/validator.rs.

No Rust toolchain was available in this environment, so none of this has been compiler-verified — run cargo check/test before merging.