### PR TITLE
Fix cache-warming LB restarts, Horizon fee stampede, and unauthentica…

### DIFF
--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,10 +1,21 @@
 //! OpenAPI / Swagger documentation.
 //!
 //! Routes:
-//!   GET /docs              — Swagger UI (non-production only)
-//!   GET /docs/openapi.json — Raw OpenAPI 3.0 JSON (all environments)
+//!   GET /docs              — Swagger UI
+//!   GET /docs/openapi.json — Raw OpenAPI 3.0 JSON
+//!
+//! In production the full API schema (including internal admin endpoint
+//! paths) is sensitive, so both routes require a static bearer token
+//! (`SWAGGER_API_KEY`) in that environment. Dev/staging remain open. Set
+//! `SWAGGER_ENABLED=false` to disable Swagger entirely, in any environment.
 
-use axum::{routing::get, Router};
+use axum::{
+    extract::Request,
+    http::{header, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Router,
+};
 use serde::{Deserialize, Serialize};
 use utoipa::{
     openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
@@ -521,35 +532,232 @@ See the cNGN Integration Guide in `/docs/cngn/` for setup instructions.
 )]
 pub struct ApiDoc;
 
+// ─── Environment / access gating ─────────────────────────────────────────────
+
+/// Current deployment environment, checking `ENVIRONMENT` then falling back
+/// to `APP_ENV` — the same precedence used elsewhere (e.g.
+/// `middleware::security`, `middleware::cors`).
+fn current_environment() -> String {
+    std::env::var("ENVIRONMENT")
+        .or_else(|_| std::env::var("APP_ENV"))
+        .unwrap_or_else(|_| "development".to_string())
+        .to_lowercase()
+}
+
+fn is_production() -> bool {
+    current_environment() == "production"
+}
+
+/// `SWAGGER_ENABLED=false` disables Swagger entirely, in any environment.
+/// Defaults to enabled.
+fn swagger_enabled() -> bool {
+    std::env::var("SWAGGER_ENABLED")
+        .map(|v| v.to_lowercase() != "false")
+        .unwrap_or(true)
+}
+
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.bytes()
+        .zip(b.bytes())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+/// Extract a bearer/API-key style credential from the request: either a
+/// standard `Authorization: Bearer <token>` header, or `X-Swagger-Key:
+/// <token>` for callers that can't easily set an Authorization header
+/// (e.g. a browser navigating to `/docs` directly).
+fn extract_swagger_token(req: &Request) -> Option<String> {
+    if let Some(v) = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    {
+        return Some(v.to_string());
+    }
+    req.headers()
+        .get("x-swagger-key")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.to_string())
+}
+
+/// Gate `/docs` and `/docs/openapi.json` behind `SWAGGER_API_KEY` in
+/// production. Fails closed: if `SWAGGER_API_KEY` isn't configured, every
+/// request is rejected rather than falling open.
+async fn swagger_auth_middleware(req: Request, next: Next) -> Response {
+    let expected = std::env::var("SWAGGER_API_KEY").unwrap_or_default();
+    let provided = extract_swagger_token(&req);
+
+    let authorized = !expected.is_empty()
+        && provided
+            .as_deref()
+            .is_some_and(|p| constant_time_eq(p, &expected));
+
+    if authorized {
+        next.run(req).await
+    } else {
+        (
+            StatusCode::UNAUTHORIZED,
+            [(header::WWW_AUTHENTICATE, "Bearer realm=\"swagger\"")],
+            "Unauthorized",
+        )
+            .into_response()
+    }
+}
+
 // ─── Route Builder ───────────────────────────────────────────────────────────
 
 /// Build the Axum router for OpenAPI documentation endpoints.
 ///
