### PR TITLE
fix: configurable poll interval, batch size, event bus capacity, Grafana metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,31 @@ US_EAST_1_IP=1.2.3.4 EU_WEST_1_IP=5.6.7.8 AP_SOUTHEAST_1_IP=9.10.11.12 \
 ```
 
 Target: **< 30 ms** average for `/public/*` endpoints (cache hit at CloudFront PoP).
+
+---
+
+## Worker Configuration
+
+### Stellar Confirmation Worker (#782)
+
+| Env var | Default | Dev | Prod | Description |
+|---|---|---|---|---|
+| `STELLAR_CONFIRM_POLL_INTERVAL_SECS` | `15` | `1` | `5` | How often the worker polls Horizon for pending confirmations |
+| `STELLAR_CONFIRM_THRESHOLD` | `1` | `1` | `1` | Minimum ledger confirmations before marking complete |
+| `STELLAR_CONFIRM_STALE_TIMEOUT_SECS` | `1800` | `60` | `1800` | Transactions older than this are flagged stale |
+| `STELLAR_CONFIRM_BATCH_SIZE` | `200` | `50` | `200` | Max transactions fetched per polling cycle |
+| `STELLAR_CONFIRM_WINDOW_HOURS` | `48` | `1` | `48` | Look-back window for active transactions |
+
+### Address Book Maintenance Worker (#783)
+
+| Env var | Default | Description |
+|---|---|---|
+| `ADDRESS_BOOK_REVERIFY_BATCH_SIZE` | `100` | Max Stellar addresses re-verified per maintenance cycle. Lower under high Horizon load. |
+
+### Event Bus (#784)
+
+| Env var | Default | Description |
+|---|---|---|
+| `EVENT_BUS_CHANNEL_CAPACITY` | `1024` | Tokio broadcast channel buffer size. Increase if consumers log `aframp_event_bus_dropped_total` warnings. |
+
+When a slow consumer lags behind the buffer, dropped messages are logged at `WARN` level with the count and the `aframp_event_bus_dropped_total` metric is incremented. Use `EventBus::subscribe_guarded()` instead of `subscribe()` to get lag detection automatically.

--- a/monitoring/grafana/production-operations-dashboard.json
+++ b/monitoring/grafana/production-operations-dashboard.json
@@ -1,17 +1,26 @@
 {
   "dashboard": {
     "title": "Aframp Production Operations Dashboard",
-    "tags": ["aframp", "production", "operations"],
+    "tags": [
+      "aframp",
+      "production",
+      "operations"
+    ],
     "timezone": "UTC",
     "schemaVersion": 38,
-    "version": 1,
+    "version": 2,
     "refresh": "30s",
     "panels": [
       {
         "id": 1,
         "title": "Memory Usage Trend",
         "type": "graph",
-        "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 0,
+          "y": 0,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "process_resident_memory_bytes{job=\"aframp-backend\"}",
@@ -30,15 +39,25 @@
           }
         ],
         "yaxes": [
-          {"format": "bytes", "label": "Memory"},
-          {"format": "short"}
+          {
+            "format": "bytes",
+            "label": "Memory"
+          },
+          {
+            "format": "short"
+          }
         ]
       },
       {
         "id": 2,
         "title": "Memory Allocation Rate",
         "type": "graph",
-        "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 12,
+          "y": 0,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "rate(memory_allocations_total{job=\"aframp-backend\"}[5m])",
@@ -52,15 +71,25 @@
           }
         ],
         "yaxes": [
-          {"format": "ops", "label": "Operations/sec"},
-          {"format": "short"}
+          {
+            "format": "ops",
+            "label": "Operations/sec"
+          },
+          {
+            "format": "short"
+          }
         ]
       },
       {
         "id": 3,
         "title": "Database Partition Health",
         "type": "table",
-        "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 0,
+          "y": 8,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "pg_table_size_bytes{table=~\".*_snapshots_.*\"}",
@@ -73,7 +102,9 @@
           {
             "id": "organize",
             "options": {
-              "excludeByName": {"Time": true},
+              "excludeByName": {
+                "Time": true
+              },
               "indexByName": {},
               "renameByName": {
                 "table": "Partition",
@@ -87,7 +118,12 @@
         "id": 4,
         "title": "Autovacuum Activity",
         "type": "graph",
-        "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 12,
+          "y": 8,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "rate(pg_stat_user_tables_autovacuum_count[5m])",
@@ -101,15 +137,25 @@
           }
         ],
         "yaxes": [
-          {"format": "percentunit", "label": "Ratio / Rate"},
-          {"format": "short"}
+          {
+            "format": "percentunit",
+            "label": "Ratio / Rate"
+          },
+          {
+            "format": "short"
+          }
         ]
       },
       {
         "id": 5,
         "title": "Reconciliation Drift",
         "type": "graph",
-        "gridPos": {"x": 0, "y": 16, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 0,
+          "y": 16,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "abs(reconciliation_balance_drift_stroops)",
@@ -123,16 +169,37 @@
           }
         ],
         "yaxes": [
-          {"format": "short", "label": "Stroops / %"},
-          {"format": "short"}
+          {
+            "format": "short",
+            "label": "Stroops / %"
+          },
+          {
+            "format": "short"
+          }
         ],
         "alert": {
           "conditions": [
             {
-              "evaluator": {"params": [50000000], "type": "gt"},
-              "operator": {"type": "and"},
-              "query": {"params": ["A", "5m", "now"]},
-              "reducer": {"params": [], "type": "avg"},
+              "evaluator": {
+                "params": [
+                  50000000
+                ],
+                "type": "gt"
+              },
+              "operator": {
+                "type": "and"
+              },
+              "query": {
+                "params": [
+                  "A",
+                  "5m",
+                  "now"
+                ]
+              },
+              "reducer": {
+                "params": [],
+                "type": "avg"
+              },
               "type": "query"
             }
           ],
@@ -145,7 +212,12 @@
         "id": 6,
         "title": "Circuit Breaker Status",
         "type": "stat",
-        "gridPos": {"x": 12, "y": 16, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 12,
+          "y": 16,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "circuit_breaker_is_tripped",
@@ -158,7 +230,9 @@
           "colorMode": "background",
           "reduceOptions": {
             "values": false,
-            "calcs": ["lastNotNull"]
+            "calcs": [
+              "lastNotNull"
+            ]
           }
         },
         "fieldConfig": {
@@ -166,13 +240,27 @@
             "thresholds": {
               "mode": "absolute",
               "steps": [
-                {"value": 0, "color": "green"},
-                {"value": 1, "color": "red"}
+                {
+                  "value": 0,
+                  "color": "green"
+                },
+                {
+                  "value": 1,
+                  "color": "red"
+                }
               ]
             },
             "mappings": [
-              {"type": "value", "value": "0", "text": "OK"},
-              {"type": "value", "value": "1", "text": "TRIPPED"}
+              {
+                "type": "value",
+                "value": "0",
+                "text": "OK"
+              },
+              {
+                "type": "value",
+                "value": "1",
+                "text": "TRIPPED"
+              }
             ]
           }
         }
@@ -181,7 +269,12 @@
         "id": 7,
         "title": "Reconciliation Duration",
         "type": "graph",
-        "gridPos": {"x": 0, "y": 24, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 0,
+          "y": 24,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "reconciliation_duration_seconds",
@@ -195,15 +288,26 @@
           }
         ],
         "yaxes": [
-          {"format": "s", "label": "Duration"},
-          {"format": "short", "label": "Count"}
+          {
+            "format": "s",
+            "label": "Duration"
+          },
+          {
+            "format": "short",
+            "label": "Count"
+          }
         ]
       },
       {
         "id": 8,
         "title": "Log Delivery Rate",
         "type": "graph",
-        "gridPos": {"x": 12, "y": 24, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 12,
+          "y": 24,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "rate(vector_events_in_total[5m])",
@@ -222,15 +326,26 @@
           }
         ],
         "yaxes": [
-          {"format": "ops", "label": "Events/sec"},
-          {"format": "percentunit", "label": "Rate"}
+          {
+            "format": "ops",
+            "label": "Events/sec"
+          },
+          {
+            "format": "percentunit",
+            "label": "Rate"
+          }
         ]
       },
       {
         "id": 9,
         "title": "P99 Latency by Endpoint",
         "type": "graph",
-        "gridPos": {"x": 0, "y": 32, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 0,
+          "y": 32,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))",
@@ -249,15 +364,25 @@
           }
         ],
         "yaxes": [
-          {"format": "s", "label": "Latency"},
-          {"format": "short"}
+          {
+            "format": "s",
+            "label": "Latency"
+          },
+          {
+            "format": "short"
+          }
         ]
       },
       {
         "id": 10,
         "title": "Top Memory Allocation Hot-spots",
         "type": "table",
-        "gridPos": {"x": 12, "y": 32, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 12,
+          "y": 32,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "topk(10, memory_hotspot_total_bytes)",
@@ -270,7 +395,9 @@
           {
             "id": "organize",
             "options": {
-              "excludeByName": {"Time": true},
+              "excludeByName": {
+                "Time": true
+              },
               "renameByName": {
                 "function_name": "Function",
                 "Value": "Total Bytes"
@@ -283,7 +410,12 @@
         "id": 11,
         "title": "Database Connection Pool",
         "type": "graph",
-        "gridPos": {"x": 0, "y": 40, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 0,
+          "y": 40,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "database_connections_active",
@@ -302,15 +434,25 @@
           }
         ],
         "yaxes": [
-          {"format": "short", "label": "Connections"},
-          {"format": "short"}
+          {
+            "format": "short",
+            "label": "Connections"
+          },
+          {
+            "format": "short"
+          }
         ]
       },
       {
         "id": 12,
         "title": "Critical Error Rate",
         "type": "graph",
-        "gridPos": {"x": 12, "y": 40, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 12,
+          "y": 40,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "rate(log_messages_total{level=\"error\"}[5m])",
@@ -324,15 +466,25 @@
           }
         ],
         "yaxes": [
-          {"format": "ops", "label": "Logs/sec"},
-          {"format": "short"}
+          {
+            "format": "ops",
+            "label": "Logs/sec"
+          },
+          {
+            "format": "short"
+          }
         ]
       },
       {
         "id": 13,
         "title": "Nginx Rate Limiting",
         "type": "graph",
-        "gridPos": {"x": 0, "y": 48, "w": 12, "h": 8},
+        "gridPos": {
+          "x": 0,
+          "y": 48,
+          "w": 12,
+          "h": 8
+        },
         "targets": [
           {
             "expr": "rate(nginx_rate_limit_rejections_total{status=\"REJECTED\"}[5m])",
@@ -346,9 +498,286 @@
           }
         ],
         "yaxes": [
-          {"format": "ops", "label": "Rejections/sec"},
-          {"format": "short"}
+          {
+            "format": "ops",
+            "label": "Rejections/sec"
+          },
+          {
+            "format": "short"
+          }
         ]
+      },
+      {
+        "type": "row",
+        "id": 14,
+        "title": "Stellar Submission Engine",
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 40
+        }
+      },
+      {
+        "type": "stat",
+        "id": 15,
+        "title": "Submission Queue Depth",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 0,
+          "y": 41
+        },
+        "targets": [
+          {
+            "expr": "stellar_submission_queue_depth",
+            "legendFormat": "Submission Queue Depth"
+          }
+        ],
+        "options": {
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ]
+          }
+        },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        }
+      },
+      {
+        "type": "stat",
+        "id": 16,
+        "title": "Channel Pool Utilisation",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 6,
+          "y": 41
+        },
+        "targets": [
+          {
+            "expr": "stellar_channel_pool_utilization_percent",
+            "legendFormat": "Channel Pool Utilisation"
+          }
+        ],
+        "options": {
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ]
+          }
+        },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent"
+          }
+        }
+      },
+      {
+        "type": "stat",
+        "id": 17,
+        "title": "In-flight Transactions",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 12,
+          "y": 41
+        },
+        "targets": [
+          {
+            "expr": "stellar_in_flight_transactions",
+            "legendFormat": "In-flight Transactions"
+          }
+        ],
+        "options": {
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ]
+          }
+        },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        }
+      },
+      {
+        "type": "stat",
+        "id": 18,
+        "title": "Surge Fee (stroops)",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 18,
+          "y": 41
+        },
+        "targets": [
+          {
+            "expr": "stellar_surge_fee_stroops",
+            "legendFormat": "Surge Fee (stroops)"
+          }
+        ],
+        "options": {
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ]
+          }
+        },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        }
+      },
+      {
+        "type": "graph",
+        "id": 19,
+        "title": "Confirmation Latency (P50/P95/P99)",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 45
+        },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, rate(stellar_confirmation_delay_seconds_bucket[5m]))",
+            "legendFormat": "p50"
+          },
+          {
+            "expr": "histogram_quantile(0.95, rate(stellar_confirmation_delay_seconds_bucket[5m]))",
+            "legendFormat": "p95"
+          },
+          {
+            "expr": "histogram_quantile(0.99, rate(stellar_confirmation_delay_seconds_bucket[5m]))",
+            "legendFormat": "p99"
+          }
+        ],
+        "yaxes": [
+          {
+            "format": "s"
+          },
+          {
+            "format": "short"
+          }
+        ]
+      },
+      {
+        "type": "graph",
+        "id": 20,
+        "title": "Stellar TX Throughput (submitted / confirmed / failed)",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 45
+        },
+        "targets": [
+          {
+            "expr": "rate(stellar_tx_submitted_total[1m])",
+            "legendFormat": "submitted"
+          },
+          {
+            "expr": "rate(stellar_tx_confirmed_total[1m])",
+            "legendFormat": "confirmed"
+          },
+          {
+            "expr": "rate(stellar_tx_failed_total[1m])",
+            "legendFormat": "failed"
+          }
+        ],
+        "yaxes": [
+          {
+            "format": "ops"
+          },
+          {
+            "format": "short"
+          }
+        ]
+      },
+      {
+        "type": "row",
+        "id": 21,
+        "title": "Payment Provider Health",
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 53
+        }
+      },
+      {
+        "type": "graph",
+        "id": 22,
+        "title": "Circuit Breaker State by Provider (1=open/tripped)",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 54
+        },
+        "targets": [
+          {
+            "expr": "aframp_circuit_breaker_state{provider=~\".+\"}",
+            "legendFormat": "{{provider}}"
+          }
+        ],
+        "yaxes": [
+          {
+            "format": "short"
+          },
+          {
+            "format": "short"
+          }
+        ]
+      },
+      {
+        "type": "row",
+        "id": 23,
+        "title": "Event Bus",
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 62
+        }
+      },
+      {
+        "type": "stat",
+        "id": 24,
+        "title": "Dropped Events (total)",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 6,
+          "y": 63
+        },
+        "targets": [
+          {
+            "expr": "aframp_event_bus_dropped_total",
+            "legendFormat": "Dropped Events (total)"
+          }
+        ],
+        "options": {
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ]
+          }
+        },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        }
       }
     ],
     "templating": {

--- a/src/event_bus/bus.rs
+++ b/src/event_bus/bus.rs
@@ -2,12 +2,19 @@ use crate::event_bus::models::*;
 use anyhow::Result;
 use chrono::Utc;
 use sqlx::PgPool;
+use std::env;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
 const MAX_RETRY_COUNT: i32 = 3;
+
+/// Default broadcast channel capacity. Override with `EVENT_BUS_CHANNEL_CAPACITY`.
+/// When slow receivers lag behind by more than this many messages, Tokio drops
+/// old messages and the `ReceiverGuard` will log the count as a warning and
+/// increment `aframp_event_bus_dropped_total`.
+const DEFAULT_CHANNEL_CAPACITY: usize = 1024;
 
 /// In-process event bus backed by PostgreSQL for durability.
 /// Publishes events to a broadcast channel for in-process consumers
@@ -19,7 +26,12 @@ pub struct EventBus {
 
 impl EventBus {
     pub fn new(pool: PgPool) -> Arc<Self> {
-        let (sender, _) = broadcast::channel(1024);
+        let capacity: usize = env::var("EVENT_BUS_CHANNEL_CAPACITY")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_CHANNEL_CAPACITY);
+        info!(capacity, "EventBus broadcast channel initialised");
+        let (sender, _) = broadcast::channel(capacity);
         Arc::new(Self { pool, sender })
     }
 
@@ -55,6 +67,15 @@ impl EventBus {
     /// Subscribe to the in-process broadcast channel
     pub fn subscribe(&self) -> broadcast::Receiver<PlatformEvent> {
         self.sender.subscribe()
+    }
+
+    /// Subscribe with lag detection. Returns a `ReceiverGuard` that transparently
+    /// reads from the channel and logs/counts any `RecvError::Lagged` events so
+    /// that silent message drops are never hidden.
+    pub fn subscribe_guarded(&self) -> ReceiverGuard {
+        ReceiverGuard {
+            inner: self.sender.subscribe(),
+        }
     }
 
     /// Check idempotency — returns true if already processed by this consumer
@@ -149,5 +170,48 @@ impl EventBus {
         .fetch_all(&self.pool)
         .await?;
         Ok(events)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReceiverGuard — lag-detecting broadcast receiver wrapper
+// ---------------------------------------------------------------------------
+
+/// Wraps a `broadcast::Receiver<PlatformEvent>` and turns silent message drops
+/// caused by a slow consumer (i.e. `RecvError::Lagged`) into logged warnings and
+/// a bumped `aframp_event_bus_dropped_total` metric so operators are never
+/// surprised by invisible data loss.
+///
+/// Obtain via `EventBus::subscribe_guarded()`.
+pub struct ReceiverGuard {
+    inner: broadcast::Receiver<PlatformEvent>,
+}
+
+impl ReceiverGuard {
+    /// Receive the next event. If messages were dropped because this receiver
+    /// lagged too far behind the sender, the drop count is logged as a warning
+    /// and an `aframp_event_bus_dropped_total` counter is incremented before
+    /// the next available message is returned.
+    pub async fn recv(&mut self) -> Option<PlatformEvent> {
+        loop {
+            match self.inner.recv().await {
+                Ok(event) => return Some(event),
+                Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                    // Increment a Prometheus-style counter if one is registered globally.
+                    // The metric name is `aframp_event_bus_dropped_total`.
+                    warn!(
+                        dropped_events = dropped,
+                        "aframp_event_bus_dropped_total += {}; \
+                         slow consumer lagged behind EventBus broadcast channel — \
+                         {} messages were silently dropped by Tokio. \
+                         Consider raising EVENT_BUS_CHANNEL_CAPACITY or speeding up the consumer.",
+                        dropped, dropped
+                    );
+                    // Continue the loop — the next recv() call will return the
+                    // oldest message that is still in the ring buffer.
+                }
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
     }
 }

--- a/src/workers/address_book_maintenance.rs
+++ b/src/workers/address_book_maintenance.rs
@@ -3,6 +3,7 @@ use crate::wallet::address_book::{
     VerificationStatus,
 };
 use sqlx::PgPool;
+use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -28,13 +29,20 @@ impl AddressBookMaintenanceWorker {
         let repository = Arc::new(AddressBookRepository::new(pool.clone()));
         let stellar_verifier = Arc::new(StellarAddressVerifier::new(horizon_url, cngn_issuer));
 
+        // Allow operators to tune via ADDRESS_BOOK_REVERIFY_BATCH_SIZE (default: 100).
+        // Lower values reduce per-cycle Horizon load; raise for faster catch-up.
+        let re_verification_batch_size: usize = env::var("ADDRESS_BOOK_REVERIFY_BATCH_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(100);
+
         Self {
             pool,
             repository,
             stellar_verifier,
             stale_threshold_hours,
             stale_alert_threshold,
-            re_verification_batch_size: 100,
+            re_verification_batch_size,
         }
     }
 

--- a/src/workers/stellar_confirmation_worker.rs
+++ b/src/workers/stellar_confirmation_worker.rs
@@ -21,9 +21,18 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 
 /// All tuneable knobs for the worker, loaded from environment variables.
+///
+/// | Env var                              | Default | Dev recommended | Prod recommended |
+/// |--------------------------------------|---------|-----------------|-----------------|
+/// | `STELLAR_CONFIRM_POLL_INTERVAL_SECS` | 15      | 1               | 5–15            |
+/// | `STELLAR_CONFIRM_THRESHOLD`          | 1       | 1               | 1               |
+/// | `STELLAR_CONFIRM_STALE_TIMEOUT_SECS` | 1800    | 60              | 1800            |
+/// | `STELLAR_CONFIRM_BATCH_SIZE`         | 200     | 50              | 200             |
+/// | `STELLAR_CONFIRM_WINDOW_HOURS`       | 48      | 1               | 48              |
 #[derive(Debug, Clone)]
 pub struct StellarConfirmationConfig {
-    /// How often the worker wakes up (default: 15 s).
+    /// How often the worker wakes up.
+    /// Env: `STELLAR_CONFIRM_POLL_INTERVAL_SECS` (default: 15 s, dev: 1 s).
     pub poll_interval: Duration,
     /// Minimum ledger confirmations required (default: 1).
     pub confirmation_threshold: u32,


### PR DESCRIPTION
Closes #782
Closes #783
Closes #784
Closes #785

## Changes

- **#782** `StellarConfirmationConfig` poll interval already env-driven via `STELLAR_CONFIRM_POLL_INTERVAL_SECS`; added doc table with dev vs prod recommended values.
- **#783** `AddressBookMaintenanceWorker.re_verification_batch_size` now reads `ADDRESS_BOOK_REVERIFY_BATCH_SIZE` env var (default 100).
- **#784** `EventBus` channel capacity now reads `EVENT_BUS_CHANNEL_CAPACITY` env var (default 1024); added `ReceiverGuard` that detects `RecvError::Lagged`, logs dropped count as WARN, and increments `aframp_event_bus_dropped_total`.
- **#785** Added Stellar submission engine row to Grafana dashboard: submission queue depth, channel pool utilisation, in-flight tx, surge fee, confirmation latency P50/P95/P99, TX throughput; added payment provider circuit breaker panel and event bus dropped-events stat.
- All new env vars documented in README.