### PR TITLE
Fix atomic month-boundary reset for KYC monthly volume tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,6 +315,11 @@ name = "liquidity_ml_tests"
 path = "tests/liquidity_ml_tests.rs"
 required-features = ["database"]
 
+[[test]]
+name = "kyc_monthly_volume_reset_integration"
+path = "tests/kyc_monthly_volume_reset_integration.rs"
+required-features = ["database"]
+
 # ---------------------------------------------------------------------------
 # Examples
 # ---------------------------------------------------------------------------

--- a/migrations/20270701000000_kyc_monthly_volume_trackers.sql
+++ b/migrations/20270701000000_kyc_monthly_volume_trackers.sql
@@ -1,0 +1,19 @@
+-- Monthly KYC volume tracking, kept separate from kyc_volume_trackers (which is
+-- keyed per calendar day and therefore cannot represent a running monthly total:
+-- a new day gets a new row via ON CONFLICT (consumer_id, date), so the old
+-- per-row `monthly_volume` column silently resets every day instead of every month.
+--
+-- This table holds a single row per consumer. `month_start` records which
+-- calendar month the row's `monthly_volume` belongs to, so a stale row (from a
+-- prior month) can be detected and rolled over atomically -- either lazily, in
+-- the same UPSERT statement that records a transaction, or via an explicit
+-- reset job. See KycRepository::upsert_monthly_volume / reset_stale_monthly_counters.
+CREATE TABLE kyc_monthly_volume_trackers (
+    consumer_id UUID PRIMARY KEY REFERENCES consumers(id) ON DELETE CASCADE,
+    month_start DATE NOT NULL,
+    monthly_volume DECIMAL(20,8) NOT NULL DEFAULT 0,
+    last_reset_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_kyc_monthly_volume_trackers_month_start ON kyc_monthly_volume_trackers(month_start);

--- a/src/database/kyc_repository.rs
+++ b/src/database/kyc_repository.rs
@@ -247,6 +247,68 @@ pub struct KycVolumeTracker {
     pub last_updated: DateTime<Utc>,
 }
 
+/// Running monthly volume for a consumer, tracked as a single row per
+/// consumer (unlike `kyc_volume_trackers`, which gets a new row every day).
+/// `month_start` is the calendar month this row's `monthly_volume` belongs
+/// to; a row whose `month_start` is before the current month is stale and
+/// is treated as (and lazily reset to) zero. See `upsert_monthly_volume`
+/// and `reset_stale_monthly_counters`.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct KycMonthlyVolumeTracker {
+    pub consumer_id: Uuid,
+    pub month_start: chrono::NaiveDate,
+    pub monthly_volume: BigDecimal,
+    pub last_reset_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Well-known PostgreSQL advisory lock key guarding the monthly volume
+/// reset job, so overlapping runs (e.g. two app instances on the same
+/// schedule) don't race each other. Scoped with `pg_try_advisory_xact_lock`,
+/// which auto-releases on commit/rollback.
+const KYC_MONTHLY_VOLUME_RESET_LOCK_KEY: i64 = 0x4b59435f4d5652; // "KYC_MVR" in hex
+
+/// Shared by `KycRepository::upsert_monthly_volume` (standalone) and
+/// `update_volume_tracker` (inside its transaction). A single INSERT ...
+/// ON CONFLICT DO UPDATE: on conflict, PostgreSQL re-evaluates the CASE
+/// against the row as it exists once the row lock is acquired, so this is
+/// atomic even when two callers for the same consumer land on either side
+/// of a month boundary at the same instant.
+async fn upsert_monthly_volume_with<'e, E>(
+    executor: E,
+    consumer_id: Uuid,
+    amount: BigDecimal,
+) -> Result<KycMonthlyVolumeTracker, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_as::<_, KycMonthlyVolumeTracker>(
+        r#"
+        INSERT INTO kyc_monthly_volume_trackers (
+            consumer_id, month_start, monthly_volume, last_reset_at, updated_at
+        ) VALUES ($1, date_trunc('month', now())::date, $2, now(), now())
+        ON CONFLICT (consumer_id) DO UPDATE SET
+            monthly_volume = CASE
+                WHEN kyc_monthly_volume_trackers.month_start < date_trunc('month', now())::date
+                THEN EXCLUDED.monthly_volume
+                ELSE kyc_monthly_volume_trackers.monthly_volume + EXCLUDED.monthly_volume
+            END,
+            month_start = date_trunc('month', now())::date,
+            last_reset_at = CASE
+                WHEN kyc_monthly_volume_trackers.month_start < date_trunc('month', now())::date
+                THEN EXCLUDED.last_reset_at
+                ELSE kyc_monthly_volume_trackers.last_reset_at
+            END,
+            updated_at = EXCLUDED.updated_at
+        RETURNING consumer_id, month_start, monthly_volume, last_reset_at, updated_at
+        "#,
+    )
+    .bind(consumer_id)
+    .bind(amount)
+    .fetch_one(executor)
+    .await
+}
+
 // Database repository for KYC operations
 pub struct KycRepository {
     pool: sqlx::PgPool,
@@ -273,6 +335,7 @@ impl KycRepository {
                 enhanced_due_diligence_active, effective_tier
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING *
+            "#,
         )
         .bind(id)
         .bind(consumer_id)
@@ -294,8 +357,9 @@ impl KycRepository {
             r#"
             SELECT * FROM kyc_records 
             WHERE consumer_id = $1 
-            ORDER BY created_at DESC 
+            ORDER BY created_at DESC
             LIMIT 1
+            "#,
         )
         .bind(consumer_id)
         .fetch_optional(&self.pool)
@@ -318,6 +382,7 @@ impl KycRepository {
                 decision_timestamp = $4, updated_at = $5
             WHERE id = $6
             RETURNING *
+            "#,
         )
         .bind(status)
         .bind(decision_reason)
@@ -342,6 +407,7 @@ impl KycRepository {
             SET tier = $1, effective_tier = $1, updated_at = $2
             WHERE id = $3
             RETURNING *
+            "#,
         )
         .bind(tier)
         .bind(now)
@@ -373,6 +439,7 @@ impl KycRepository {
                 selfie_image_reference, created_at, updated_at
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             RETURNING *
+            "#,
         )
         .bind(id)
         .bind(kyc_record_id)
@@ -396,8 +463,9 @@ impl KycRepository {
         sqlx::query_as::<_, KycDocument>(
             r#"
             SELECT * FROM kyc_documents 
-            WHERE kyc_record_id = $1 
+            WHERE kyc_record_id = $1
             ORDER BY created_at ASC
+            "#,
         )
         .bind(kyc_record_id)
         .fetch_all(&self.pool)
@@ -424,6 +492,7 @@ impl KycRepository {
                 provider_response, metadata, timestamp
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING *
+            "#,
         )
         .bind(id)
         .bind(consumer_id)
@@ -448,8 +517,9 @@ impl KycRepository {
             r#"
             SELECT * FROM kyc_events 
             WHERE consumer_id = $1 
-            ORDER BY timestamp DESC 
+            ORDER BY timestamp DESC
             LIMIT $2
+            "#,
         )
         .bind(consumer_id)
         .bind(limit)
@@ -525,15 +595,17 @@ impl KycRepository {
         let now = Utc::now();
         let today = now.date_naive();
 
-        sqlx::query_as!(
+        let mut tx = self.pool.begin().await?;
+
+        let updated_tracker = sqlx::query_as!(
             KycVolumeTracker,
             r#"
             INSERT INTO kyc_volume_trackers (
-                consumer_id, date, daily_volume, monthly_volume, 
+                consumer_id, date, daily_volume, monthly_volume,
                 transaction_count, last_updated
             ) VALUES ($1, $2, $3, $4, $5, $6)
-            ON CONFLICT (consumer_id, date) 
-            DO UPDATE SET 
+            ON CONFLICT (consumer_id, date)
+            DO UPDATE SET
                 daily_volume = kyc_volume_trackers.daily_volume + EXCLUDED.daily_volume,
                 monthly_volume = kyc_volume_trackers.monthly_volume + EXCLUDED.monthly_volume,
                 transaction_count = kyc_volume_trackers.transaction_count + 1,
@@ -547,8 +619,117 @@ impl KycRepository {
             1i32,
             now
         )
-        .fetch_one(&self.pool)
-        .await
+        .fetch_one(&mut *tx)
+        .await?;
+
+        upsert_monthly_volume_with(&mut *tx, consumer_id, transaction_amount).await?;
+
+        tx.commit().await?;
+
+        Ok(updated_tracker)
+    }
+
+    /// Atomically record `amount` against the consumer's running monthly
+    /// total, transparently rolling the counter over if the stored row
+    /// belongs to a prior month. This is a single INSERT ... ON CONFLICT
+    /// statement, so PostgreSQL's row-level locking serializes concurrent
+    /// callers for the same consumer -- a transaction landing exactly on
+    /// the month boundary either commits before or after a concurrent
+    /// reset/increment, never interleaved with it, so volume can't be
+    /// double-counted or silently dropped.
+    pub async fn upsert_monthly_volume(
+        &self,
+        consumer_id: Uuid,
+        amount: BigDecimal,
+    ) -> Result<KycMonthlyVolumeTracker, sqlx::Error> {
+        upsert_monthly_volume_with(&self.pool, consumer_id, amount).await
+    }
+
+    /// Idempotent batch reset of any monthly volume rows left over from a
+    /// prior month. Not required for correctness (`upsert_monthly_volume`
+    /// self-heals on the next write), but lets reads immediately after a
+    /// month rollover see zero without waiting for that consumer's next
+    /// transaction. Guarded by a PostgreSQL advisory lock so overlapping
+    /// runs (e.g. two app instances on the same schedule) don't do
+    /// redundant work; the UPDATE's WHERE clause re-checks `month_start`
+    /// after acquiring each row's lock, so running it twice in the same
+    /// month is a no-op the second time (0 rows affected).
+    pub async fn reset_stale_monthly_counters(&self) -> Result<u64, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        let lock_acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_xact_lock($1)")
+            .bind(KYC_MONTHLY_VOLUME_RESET_LOCK_KEY)
+            .fetch_one(&mut *tx)
+            .await?;
+
+        if !lock_acquired {
+            tx.rollback().await?;
+            return Ok(0);
+        }
+
+        let result = sqlx::query(
+            r#"
+            UPDATE kyc_monthly_volume_trackers
+            SET monthly_volume = 0,
+                month_start = date_trunc('month', now())::date,
+                last_reset_at = now(),
+                updated_at = now()
+            WHERE month_start < date_trunc('month', now())::date
+            "#,
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Current-month volume used, or zero if the consumer has no row yet
+    /// this month (including a stale row from a prior month that hasn't
+    /// been touched or reset yet).
+    pub async fn get_monthly_volume_used(&self, consumer_id: Uuid) -> Result<BigDecimal, sqlx::Error> {
+        use sqlx::Row;
+
+        let row = sqlx::query(
+            r#"
+            SELECT monthly_volume
+            FROM kyc_monthly_volume_trackers
+            WHERE consumer_id = $1 AND month_start = date_trunc('month', now())::date
+            "#,
+        )
+        .bind(consumer_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some(row) => row.try_get::<BigDecimal, _>("monthly_volume"),
+            None => Ok(BigDecimal::from(0)),
+        }
+    }
+
+    /// Today's daily volume used, or zero if the consumer has no row yet today.
+    pub async fn get_daily_volume_used(&self, consumer_id: Uuid) -> Result<BigDecimal, sqlx::Error> {
+        use sqlx::Row;
+
+        let today = Utc::now().date_naive();
+
+        let row = sqlx::query(
+            r#"
+            SELECT daily_volume
+            FROM kyc_volume_trackers
+            WHERE consumer_id = $1 AND date = $2
+            "#,
+        )
+        .bind(consumer_id)
+        .bind(today)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some(row) => row.try_get::<BigDecimal, _>("daily_volume"),
+            None => Ok(BigDecimal::from(0)),
+        }
     }
 
     pub async fn get_current_limits(
@@ -560,18 +741,20 @@ impl KycRepository {
 
         sqlx::query_as::<_, KycLimits>(
             r#"
-            SELECT 
+            SELECT
                 kr.tier as tier,
                 tdl.max_transaction_amount,
                 tdl.daily_volume_limit,
                 tdl.monthly_volume_limit,
                 COALESCE(vt.daily_volume, '0'::numeric) as daily_volume_used,
-                COALESCE(vt.monthly_volume, '0'::numeric) as monthly_volume_used,
+                COALESCE(mvt.monthly_volume, '0'::numeric) as monthly_volume_used,
                 COALESCE(vt.last_updated, $3) as last_daily_reset,
-                COALESCE(vt.last_updated, $3) as last_monthly_reset
+                COALESCE(mvt.last_reset_at, $3) as last_monthly_reset
             FROM kyc_records kr
             JOIN kyc_tier_definitions tdl ON kr.tier = tdl.tier
             LEFT JOIN kyc_volume_trackers vt ON kr.consumer_id = vt.consumer_id AND vt.date = $1
+            LEFT JOIN kyc_monthly_volume_trackers mvt ON kr.consumer_id = mvt.consumer_id
+                AND mvt.month_start = date_trunc('month', $3::timestamptz)::date
             WHERE kr.consumer_id = $2
             ORDER BY kr.created_at DESC
             LIMIT 1

--- a/src/kyc/limits.rs
+++ b/src/kyc/limits.rs
@@ -267,26 +267,24 @@ impl KycLimitsEnforcer {
         Ok(count as usize)
     }
 
-    /// Reset monthly volume counters (called by scheduled job)
+    /// Reset monthly volume counters left over from a prior month (called by
+    /// scheduled job). This is a proactive convenience, not a correctness
+    /// requirement: `KycRepository::upsert_monthly_volume` already rolls a
+    /// stale counter over atomically the next time a transaction is
+    /// recorded, guarded by PostgreSQL's row-level locking rather than an
+    /// application-level lock. This job just makes the rollover visible to
+    /// reads immediately after the month boundary instead of waiting for a
+    /// consumer's next transaction, and is idempotent -- running it twice in
+    /// the same month is a no-op the second time.
     pub async fn reset_monthly_counters(&self) -> Result<usize, KycLimitsError> {
         info!("Resetting monthly volume counters");
 
-        let today = Utc::now().date_naive();
+        let count = self
+            .repository
+            .reset_stale_monthly_counters()
+            .await
+            .map_err(|e| KycLimitsError::DatabaseError(e.to_string()))?;
 
-        let result = sqlx::query!(
-            r#"
-            UPDATE kyc_volume_trackers 
-            SET monthly_volume = 0, last_updated = $1
-            WHERE date = $2 AND monthly_volume > 0
-            "#,
-            Utc::now(),
-            today
-        )
-        .execute(&self.repository.pool)
-        .await
-        .map_err(|e| KycLimitsError::DatabaseError(e.to_string()))?;
-
-        let count = result.rows_affected();
         info!("Reset monthly counters for {} consumers", count);
 
         // Clear all limits cache
@@ -430,27 +428,19 @@ impl KycLimitsEnforcer {
             }
         }
 
-        // Fallback to database
-        let today = Utc::now().date_naive();
-
-        let result = sqlx::query!(
-            r#"
-            SELECT COALESCE(daily_volume, '0'::numeric) as daily_volume,
-                   COALESCE(monthly_volume, '0'::numeric) as monthly_volume
-            FROM kyc_volume_trackers
-            WHERE consumer_id = $1 AND date = $2
-            "#,
-            consumer_id,
-            today
-        )
-        .fetch_optional(&self.repository.pool)
-        .await
-        .map_err(|e| KycLimitsError::DatabaseError(e.to_string()))?;
-
-        let (daily, monthly) = match result {
-            Some(record) => (record.daily_volume, record.monthly_volume),
-            None => (BigDecimal::from(0), BigDecimal::from(0)),
-        };
+        // Fallback to database. Daily and monthly volumes live in separate
+        // tables (see KycMonthlyVolumeTracker) since a day's row and a
+        // month's row don't share the same reset cadence.
+        let daily = self
+            .repository
+            .get_daily_volume_used(consumer_id)
+            .await
+            .map_err(|e| KycLimitsError::DatabaseError(e.to_string()))?;
+        let monthly = self
+            .repository
+            .get_monthly_volume_used(consumer_id)
+            .await
+            .map_err(|e| KycLimitsError::DatabaseError(e.to_string()))?;
 
         // Update cache
         let volumes_data = serde_json::json!({

--- a/tests/kyc_monthly_volume_reset_integration.rs
+++ b/tests/kyc_monthly_volume_reset_integration.rs
@@ -1,0 +1,179 @@
+//! Integration tests for atomic month-boundary reset of KYC monthly volume
+//! tracking (src/database/kyc_repository.rs, src/kyc/limits.rs).
+//!
+//! These exercise real PostgreSQL row-locking behavior, so they can't be
+//! written as no-DB unit tests: the guarantee under test ("a stale monthly
+//! counter can't be double-counted or lost when a reset races a concurrent
+//! transaction") only exists because of how the UPSERT and reset UPDATE are
+//! phrased against the database, not any client-side logic.
+//!
+//! Run with:
+//!   DATABASE_URL=postgres://... cargo test --test kyc_monthly_volume_reset_integration --features database -- --nocapture
+//!
+//! Each test creates its own consumer and cleans up after itself.
+
+#![cfg(feature = "database")]
+
+use aframp_backend::database::kyc_repository::KycRepository;
+use chrono::Datelike;
+use sqlx::types::BigDecimal;
+use sqlx::{PgPool, Row};
+use std::str::FromStr;
+use uuid::Uuid;
+
+async fn test_pool() -> Result<PgPool, Box<dyn std::error::Error>> {
+    let url = std::env::var("DATABASE_URL")?;
+    let pool = PgPool::connect(&url).await?;
+    Ok(pool)
+}
+
+async fn seed_consumer(pool: &PgPool) -> Result<Uuid, Box<dyn std::error::Error>> {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO consumers (id, name, consumer_type, environment)
+        VALUES ($1, 'kyc monthly volume test consumer', 'backend_microservice', 'testnet')
+        "#,
+    )
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(id)
+}
+
+async fn cleanup(pool: &PgPool, consumer_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM kyc_monthly_volume_trackers WHERE consumer_id = $1")
+        .bind(consumer_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM consumers WHERE id = $1")
+        .bind(consumer_id)
+        .execute(pool)
+        .await;
+}
+
+/// Seed a stale monthly tracker row (as if last written N months ago) so
+/// tests can exercise the rollover path deterministically instead of
+/// waiting for a real month boundary.
+async fn seed_stale_row(
+    pool: &PgPool,
+    consumer_id: Uuid,
+    months_ago: i32,
+    monthly_volume: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    sqlx::query(
+        r#"
+        INSERT INTO kyc_monthly_volume_trackers (consumer_id, month_start, monthly_volume, last_reset_at, updated_at)
+        VALUES (
+            $1,
+            date_trunc('month', now() - ($2 || ' months')::interval)::date,
+            $3,
+            now() - ($2 || ' months')::interval,
+            now() - ($2 || ' months')::interval
+        )
+        "#,
+    )
+    .bind(consumer_id)
+    .bind(months_ago.to_string())
+    .bind(BigDecimal::from_str(monthly_volume)?)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_upserts_across_a_stale_month_roll_over_without_double_counting() -> Result<(), Box<dyn std::error::Error>>
+{
+    let pool = test_pool().await?;
+    let consumer_id = seed_consumer(&pool).await?;
+
+    // Simulate a counter last touched two months ago with a large leftover
+    // balance that must NOT survive into this month's total.
+    seed_stale_row(&pool, consumer_id, 2, "999999.00").await?;
+
+    let repo = KycRepository::new(pool.clone());
+
+    const CONCURRENT_WRITERS: usize = 20;
+    const AMOUNT_PER_WRITER: &str = "10.00";
+
+    let mut handles = Vec::with_capacity(CONCURRENT_WRITERS);
+    for _ in 0..CONCURRENT_WRITERS {
+        let repo_pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            let repo = KycRepository::new(repo_pool);
+            repo.upsert_monthly_volume(consumer_id, BigDecimal::from_str(AMOUNT_PER_WRITER).unwrap())
+                .await
+        }));
+    }
+
+    for handle in handles {
+        handle.await??;
+    }
+
+    let row = sqlx::query("SELECT monthly_volume, month_start FROM kyc_monthly_volume_trackers WHERE consumer_id = $1")
+        .bind(consumer_id)
+        .fetch_one(&pool)
+        .await?;
+
+    let final_volume: BigDecimal = row.try_get("monthly_volume")?;
+    let month_start: chrono::NaiveDate = row.try_get("month_start")?;
+
+    let expected = BigDecimal::from_str(AMOUNT_PER_WRITER)? * BigDecimal::from(CONCURRENT_WRITERS as i64);
+    assert_eq!(
+        final_volume, expected,
+        "monthly volume must equal exactly the sum of concurrent writes after rollover (no double-count, no lost update)"
+    );
+    assert_eq!(
+        month_start,
+        chrono::Utc::now().date_naive().with_day(1).unwrap(),
+        "stale month_start must have rolled over to the current month"
+    );
+
+    // Sanity check via the read path used by limits.rs.
+    let read_back = repo.get_monthly_volume_used(consumer_id).await?;
+    assert_eq!(read_back, expected);
+
+    cleanup(&pool, consumer_id).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn reset_stale_monthly_counters_is_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = test_pool().await?;
+    let consumer_id = seed_consumer(&pool).await?;
+
+    seed_stale_row(&pool, consumer_id, 1, "500.00").await?;
+
+    let repo = KycRepository::new(pool.clone());
+
+    let first_run = repo.reset_stale_monthly_counters().await?;
+    assert_eq!(first_run, 1, "first run should reset the one stale row");
+
+    let row = sqlx::query("SELECT monthly_volume, month_start FROM kyc_monthly_volume_trackers WHERE consumer_id = $1")
+        .bind(consumer_id)
+        .fetch_one(&pool)
+        .await?;
+    let volume: BigDecimal = row.try_get("monthly_volume")?;
+    let month_start: chrono::NaiveDate = row.try_get("month_start")?;
+    assert_eq!(volume, BigDecimal::from(0));
+    assert_eq!(month_start, chrono::Utc::now().date_naive().with_day(1).unwrap());
+
+    let second_run = repo.reset_stale_monthly_counters().await?;
+    assert_eq!(second_run, 0, "re-running in the same month must be a no-op");
+
+    cleanup(&pool, consumer_id).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn fresh_consumer_reads_zero_monthly_volume() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = test_pool().await?;
+    let consumer_id = seed_consumer(&pool).await?;
+
+    let repo = KycRepository::new(pool.clone());
+    let volume = repo.get_monthly_volume_used(consumer_id).await?;
+    assert_eq!(volume, BigDecimal::from(0));
+
+    cleanup(&pool, consumer_id).await;
+    Ok(())
+}


### PR DESCRIPTION
closes #732 
closes #733 
closes #734 
closes #735 

kyc_volume_trackers is keyed by (consumer_id, date), so a new day gets a new row and monthly_volume was silently reset every day instead of every month, independent of any race condition. Add a dedicated kyc_monthly_volume_trackers table (one row per consumer) with an atomic UPSERT that lazily rolls a stale month over on write, plus an idempotent, advisory-lock-guarded batch reset job for proactive resets. Also fixes 8 pre-existing unterminated raw-string SQL literals in kyc_repository.rs that left the file unparseable.