-/// - `GET /docs/openapi.json` is always mounted.
-/// - `GET /docs` (Swagger UI) is only mounted in non-production environments.
+/// - `GET /docs` (Swagger UI) and `GET /docs/openapi.json` are always mounted
+///   together, unless `SWAGGER_ENABLED=false`.
+/// - In production both routes require `Authorization: Bearer <SWAGGER_API_KEY>`
+///   (or an `X-Swagger-Key` header). Dev/staging are unauthenticated.
 pub fn openapi_routes() -> Router {
-    let environment = std::env::var("ENVIRONMENT").unwrap_or_else(|_| "development".to_string());
-    let serve_ui = environment != "production";
+    if !swagger_enabled() {
+        return Router::new();
+    }
 
     let openapi = ApiDoc::openapi();
+    let docs_router = Router::new().merge(SwaggerUi::new("/docs").url("/docs/openapi.json", openapi));
 
-    if serve_ui {
-        Router::new().merge(SwaggerUi::new("/docs").url("/docs/openapi.json", openapi))
+    if is_production() {
+        docs_router.layer(axum::middleware::from_fn(swagger_auth_middleware))
     } else {
-        // In production only serve the raw JSON at /docs/openapi.json
-        let spec_json = openapi.to_json().unwrap_or_else(|_| "{}".to_string());
-        Router::new().route(
+        docs_router
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use tower::ServiceExt;
+
+    // Env vars are process-global and these tests mutate them directly
+    // (matching the existing convention in middleware::cors's tests) — each
+    // test resets everything it touches at the top, so ordering doesn't matter
+    // even though `cargo test` runs them on separate threads within this binary.
+    fn reset_env() {
+        std::env::remove_var("ENVIRONMENT");
+        std::env::remove_var("APP_ENV");
+        std::env::remove_var("SWAGGER_API_KEY");
+        std::env::remove_var("SWAGGER_ENABLED");
+    }
+
+    async fn get(app: Router, uri: &str, auth_header: Option<&str>) -> StatusCode {
+        let mut builder = Request::builder().uri(uri);
+        if let Some(h) = auth_header {
+            builder = builder.header(header::AUTHORIZATION, h);
+        }
+        let response = app.oneshot(builder.body(Body::empty()).unwrap()).await.unwrap();
+        response.status()
+    }
+
+    #[tokio::test]
+    async fn test_production_without_token_returns_401() {
+        reset_env();
+        std::env::set_var("ENVIRONMENT", "production");
+        std::env::set_var("SWAGGER_API_KEY", "secret-token");
+
+        let status = get(openapi_routes(), "/docs/openapi.json", None).await;
+
+        reset_env();
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_production_with_correct_token_is_authorized() {
+        reset_env();
+        std::env::set_var("ENVIRONMENT", "production");
+        std::env::set_var("SWAGGER_API_KEY", "secret-token");
+
+        let status = get(
+            openapi_routes(),
             "/docs/openapi.json",
-            get(move || {
-                let json = spec_json.clone();
-                async move {
-                    (
-                        axum::http::StatusCode::OK,
-                        [("content-type", "application/json")],
-                        json,
-                    )
-                }
-            }),
+            Some("Bearer secret-token"),
         )
+        .await;
+
+        reset_env();
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_production_with_wrong_token_returns_401() {
+        reset_env();
+        std::env::set_var("ENVIRONMENT", "production");
+        std::env::set_var("SWAGGER_API_KEY", "secret-token");
+
+        let status = get(
+            openapi_routes(),
+            "/docs/openapi.json",
+            Some("Bearer wrong-token"),
+        )
+        .await;
+
+        reset_env();
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_production_without_configured_key_fails_closed() {
+        reset_env();
+        std::env::set_var("ENVIRONMENT", "production");
+        // SWAGGER_API_KEY intentionally left unset.
+
+        let status = get(
+            openapi_routes(),
+            "/docs/openapi.json",
+            Some("Bearer anything"),
+        )
+        .await;
+
+        reset_env();
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "must fail closed when no key is configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_development_is_unauthenticated() {
+        reset_env();
+        std::env::set_var("ENVIRONMENT", "development");
+
+        let status = get(openapi_routes(), "/docs/openapi.json", None).await;
+
+        reset_env();
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_swagger_disabled_returns_404_regardless_of_environment() {
+        reset_env();
+        std::env::set_var("ENVIRONMENT", "production");
+        std::env::set_var("SWAGGER_API_KEY", "secret-token");
+        std::env::set_var("SWAGGER_ENABLED", "false");
+
+        let status = get(
+            openapi_routes(),
+            "/docs/openapi.json",
+            Some("Bearer secret-token"),
+        )
+        .await;
+
+        reset_env();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd"));
     }
 }

--- a/src/cache/single_flight.rs
+++ b/src/cache/single_flight.rs
@@ -32,43 +32,105 @@ impl<T: Clone + Send + 'static> SingleFlight<T> {
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<T, String>>,
     {
-        {
-            let map = self.in_flight.lock().await;
-
-            if let Some(tx) = map.get(key) {
-                // Another request is already rebuilding — subscribe and wait.
-                let mut rx = tx.subscribe();
-                drop(map); // release lock before awaiting
-
-                debug!(key, "single-flight: waiting for in-flight rebuild");
-                match rx.recv().await {
-                    Ok(result) => {
-                        return (*result).clone().map_err(|e| e.clone());
-                    }
-                    Err(_) => {
-                        // Sender dropped without sending — treat as miss and rebuild.
-                    }
-                }
-            }
+        enum Role<T> {
+            Waiter(broadcast::Receiver<SharedResult<T>>),
+            Leader(broadcast::Sender<SharedResult<T>>),
         }
 
-        // We are the leader for this key.
-        let (tx, _rx) = broadcast::channel::<SharedResult<T>>(1);
-        let mut map = self.in_flight.lock().await;
-        map.insert(key.to_string(), tx.clone());
-        drop(map); // release lock before doing the expensive rebuild
+        // Check-for-in-flight and register-as-leader happen under a single
+        // lock hold. Splitting them into two separate critical sections (check,
+        // then insert) leaves a race window where multiple concurrent misses
+        // can each conclude they're the leader — exactly the stampede this
+        // type exists to prevent.
+        let role = {
+            let mut map = self.in_flight.lock().await;
+            if let Some(tx) = map.get(key) {
+                Role::Waiter(tx.subscribe())
+            } else {
+                let (tx, _rx) = broadcast::channel::<SharedResult<T>>(1);
+                map.insert(key.to_string(), tx.clone());
+                Role::Leader(tx)
+            }
+        };
 
-        info!(key, "single-flight: leader rebuilding cache entry");
-        let result = rebuild().await;
-        let shared: SharedResult<T> = Arc::new(result.clone().map_err(|e| e.to_string()));
+        match role {
+            Role::Waiter(mut rx) => {
+                debug!(key, "single-flight: waiting for in-flight rebuild");
+                match rx.recv().await {
+                    Ok(result) => (*result).clone().map_err(|e| e.clone()),
+                    Err(_) => Err(format!(
+                        "single-flight leader for {key} ended without producing a result"
+                    )),
+                }
+            }
+            Role::Leader(tx) => {
+                info!(key, "single-flight: leader rebuilding cache entry");
+                let result = rebuild().await;
+                let shared: SharedResult<T> = Arc::new(result.clone().map_err(|e| e.to_string()));
 
-        // Broadcast result to all waiters (ignore send errors — no subscribers is fine).
-        let _ = tx.send(shared);
+                // Broadcast result to all waiters (ignore send errors — no subscribers is fine).
+                let _ = tx.send(shared);
 
-        // Remove from in-flight map.
-        let mut map = self.in_flight.lock().await;
-        map.remove(key);
+                // Remove from in-flight map.
+                let mut map = self.in_flight.lock().await;
+                map.remove(key);
 
-        result
+                result
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn test_concurrent_misses_rebuild_exactly_once() {
+        let sf = SingleFlight::<i32>::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..50)
+            .map(|_| {
+                let sf = sf.clone();
+                let calls = calls.clone();
+                tokio::spawn(async move {
+                    sf.get_or_rebuild("k", || async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                        Ok(42)
+                    })
+                    .await
+                })
+            })
+            .collect();
+
+        for h in handles {
+            assert_eq!(h.await.unwrap().unwrap(), 42);
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "expected exactly one rebuild across all concurrent callers"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_distinct_keys_rebuild_independently() {
+        let sf = SingleFlight::<i32>::new();
+        let a = sf.get_or_rebuild("a", || async { Ok(1) }).await.unwrap();
+        let b = sf.get_or_rebuild("b", || async { Ok(2) }).await.unwrap();
+        assert_eq!((a, b), (1, 2));
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_error_is_propagated() {
+        let sf = SingleFlight::<i32>::new();
+        let result = sf
+            .get_or_rebuild("k", || async { Err("boom".to_string()) })
+            .await;
+        assert_eq!(result, Err("boom".to_string()));
     }
 }

--- a/src/cache/warmer.rs
+++ b/src/cache/warmer.rs
@@ -1,9 +1,14 @@
 //! Cache warming — pre-populates L1 and L2 caches at startup.
 //!
-//! The application readiness gate must not return healthy until warming completes.
+//! Runs as a detached background task (see `main.rs`) so it never blocks the
+//! server from accepting traffic. While warming is in progress the health
+//! endpoint reports a degraded-but-serving `Warming` state with a progress
+//! percentage (`WarmingState::progress_pct`, published as the
+//! `aframp_cache_warmup_progress_pct` gauge) rather than `Unhealthy` — the
+//! previous behavior caused load balancers to restart instances mid-warmup.
 //! Warming duration and entry counts are logged as structured events.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::{error, info, warn};
@@ -14,16 +19,20 @@ use crate::cache::l1::L1Cache;
 use crate::database::exchange_rate_repository::ExchangeRateRepository;
 use crate::database::fee_structure_repository::FeeStructureRepository;
 
-/// Shared flag indicating whether cache warming has completed.
+/// Shared flag indicating whether cache warming has completed, plus a
+/// 0-100 progress counter so the health endpoint and `aframp_cache_warmup_progress_pct`
+/// metric can report partial progress instead of a binary ready/not-ready.
 #[derive(Clone)]
 pub struct WarmingState {
     pub ready: Arc<AtomicBool>,
+    progress_pct: Arc<AtomicU8>,
 }
 
 impl WarmingState {
     pub fn new() -> Self {
         Self {
             ready: Arc::new(AtomicBool::new(false)),
+            progress_pct: Arc::new(AtomicU8::new(0)),
         }
     }
 
@@ -31,7 +40,21 @@ impl WarmingState {
         self.ready.load(Ordering::Acquire)
     }
 
+    /// Current warmup progress, 0-100.
+    pub fn progress_pct(&self) -> u8 {
+        self.progress_pct.load(Ordering::Acquire)
+    }
+
+    /// Update warmup progress (0-100) and publish it to the
+    /// `aframp_cache_warmup_progress_pct` gauge.
+    fn set_progress(&self, pct: u8) {
+        let pct = pct.min(100);
+        self.progress_pct.store(pct, Ordering::Release);
+        crate::metrics::cache::cache_warmup_progress_pct().set(pct as f64);
+    }
+
     pub fn mark_ready(&self) {
+        self.set_progress(100);
         self.ready.store(true, Ordering::Release);
     }
 }
@@ -66,6 +89,10 @@ pub async fn warm_caches(
     let mut total_l1 = 0usize;
     let mut total_l2 = 0usize;
 
+    let total_items = FEE_TYPES.len() + CURRENCY_PAIRS.len();
+    let mut completed_items = 0usize;
+    warming_state.set_progress(0);
+
     // --- L1: fee structures ---
     for fee_type in FEE_TYPES {
         match fee_repo.get_active_by_type(fee_type, None).await {
@@ -86,6 +113,8 @@ pub async fn warm_caches(
                 warn!(fee_type, error = %e, "Failed to warm fee structures for type");
             }
         }
+        completed_items += 1;
+        warming_state.set_progress(((completed_items * 100) / total_items) as u8);
     }
 
     // --- L2: exchange rates for all known currency pairs ---
@@ -107,6 +136,8 @@ pub async fn warm_caches(
                 warn!(from, to, error = %e, "Failed to fetch exchange rate for warming");
             }
         }
+        completed_items += 1;
+        warming_state.set_progress(((completed_items * 100) / total_items) as u8);
     }
 
     let elapsed = start.elapsed();
@@ -123,3 +154,32 @@ pub async fn warm_caches(
 // Allow dead_code for the debug macro used in non-debug builds
 #[allow(unused_imports)]
 use tracing::debug;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_warming_state_starts_not_ready_at_zero_progress() {
+        let ws = WarmingState::new();
+        assert!(!ws.is_ready());
+        assert_eq!(ws.progress_pct(), 0);
+    }
+
+    #[test]
+    fn test_mark_ready_sets_full_progress() {
+        let _ = crate::metrics::registry();
+        let ws = WarmingState::new();
+        ws.mark_ready();
+        assert!(ws.is_ready());
+        assert_eq!(ws.progress_pct(), 100);
+    }
+
+    #[test]
+    fn test_set_progress_clamps_to_100() {
+        let _ = crate::metrics::registry();
+        let ws = WarmingState::new();
+        ws.set_progress(255);
+        assert_eq!(ws.progress_pct(), 100);
+    }
+}

--- a/src/health.rs
+++ b/src/health.rs
@@ -23,6 +23,10 @@ pub struct HealthStatus {
 #[derive(Debug, Serialize, Clone)]
 pub enum HealthState {
     Healthy,
+    /// Cache warming is still in progress. The service is otherwise healthy and
+    /// DOES accept traffic — this is a degraded-but-serving state, distinct from
+    /// `Unhealthy`, so load balancers don't restart the instance mid-warmup.
+    Warming,
     Degraded,
     Unhealthy,
 }
@@ -52,8 +56,33 @@ impl HealthStatus {
         }
     }
 
+    /// Whether the service should be considered up for load-balancer purposes.
+    /// `Warming` counts as healthy: the service accepts traffic while cache
+    /// warmup finishes in the background.
     pub fn is_healthy(&self) -> bool {
-        matches!(self.status, HealthState::Healthy)
+        matches!(self.status, HealthState::Healthy | HealthState::Warming)
+    }
+
+    /// Merge cache-warming state into this health status. Escalates to
+    /// `Warming` only when nothing else has already reported Degraded/Unhealthy,
+    /// so a real dependency failure during warmup is never masked.
+    fn apply_warming(&mut self, ws: &WarmingState) {
+        if !ws.is_ready() {
+            let pct = ws.progress_pct();
+            self.checks.insert(
+                "cache_warming".to_string(),
+                ComponentHealth::warning(
+                    None,
+                    Some(format!("Cache warming in progress ({}%)", pct)),
+                ),
+            );
+            if matches!(self.status, HealthState::Healthy) {
+                self.status = HealthState::Warming;
+            }
+        } else {
+            self.checks
+                .insert("cache_warming".to_string(), ComponentHealth::up(None));
+        }
     }
 }
 
@@ -89,7 +118,8 @@ pub struct HealthChecker {
     db_pool: Option<sqlx::PgPool>,
     cache: Option<RedisCache>,
     stellar_client: Option<StellarClient>,
-    /// Readiness gate: unhealthy until cache warming completes.
+    /// Reports `Warming` (not `Unhealthy`) with progress until cache warming
+    /// completes — the service still accepts traffic throughout.
     pub warming_state: Option<WarmingState>,
     /// Optional replication monitor for circuit-breaker-aware lag checks.
     pub replication_monitor: Option<crate::database::replication_monitor::ReplicationMonitor>,
@@ -110,7 +140,8 @@ impl HealthChecker {
         }
     }
 
-    /// Attach a warming state so the readiness probe blocks until warming is done.
+    /// Attach a warming state so health checks report `Warming` (with progress)
+    /// instead of `Unhealthy` while cache warming is still in progress.
     pub fn with_warming_state(mut self, state: WarmingState) -> Self {
         self.warming_state = Some(state);
         self
@@ -258,19 +289,12 @@ impl HealthChecker {
             HealthState::Unhealthy
         };
 
-        // Readiness gate: report Unhealthy until cache warming completes.
+        // Cache warming: reported as a degraded-but-serving `Warming` state, not
+        // `Unhealthy` — the server accepts traffic immediately on startup and
+        // warms caches in the background (Issue: premature LB restarts during
+        // warmup).
         if let Some(ref ws) = self.warming_state {
-            if !ws.is_ready() {
-                health_status.checks.insert(
-                    "cache_warming".to_string(),
-                    ComponentHealth::down(Some("Cache warming not yet complete".to_string())),
-                );
-                health_status.status = HealthState::Unhealthy;
-            } else {
-                health_status
-                    .checks
-                    .insert("cache_warming".to_string(), ComponentHealth::up(None));
-            }
+            health_status.apply_warming(ws);
         }
 
         health_status
@@ -352,6 +376,45 @@ mod tests {
         assert!(matches!(warning_health.status, ComponentState::Warning));
         assert_eq!(warning_health.response_time_ms, Some(500));
         assert_eq!(warning_health.details, Some("Slow response".to_string()));
+    }
+
+    #[test]
+    fn test_warming_reports_degraded_not_unhealthy() {
+        // Regression test: cache warming in progress must never force
+        // Unhealthy — that causes premature load-balancer restarts.
+        let ws = WarmingState::new();
+        let mut status = HealthStatus::new();
+        status.apply_warming(&ws);
+
+        assert!(matches!(status.status, HealthState::Warming));
+        assert!(status.is_healthy(), "Warming must still accept traffic");
+        let check = status.checks.get("cache_warming").unwrap();
+        assert!(matches!(check.status, ComponentState::Warning));
+        assert!(check.details.as_ref().unwrap().contains("0%"));
+    }
+
+    #[test]
+    fn test_warming_does_not_mask_existing_unhealthy_status() {
+        let ws = WarmingState::new();
+        let mut status = HealthStatus::new();
+        status.status = HealthState::Unhealthy;
+        status.apply_warming(&ws);
+
+        // A real dependency failure must not be overwritten by the warming state.
+        assert!(matches!(status.status, HealthState::Unhealthy));
+    }
+
+    #[test]
+    fn test_warming_ready_reports_healthy() {
+        let _ = crate::metrics::registry(); // mark_ready() publishes the progress gauge
+        let ws = WarmingState::new();
+        ws.mark_ready();
+        let mut status = HealthStatus::new();
+        status.apply_warming(&ws);
+
+        assert!(matches!(status.status, HealthState::Healthy));
+        let check = status.checks.get("cache_warming").unwrap();
+        assert!(matches!(check.status, ComponentState::Up));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,12 @@ fn load_app_config() -> anyhow::Result<config::AppConfig> {
             None
         };
 
-    // --- Cache warming (must complete before traffic is accepted) ---
+    // --- Cache warming ---
+    // Runs in a detached background task so it never blocks server startup —
+    // the listener binds and starts accepting traffic immediately. The health
+    // endpoint reports `Warming` (not `Unhealthy`) with a progress percentage
+    // until `warm_caches` calls `warming_state.mark_ready()`, so load balancers
+    // don't restart the instance mid-warmup (see src/health.rs, src/cache/warmer.rs).
     if let (Some(ref pool), Some(ref redis), Some(ref ml)) =
         (&db_pool, &redis_cache, &shared_ml_cache)
     {
@@ -1869,6 +1874,8 @@ fn validate_production_config() -> anyhow::Result<()> {
     };
 
     // ── OpenAPI / Swagger UI (Issue #114) ────────────────────────────────────
+    // Gating (production auth via SWAGGER_API_KEY, SWAGGER_ENABLED kill switch)
+    // lives in api::openapi::openapi_routes() itself — see src/api/openapi.rs.
     let openapi_routes = api::openapi::openapi_routes();
 
     // ── Remittance Partner routes (Issue #408) ────────────────────────────────

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -12,7 +12,8 @@ pub mod tests;
 
 use prometheus::{
     register_counter_vec_with_registry, register_gauge_vec_with_registry,
-    register_histogram_vec_with_registry, CounterVec, GaugeVec, HistogramVec, Registry,
+    register_gauge_with_registry, register_histogram_vec_with_registry, CounterVec, Gauge,
+    GaugeVec, HistogramVec, Registry,
 };
 use std::sync::OnceLock;
 
@@ -531,6 +532,15 @@ pub mod cache {
     static CDN_CACHE_STATUS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
     static REDIS_MEMORY_USED_BYTES: OnceLock<GaugeVec> = OnceLock::new();
     static REDIS_MAXMEMORY_BYTES: OnceLock<GaugeVec> = OnceLock::new();
+    static CACHE_WARMUP_PROGRESS_PCT: OnceLock<Gauge> = OnceLock::new();
+
+    /// Cache warmup progress, 0-100. Reaches 100 once `WarmingState::mark_ready`
+    /// is called; read by dashboards/alerts to catch stalled warmups.
+    pub fn cache_warmup_progress_pct() -> &'static Gauge {
+        CACHE_WARMUP_PROGRESS_PCT
+            .get()
+            .expect("metrics not initialised")
+    }
 
     pub fn redis_memory_used_bytes() -> &'static GaugeVec {
         REDIS_MEMORY_USED_BYTES.get().expect("metrics not initialised")
@@ -645,6 +655,17 @@ pub mod cache {
                     "aframp_redis_maxmemory_bytes",
                     "Redis maxmemory configured limit in bytes (0 = unlimited)",
                     &["instance"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        CACHE_WARMUP_PROGRESS_PCT
+            .set(
+                register_gauge_with_registry!(
+                    "aframp_cache_warmup_progress_pct",
+                    "Startup cache warmup progress, 0-100",
                     r
                 )
                 .unwrap(),

--- a/src/stellar/fee_engine.rs
+++ b/src/stellar/fee_engine.rs
@@ -3,11 +3,29 @@
 /// Queries Horizon's /fee_stats endpoint to determine network congestion levels
 /// and dynamically adjusts transaction submission fees to guarantee inclusion
 /// within the immediate next ledger.
+///
+/// Concurrent-refresh protection: on cache expiry, many requests can arrive at
+/// once (e.g. after a burst of submissions). Without a guard, all of them would
+/// hit Horizon simultaneously — a stampede. `get_fee_stats` uses the shared
+/// `SingleFlight` guard so only one caller per instance actually calls Horizon;
+/// the rest await that single in-flight fetch. TTLs are jittered per-entry so
+/// multiple instances (and repeated refreshes on the same instance) don't all
+/// expire in lock-step. If Horizon is unreachable, the last-known-good fee
+/// estimate is served instead of failing the caller.
+use crate::cache::single_flight::SingleFlight;
 use crate::stellar::error::{SubmissionError, SubmissionResult};
 use crate::stellar::models::{FeeConfiguration, FeeStats};
 use chrono::{DateTime, Duration, Utc};
+use rand::Rng;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::warn;
+
+/// TTL jitter as a fraction of the base TTL (±20%), applied on every cache
+/// write so entries don't all expire at the same instant.
+const TTL_JITTER_FRACTION: f64 = 0.2;
+
+const SINGLE_FLIGHT_KEY: &str = "fee_stats";
 
 /// Dynamic fee engine with caching and surge pricing
 pub struct DynamicFeeEngine {
@@ -15,11 +33,27 @@ pub struct DynamicFeeEngine {
     cache: Arc<RwLock<FeeCache>>,
     horizon_client: reqwest::Client,
     horizon_url: String,
+    /// Guards concurrent Horizon `/fee_stats` fetches against a stampede.
+    single_flight: Arc<SingleFlight<FeeStats>>,
 }
 
 struct FeeCache {
-    last_stats: Option<(FeeStats, DateTime<Utc>)>,
-    cache_ttl_seconds: i64,
+    last_stats: Option<CachedFeeStats>,
+    base_ttl_seconds: i64,
+}
+
+struct CachedFeeStats {
+    stats: FeeStats,
+    cached_at: DateTime<Utc>,
+    /// Jittered TTL for this entry specifically (computed at write time).
+    ttl_seconds: i64,
+}
+
+/// Apply ±`TTL_JITTER_FRACTION` jitter to a base TTL.
+fn jittered_ttl_seconds(base_seconds: i64) -> i64 {
+    let factor = rand::thread_rng()
+        .gen_range((1.0 - TTL_JITTER_FRACTION)..=(1.0 + TTL_JITTER_FRACTION));
+    ((base_seconds as f64) * factor).round().max(1.0) as i64
 }
 
 impl DynamicFeeEngine {
@@ -29,47 +63,87 @@ impl DynamicFeeEngine {
             config,
             cache: Arc::new(RwLock::new(FeeCache {
                 last_stats: None,
-                cache_ttl_seconds: 10,
+                base_ttl_seconds: 10,
             })),
             horizon_client: reqwest::Client::new(),
             horizon_url,
+            single_flight: SingleFlight::new(),
         }
     }
 
-    /// Query current fee stats from Horizon with caching
+    /// Query current fee stats from Horizon with caching.
+    ///
+    /// Cache expiry triggers at most one concurrent Horizon fetch per instance
+    /// (via `SingleFlight`); if that fetch fails, the last-known-good stats are
+    /// returned instead of propagating the error, provided one exists.
     pub async fn get_fee_stats(&self) -> SubmissionResult<FeeStats> {
-        // Check cache first
-        {
-            let cache = self.cache.read().await;
-            if let Some((stats, cached_at)) = &cache.last_stats {
-                let age = Utc::now().signed_duration_since(*cached_at);
-                if age.num_seconds() < cache.cache_ttl_seconds {
-                    return Ok(stats.clone());
+        if let Some(stats) = self.fresh_cached_stats().await {
+            return Ok(stats);
+        }
+
+        let horizon_client = self.horizon_client.clone();
+        let url = format!("{}/fee_stats", self.horizon_url);
+
+        let fetch_result = self
+            .single_flight
+            .get_or_rebuild(SINGLE_FLIGHT_KEY, || async move {
+                let response = horizon_client
+                    .get(&url)
+                    .timeout(std::time::Duration::from_secs(10))
+                    .send()
+                    .await
+                    .map_err(|e| format!("fee_stats request failed: {}", e))?;
+
+                let stats: FeeStats = response
+                    .json()
+                    .await
+                    .map_err(|e| format!("failed to parse fee_stats response: {}", e))?;
+
+                Ok(stats)
+            })
+            .await;
+
+        match fetch_result {
+            Ok(stats) => {
+                self.store_cached_stats(stats.clone()).await;
+                Ok(stats)
+            }
+            Err(err) => {
+                if let Some(stale) = self.last_known_good().await {
+                    warn!(
+                        error = %err,
+                        "Horizon fee_stats fetch failed; falling back to last-known-good fee estimate"
+                    );
+                    Ok(stale)
+                } else {
+                    Err(SubmissionError::HorizonApi(err))
                 }
             }
         }
+    }
 
-        // Fetch from Horizon
-        let url = format!("{}/fee_stats", self.horizon_url);
-        let response = self
-            .horizon_client
-            .get(&url)
-            .timeout(std::time::Duration::from_secs(10))
-            .send()
-            .await
-            .map_err(|e| SubmissionError::HorizonApi(format!("fee_stats request failed: {}", e)))?;
+    /// Cached stats if present and within their (jittered) TTL.
+    async fn fresh_cached_stats(&self) -> Option<FeeStats> {
+        let cache = self.cache.read().await;
+        let entry = cache.last_stats.as_ref()?;
+        let age = Utc::now().signed_duration_since(entry.cached_at);
+        (age.num_seconds() < entry.ttl_seconds).then(|| entry.stats.clone())
+    }
 
-        let stats: FeeStats = response.json().await.map_err(|e| {
-            SubmissionError::HorizonApi(format!("failed to parse fee_stats response: {}", e))
-        })?;
+    /// Last cached stats regardless of freshness — used as the Horizon-unreachable fallback.
+    async fn last_known_good(&self) -> Option<FeeStats> {
+        let cache = self.cache.read().await;
+        cache.last_stats.as_ref().map(|e| e.stats.clone())
+    }
 
-        // Update cache
-        {
-            let mut cache = self.cache.write().await;
-            cache.last_stats = Some((stats.clone(), Utc::now()));
-        }
-
-        Ok(stats)
+    async fn store_cached_stats(&self, stats: FeeStats) {
+        let mut cache = self.cache.write().await;
+        let ttl_seconds = jittered_ttl_seconds(cache.base_ttl_seconds);
+        cache.last_stats = Some(CachedFeeStats {
+            stats,
+            cached_at: Utc::now(),
+            ttl_seconds,
+        });
     }
 
     /// Calculate optimal submission fee based on current network conditions.
@@ -161,10 +235,19 @@ impl DynamicFeeEngine {
         cache.last_stats = None;
     }
 
+    /// Force the current cache entry (if any) to read as expired, without
+    /// waiting out its TTL in real time. Test-only.
+    #[cfg(test)]
+    pub async fn force_expire_for_test(&self) {
+        let mut cache = self.cache.write().await;
+        if let Some(entry) = cache.last_stats.as_mut() {
+            entry.cached_at = Utc::now() - Duration::seconds(entry.ttl_seconds + 1);
+        }
+    }
+
     /// Get cached fee stats if available
     pub async fn get_cached_stats(&self) -> SubmissionResult<Option<FeeStats>> {
-        let cache = self.cache.read().await;
-        Ok(cache.last_stats.as_ref().map(|(stats, _)| stats.clone()))
+        Ok(self.last_known_good().await)
     }
 }
 
@@ -175,16 +258,42 @@ use sqlx::types::Decimal;
 mod tests {
     use super::*;
 
-    fn create_test_engine() -> DynamicFeeEngine {
-        let config = FeeConfiguration {
+    fn test_fee_config() -> FeeConfiguration {
+        FeeConfiguration {
             base_fee: 100,
             min_fee: 100,
             max_fee: 10_000,
             surge_threshold: 0.8,
             surge_multiplier: 1.5,
             low_capacity_fee: 1_000,
-        };
-        DynamicFeeEngine::new(config, "https://horizon-testnet.stellar.org".to_string())
+        }
+    }
+
+    fn create_test_engine() -> DynamicFeeEngine {
+        DynamicFeeEngine::new(
+            test_fee_config(),
+            "https://horizon-testnet.stellar.org".to_string(),
+        )
+    }
+
+    fn sample_fee_stats_json(last_ledger: i64) -> serde_json::Value {
+        serde_json::json!({
+            "ledger_capacity_usage": "0.5",
+            "last_ledger_base_fee": 100,
+            "last_ledger": last_ledger,
+            "network_capacity_usage": "0.5",
+            "percentile_10_accepted_fee": 100,
+            "percentile_20_accepted_fee": 100,
+            "percentile_30_accepted_fee": 100,
+            "percentile_40_accepted_fee": 100,
+            "percentile_50_accepted_fee": 100,
+            "percentile_60_accepted_fee": 100,
+            "percentile_70_accepted_fee": 100,
+            "percentile_80_accepted_fee": 100,
+            "percentile_90_accepted_fee": 150,
+            "percentile_95_accepted_fee": 200,
+            "percentile_99_accepted_fee": 300
+        })
     }
 
     #[test]
@@ -220,5 +329,147 @@ mod tests {
         let engine = create_test_engine();
         let fee = engine.calculate_fee_with_multiplier(5, 100, 1.0);
         assert_eq!(fee, 500);
+    }
+
+    // ── Horizon stampede protection ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_concurrent_cache_miss_hits_horizon_exactly_once() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/fee_stats"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(150))
+                    .set_body_json(sample_fee_stats_json(12345)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let engine = Arc::new(DynamicFeeEngine::new(test_fee_config(), mock_server.uri()));
+
+        // 20 concurrent callers, all missing a cold cache at once — the
+        // scenario that used to stampede Horizon before SingleFlight was wired in.
+        let handles: Vec<_> = (0..20)
+            .map(|_| {
+                let engine = engine.clone();
+                tokio::spawn(async move { engine.get_fee_stats().await })
+            })
+            .collect();
+
+        for h in handles {
+            let stats = h.await.unwrap().expect("fee stats fetch should succeed");
+            assert_eq!(stats.last_ledger, 12345);
+        }
+
+        let received = mock_server.received_requests().await.unwrap();
+        assert_eq!(
+            received.len(),
+            1,
+            "expected exactly one Horizon request across 20 concurrent callers"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fresh_cache_avoids_refetching_horizon() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/fee_stats"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(sample_fee_stats_json(1)))
+            .mount(&mock_server)
+            .await;
+
+        let engine = DynamicFeeEngine::new(test_fee_config(), mock_server.uri());
+        engine.get_fee_stats().await.unwrap();
+        engine.get_fee_stats().await.unwrap();
+        engine.get_fee_stats().await.unwrap();
+
+        let received = mock_server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1, "fresh cache hits must not re-fetch Horizon");
+    }
+
+    #[tokio::test]
+    async fn test_falls_back_to_last_known_good_when_horizon_unreachable() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_responder = call_count.clone();
+
+        // First request succeeds and populates the cache; every request after
+        // that fails, deterministically (no reliance on wiremock mock-priority
+        // ordering between two separate `Mock`s).
+        Mock::given(method("GET"))
+            .and(path("/fee_stats"))
+            .respond_with(move |_: &wiremock::Request| {
+                if call_count_responder.fetch_add(1, Ordering::SeqCst) == 0 {
+                    ResponseTemplate::new(200).set_body_json(sample_fee_stats_json(999))
+                } else {
+                    ResponseTemplate::new(503)
+                }
+            })
+            .mount(&mock_server)
+            .await;
+
+        let engine = DynamicFeeEngine::new(test_fee_config(), mock_server.uri());
+
+        let first = engine
+            .get_fee_stats()
+            .await
+            .expect("first fetch should succeed and populate the cache");
+        assert_eq!(first.last_ledger, 999);
+
+        engine.force_expire_for_test().await;
+
+        // Horizon now fails every request; the engine must serve the
+        // last-known-good value instead of propagating the error.
+        let second = engine
+            .get_fee_stats()
+            .await
+            .expect("should fall back to last-known-good instead of erroring");
+        assert_eq!(second.last_ledger, 999);
+    }
+
+    #[tokio::test]
+    async fn test_errors_when_horizon_unreachable_and_no_cache_exists() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/fee_stats"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&mock_server)
+            .await;
+
+        let engine = DynamicFeeEngine::new(test_fee_config(), mock_server.uri());
+        let result = engine.get_fee_stats().await;
+        assert!(result.is_err(), "no last-known-good exists, so the error must surface");
+    }
+
+    #[test]
+    fn test_ttl_jitter_stays_within_bounds() {
+        for _ in 0..500 {
+            let ttl = jittered_ttl_seconds(10);
+            assert!((8..=12).contains(&ttl), "jittered ttl {ttl} outside ±20% of base 10s");
+        }
+    }
+
+    #[test]
+    fn test_ttl_jitter_varies() {
+        let samples: std::collections::HashSet<i64> =
+            (0..200).map(|_| jittered_ttl_seconds(100)).collect();
+        assert!(
+            samples.len() > 1,
+            "expected jitter to produce varying TTLs across repeated calls"
+        );
     }
 }


### PR DESCRIPTION
closes #750 
closes #751 
closes #749 
closes #748 




…ted Swagger UI

- health.rs/warmer.rs: cache warming now reports a degraded-but-serving `Warming` health state (with progress %) instead of `Unhealthy`, so load balancers stop restarting instances mid-warmup. Adds the aframp_cache_warmup_progress_pct gauge.
- fee_engine.rs: Horizon /fee_stats fetches are now guarded by SingleFlight, with jittered TTLs and a last-known-good fallback on Horizon failure. Also fixes a real check-then-insert race in cache/single_flight.rs that let concurrent misses each become "leader".
- api/openapi.rs: Swagger UI and the raw OpenAPI JSON now require a SWAGGER_API_KEY bearer token in production (fail-closed if unset), stay open in dev/staging, and can be fully disabled via SWAGGER_ENABLED=false.