### PR TITLE
Fix/monitoring and worker issues

### DIFF
--- a/migrations/20270702000000_audit_events_autovacuum_tuning.sql
+++ b/migrations/20270702000000_audit_events_autovacuum_tuning.sql
@@ -1,0 +1,13 @@
+-- Tune autovacuum for high-write tables so dead tuples are reclaimed before
+-- they cause table bloat. Default autovacuum_vacuum_scale_factor (20% of the
+-- table) is far too high for a table that accumulates dead tuples as
+-- rapidly as audit_events; lower the scale factor/threshold and raise the
+-- cost limit so autovacuum runs more often and completes faster.
+
+ALTER TABLE audit_events SET (
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 1000,
+    autovacuum_analyze_scale_factor = 0.02,
+    autovacuum_analyze_threshold = 1000,
+    autovacuum_vacuum_cost_limit = 2000
+);

--- a/src/database/refresh_token_repository.rs
+++ b/src/database/refresh_token_repository.rs
@@ -203,6 +203,53 @@ impl RefreshTokenRepository {
         Ok(result.rows_affected() > 0)
     }
 
+    /// Atomically claim a refresh token for rotation and return whether the
+    /// caller won the race.
+    ///
+    /// `mark_as_used` alone is safe against concurrent UPDATEs on the same
+    /// row, but callers that first check token state (e.g. `is_used`) via a
+    /// separate, unlocked SELECT and only call `mark_as_used` afterwards
+    /// leave a window where two concurrent requests can both pass the
+    /// initial check before either claims the row. This method takes an
+    /// explicit row lock (`SELECT ... FOR UPDATE`) and performs the
+    /// active -> used transition in the same transaction, so only one of two
+    /// concurrent callers for the same token_id can ever return `true`.
+    pub async fn claim_token_for_rotation(&self, token_id: &str) -> DbResult<bool> {
+        let now = Utc::now();
+        let mut tx = self.db.begin().await.map_err(DatabaseError::from_sqlx)?;
+
+        let locked_status: Option<(String,)> = sqlx::query_as(
+            "SELECT status FROM refresh_tokens WHERE token_id = $1 FOR UPDATE",
+        )
+        .bind(token_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(DatabaseError::from_sqlx)?;
+
+        let claimed = match locked_status {
+            Some((status,)) if status == "active" => {
+                sqlx::query(
+                    r#"
+                    UPDATE refresh_tokens
+                    SET status = 'used', last_used_at = $1, updated_at = $2
+                    WHERE token_id = $3
+                    "#,
+                )
+                .bind(now)
+                .bind(now)
+                .bind(token_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(DatabaseError::from_sqlx)?;
+                true
+            }
+            _ => false,
+        };
+
+        tx.commit().await.map_err(DatabaseError::from_sqlx)?;
+        Ok(claimed)
+    }
+
     /// Set replacement token for rotation
     pub async fn set_replacement(
         &self,

--- a/src/database/replication_monitor.rs
+++ b/src/database/replication_monitor.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use sqlx::PgPool;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::database::metrics as db_metrics;
 
@@ -85,7 +85,16 @@ impl ReplicationMonitor {
                 self.inner.breaker_open.store(false, Ordering::Relaxed);
             }
             Err(e) => {
-                warn!(replica=%self.inner.replica_label, "Replication lag query failed: {e}");
+                // pg_stat_replication only exists on the primary. If this monitor is
+                // pointed at a replica (or the query fails for any other reason), we
+                // cannot verify lag is within bounds — fail safe by opening the
+                // breaker instead of silently keeping the last-known (possibly
+                // healthy) state, which would give a false healthy signal.
+                self.inner.breaker_open.store(true, Ordering::Relaxed);
+                error!(
+                    replica=%self.inner.replica_label,
+                    "Replication lag query failed — opening circuit breaker (fail-safe): {e}"
+                );
             }
         }
     }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -21,5 +21,6 @@ pub mod stellar_submitter_worker;
 pub mod supply_monitor_worker;
 pub mod transaction_monitor;
 pub mod webhook_retry;
+pub mod partition_maintenance_worker;
 pub mod payment_reconciliation_worker;
 pub mod supervisor;

--- a/src/workers/partition_maintenance_worker.rs
+++ b/src/workers/partition_maintenance_worker.rs
@@ -1,0 +1,43 @@
+//! Partition Maintenance Worker
+//!
+//! Migration `20270630000000_automated_maintenance_partitioning.sql` defines
+//! `create_future_partitions(table, days_ahead)` and only schedules it via
+//! `pg_cron` when that extension is installed. Managed Postgres instances
+//! without `pg_cron` (or with it disabled) would silently never create new
+//! partitions ahead of time, so this worker is an application-side fallback
+//! that calls the same SQL function on a daily interval.
+
+use sqlx::PgPool;
+use std::time::Duration;
+use tokio::time::interval;
+use tracing::{error, info};
+
+/// Tables managed by `create_future_partitions`, see the partitioning migration.
+const PARTITIONED_TABLES: &[&str] = &["risk_exposure_snapshots", "partner_performance_logs"];
+
+/// How many days of partitions to keep pre-created.
+const DAYS_AHEAD: i32 = 7;
+
+/// Run the partition maintenance loop forever, creating upcoming partitions
+/// once per day.
+pub async fn run(pool: PgPool) {
+    let mut ticker = interval(Duration::from_secs(24 * 60 * 60));
+    loop {
+        ticker.tick().await;
+        for table in PARTITIONED_TABLES {
+            match sqlx::query_scalar::<_, i32>("SELECT create_future_partitions($1, $2)")
+                .bind(table)
+                .bind(DAYS_AHEAD)
+                .fetch_one(&pool)
+                .await
+            {
+                Ok(created) => {
+                    info!(table = %table, partitions_created = created, "Partition maintenance run complete");
+                }
+                Err(e) => {
+                    error!(table = %table, "Failed to create future partitions: {e}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #766
closes #767
closes #768 
closes #769 
src/database/replication_monitor.rs queries pg_stat_replication which only exists on the primary. If the monitor is accidentally pointed at a replica, the query returns an error that is silently swallowed (warn! log only), giving a false healthy signal.

High-write tables like audit_events accumulate dead tuples rapidly. While PostgreSQL autovacuum handles this, the aggressive write pattern may overwhelm default autovacuum settings, causing table bloat.

Migration 20270630000000_automated_maintenance_partitioning.sql defines partitioning logic for high-volume tables, but there is no application-side worker that creates new partitions ahead of time.