### PR TITLE
fix: all issues

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,6 +51,7 @@ jobs:
       ci: ${{ steps.filter.outputs.ci }}
       openapi: ${{ steps.filter.outputs.openapi }}
       config: ${{ steps.filter.outputs.config }}
+      stellar: ${{ steps.filter.outputs.stellar }}
     steps:
       - uses: actions/checkout@v4
       - name: Detect changed paths
@@ -79,6 +80,11 @@ jobs:
               - 'config/production.toml'
               - 'k8s/production/configmap.yaml'
               - 'scripts/detect_config_drift.py'
+            stellar:
+              - 'src/stellar/**'
+              - 'src/chains/stellar/**'
+              - 'benches/xdr_parser.rs'
+              - 'scripts/compare_benchmarks.py'
 
   # ── Formatting ──────────────────────────────────────────────────────────────
   fmt:
@@ -247,6 +253,51 @@ jobs:
         run: |
           cargo install cargo-audit --locked
           cargo audit
+
+  # ── Performance benchmarks (Stellar XDR parser) ─────────────────────────────
+  benchmarks:
+    name: Benchmarks (cargo bench)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.stellar == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-bench-
+      - name: Run xdr_parser benchmarks
+        run: |
+          cargo bench --bench xdr_parser --features database -- --output-format bencher \
+            | tee bench_current.txt
+      - name: Compare against stored baseline (fail on >10% regression)
+        run: |
+          set +e
+          python3 scripts/compare_benchmarks.py \
+            --baseline test_snapshots/benchmarks/xdr_parser.bench.txt \
+            --current bench_current.txt \
+            --threshold-pct 10
+          status=$?
+          # Exit code 2 = no baseline committed yet; warn instead of blocking
+          # unrelated PRs until a maintainer generates one on real hardware
+          # (see test_snapshots/benchmarks/README.md). Exit code 1 = an
+          # actual regression against an existing baseline, which must fail.
+          if [ "$status" -eq 2 ]; then
+            echo "::warning::no benchmark baseline committed yet — see test_snapshots/benchmarks/README.md"
+            exit 0
+          fi
+          exit $status
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xdr-parser-benchmarks-${{ github.run_number }}
+          path: bench_current.txt
 
   # ── Integration tests ───────────────────────────────────────────────────────
   integration-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [Unreleased]
+
+### Evaluated, blocked
+
+- **Soroban SDK upgrade (`soroban-sdk` 21.0.0 → 27.0.2, `stellar-xdr` 25.0.0 →
+  27.0.0, `stellar-strkey` 0.0.16 → 0.0.18)**: evaluated but not performed. The
+  pinned `soroban-sdk` is six protocol versions behind current mainnet
+  (Protocol 27, live since 2026-06-18) and is already on a different protocol
+  era than the separately-pinned `stellar-xdr`. Protocol 22 ("Auth Next")
+  changed contract authorization in a way that affects this repo's
+  `EscrowContract` (`src/lib.rs`, `require_auth` call sites). A safe upgrade
+  needs a Rust toolchain to compile and test each intermediate version and
+  testnet access to re-verify the contract under the new auth semantics —
+  neither was available in the environment this evaluation ran in, so the
+  version bump was not attempted rather than land unverified. Full findings
+  and a recommended step-by-step upgrade path:
+  see [`docs/soroban-sdk-upgrade-evaluation.md`](docs/soroban-sdk-upgrade-evaluation.md).
+
+### Added
+
+- CI now runs the `benches/xdr_parser.rs` Criterion benchmarks on every PR
+  touching `src/stellar/`, `src/chains/stellar/`, or the benchmark itself, and
+  fails the build if any benchmark regresses by more than 10% against the
+  committed baseline in `test_snapshots/benchmarks/` (see
+  `.github/workflows/ci-cd.yml`'s `benchmarks` job and
+  `scripts/compare_benchmarks.py`). Baseline generation is documented in
+  `test_snapshots/benchmarks/README.md`; the job only warns, rather than
+  failing the build, until that baseline is committed.
+- `src/chains/stellar/xdr_parser.rs`: a zero-copy parser for the header
+  fields of a `TransactionV1Envelope` (envelope type, source account, fee,
+  sequence number, preconditions, memo), backing the above benchmark. The
+  benchmark file referenced this module and a `Bitmesh_backend` crate alias
+  before this change; neither existed, so `cargo bench` could not previously
+  compile.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,6 +334,15 @@ path = "examples/stellar_demo.rs"
 required-features = ["database"]
 
 # ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+[[bench]]
+name = "xdr_parser"
+path = "benches/xdr_parser.rs"
+harness = false
+required-features = ["database"]
+
+# ---------------------------------------------------------------------------
 # Dev dependencies
 # ---------------------------------------------------------------------------
 [dev-dependencies]
@@ -349,3 +358,4 @@ bigdecimal  = "0.4"
 proptest    = "1.4"
 base64      = "0.22.1"
 uuid        = { version = "1.6", features = ["v4"] }
+criterion   = "0.5"

--- a/benches/xdr_parser.rs
+++ b/benches/xdr_parser.rs
@@ -9,7 +9,7 @@ use bytes::BufMut;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 // Re-use the parser directly from the library crate.
-use Bitmesh_backend::chains::stellar::xdr_parser::{
+use aframp_backend::chains::stellar::xdr_parser::{
     parse_envelope, pool::BufferPool, ENVELOPE_TYPE_TX, MIN_TX_V1_LEN,
 };
 

--- a/docs/soroban-sdk-upgrade-evaluation.md
+++ b/docs/soroban-sdk-upgrade-evaluation.md
@@ -1,0 +1,114 @@
+# Soroban / Stellar XDR SDK upgrade evaluation
+
+Status: **blocked** — not attempted in this change. See "Why this is blocked, not just deferred" below.
+
+## Current state (Cargo.toml)
+
+| Crate            | Pinned version | Corresponds to  |
+|------------------|----------------|-----------------|
+| `soroban-sdk`    | `21.0.0`       | Protocol 21 (mainnet since 2024-06-18) |
+| `stellar-xdr`    | `25.0.0`       | Protocol 25 (mainnet since 2026-01-22) |
+| `stellar-strkey` | `0.0.16`       | latest published is `0.0.18` |
+| `stellar_sdk`    | `0.1.4`        | latest published is also `0.1.4` (community Horizon client, not protocol-versioned) |
+
+Current mainnet protocol as of 2026-07-27 is **Protocol 27** (since 2026-06-18). Official
+Stellar version-mapping (developers.stellar.org/docs/networks/software-versions):
+
+| Protocol | Mainnet date | Rust XDR | Soroban Rust SDK |
+|----------|--------------|----------|-------------------|
+| 21       | 2024-06-18   | v21.0.1  | 21.0.1-preview.3  |
+| 22       | 2024-12-05   | v22.0.0  | v22.0.3           |
+| 23       | 2025-09-03   | v23.0.0  | v23.0.2           |
+| 24       | 2025-10-22   | 24.0.1   | 23.0.3            |
+| 25       | 2026-01-22   | 25.0.0   | 25.0.0            |
+| 26       | 2026-05-06   | 26.0.1   | 26.0.1            |
+| 27       | 2026-06-18   | v27.0    | 27.0.2            |
+
+Two separate problems fall out of this:
+
+1. **`soroban-sdk` is 6 protocol versions stale** (21 → 27). This is the crate that
+   compiles `src/lib.rs`'s `EscrowContract` (`#[contract]`/`#[contractimpl]`, gated
+   `#[cfg(not(feature = "database"))]`) to wasm for on-chain deployment.
+2. **`soroban-sdk` and `stellar-xdr` are pinned to different protocol eras** (21 vs.
+   25) *right now*, independent of any upgrade. `soroban-sdk` 21.0.0's own internal
+   XDR/env dependencies (`soroban-env-host`/`soroban-env-guest`) are exact-pinned to
+   `=21.0.0`, while this crate separately depends on `stellar-xdr 25.0.0` directly
+   (feature `database`, used in `src/chains/stellar`, `src/stellar`, etc. for
+   Horizon-side XDR handling). These are disjoint dependency subgraphs today (the
+   `database` feature is `no_std`-excluded from the contract build, so they don't
+   collide inside a single compiled artifact), but it means "the XDR types this repo
+   uses for wallet/Horizon code" and "the XDR types the on-chain contract compiles
+   against" already disagree on wire format by 4 protocol versions. Any future code
+   that bridges the two (e.g., decoding a contract invocation's XDR on the server
+   side using the same struct shapes the contract emits) is at risk of silent
+   mismatches today, before touching the SDK-27 question at all.
+
+## What changed between the pinned version and current (22 → 27)
+
+- **Protocol 22 ("Auth Next")**: reworked contract authorization — nonce handling
+  moved from auto-incrementing to random per-signature values, and the
+  authorization-entry XDR shape changed. This is **breaking for any contract that
+  calls `require_auth`/`require_auth_for_args`**, which `EscrowContract` does in
+  `initialize`, `set_admin`, `set_fee_rate`, `pause`, `unpause`, and (per the
+  contract's purpose) presumably the order-lifecycle methods later in the file.
+  Source-level call sites (`admin.require_auth()`) are unlikely to need code
+  changes, but the authorization *proofs* clients submit against this contract
+  change shape, and existing integration/e2e tests or SDKs that construct auth
+  entries manually will need updating.
+- **Protocols 23–27**: state archival / TTL extension changes, stellar-core version
+  bumps, and further host-function additions across each release. I have not
+  itemized these line-by-line — doing so accurately requires the released
+  changelogs for `rs-soroban-env` and `rs-stellar-xdr` at each intermediate tag,
+  cross-referenced against actual usage in this contract, which is exactly the
+  verification step this evaluation is blocked on (see below).
+
+## Why this is blocked, not just deferred
+
+This session has no Rust toolchain available (`cargo`/`rustc` are not installed in
+this sandbox), so none of the following — required before landing a bump this size
+— could be done here:
+
+- Compile `EscrowContract` against `soroban-sdk 27.0.2` and fix any breakage.
+- Compile the `database`-feature server build against `stellar-xdr 27.0.0` /
+  `stellar-strkey 0.0.18` and fix any breakage in `src/chains/stellar`,
+  `src/stellar`, `src/multisig/xdr_builder.rs`, and the new
+  `src/chains/stellar/xdr_parser.rs`.
+- Run the integration test suite (`cargo test --tests --all-features`) end to end.
+- Redeploy/re-test the escrow contract against testnet under Auth Next semantics.
+
+Bumping the version strings in `Cargo.toml` without being able to do the above would
+just push an unverified, likely-broken build onto whoever runs CI next. Given the
+6-version jump crosses at least one confirmed breaking change (Auth Next) directly
+affecting this contract's `require_auth` calls, that risk is not acceptable to take
+blind.
+
+## Recommended path forward (for whoever picks this up with a working toolchain)
+
+1. Fix the pre-existing mismatch first and separately: decide whether the
+   `database`-feature `stellar-xdr`/`stellar-strkey` pins should track the same
+   protocol as `soroban-sdk`, and record that decision — don't let the two drift
+   further apart while the SDK bump is pending.
+2. Upgrade `soroban-sdk` one major/protocol version at a time (21 → 22 → 23 → 24 →
+   25 → 26 → 27), running `cargo check --no-default-features` (the contract is built
+   with `database` off) after each step, rather than jumping straight to 27 — this
+   isolates which protocol's changes caused which compile error instead of debugging
+   all of them at once.
+3. Pay special attention at the 22 step to `require_auth`/`require_auth_for_args`
+   call sites and any test helper that constructs `soroban_sdk::testutils::Address`
+   auth entries by hand.
+4. Once compiling, bump `stellar-xdr` to `27.0.0` and `stellar-strkey` to `0.0.18`
+   together (`database` feature) and run the full integration suite.
+5. Leave `stellar_sdk = "0.1.4"` as-is — it's already the newest version published
+   for that crate; there is nothing to upgrade to.
+6. Redeploy `EscrowContract` to testnet and exercise the full order lifecycle before
+   considering this done — Auth Next changes the shape of authorization but not, as
+   far as this evaluation could determine without a toolchain, the Rust-level call
+   sites, so a compile pass alone would not be sufficient evidence of correctness.
+
+## Sources
+
+- [Software Versions — Stellar Docs](https://developers.stellar.org/docs/networks/software-versions)
+- [soroban-sdk — crates.io](https://crates.io/crates/soroban-sdk)
+- [stellar-xdr — crates.io](https://crates.io/crates/stellar-xdr)
+- [stellar-strkey — crates.io](https://crates.io/crates/stellar-strkey)
+- [stellar_sdk — crates.io](https://crates.io/crates/stellar_sdk)

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Compare `cargo bench --output-format bencher` output against a committed
+baseline and fail if any benchmark regressed by more than a threshold.
+
+Used by the `benchmarks` CI job (.github/workflows/ci-cd.yml) to gate PRs
+touching src/stellar/ or src/chains/stellar/ against performance
+regressions in the zero-copy XDR parser (benches/xdr_parser.rs).
+
+Usage:
+    compare_benchmarks.py --baseline PATH --current PATH --threshold-pct N
+
+Baseline/current files are in libtest "bencher" format, e.g.:
+    test parse_envelope/tx_v1_minimal ... bench:          45 ns/iter (+/- 3)
+
+To (re)generate the baseline locally:
+    cargo bench --bench xdr_parser --features database -- --output-format bencher \\
+        | tee test_snapshots/benchmarks/xdr_parser.bench.txt
+
+Review the diff carefully before committing -- an unexpected improvement or
+regression in the numbers usually means something changed in the parser,
+not just machine noise.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+LINE_RE = re.compile(r"^test\s+(\S+)\s+\.\.\.\s+bench:\s*([\d,]+)\s*ns/iter")
+
+
+def parse_bencher_output(text: str) -> dict[str, int]:
+    results: dict[str, int] = {}
+    for line in text.splitlines():
+        m = LINE_RE.match(line.strip())
+        if m:
+            name, ns = m.group(1), int(m.group(2).replace(",", ""))
+            results[name] = ns
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--current", required=True, type=Path)
+    parser.add_argument("--threshold-pct", required=True, type=float)
+    args = parser.parse_args()
+
+    if not args.current.exists() or not args.current.read_text().strip():
+        print(f"::error::no benchmark output found at {args.current}")
+        return 1
+
+    current = parse_bencher_output(args.current.read_text())
+    if not current:
+        print(f"::error::could not parse any benchmark results from {args.current}")
+        return 1
+
+    if not args.baseline.exists():
+        print(
+            f"::error::no baseline found at {args.baseline}. A maintainer must run "
+            "the benchmarks locally (real hardware, not a shared CI runner, to keep "
+            "the baseline stable) and commit the result:\n"
+            "  cargo bench --bench xdr_parser --features database -- "
+            f"--output-format bencher | tee {args.baseline}"
+        )
+        print("\nCurrent run's results, for reference:")
+        for name, ns in sorted(current.items()):
+            print(f"  {name}: {ns} ns/iter")
+        return 2
+
+    baseline = parse_bencher_output(args.baseline.read_text())
+    if not baseline:
+        print(f"::error::could not parse any benchmark results from {args.baseline}")
+        return 1
+
+    failures = []
+    for name, current_ns in sorted(current.items()):
+        baseline_ns = baseline.get(name)
+        if baseline_ns is None:
+            print(f"::notice::'{name}' has no baseline entry yet (new benchmark)")
+            continue
+        allowed = baseline_ns * (1 + args.threshold_pct / 100)
+        delta_pct = (current_ns - baseline_ns) / baseline_ns * 100
+        status = "REGRESSION" if current_ns > allowed else "OK"
+        if status == "REGRESSION":
+            failures.append((name, baseline_ns, current_ns, delta_pct))
+        print(
+            f"  {name}: {current_ns} ns/iter (baseline {baseline_ns} ns/iter, "
+            f"{delta_pct:+.1f}%) [{status}]"
+        )
+
+    if failures:
+        print(f"\n::error::{len(failures)} benchmark(s) regressed by more than {args.threshold_pct}%:")
+        for name, baseline_ns, current_ns, delta_pct in failures:
+            print(f"  - {name}: {baseline_ns} -> {current_ns} ns/iter ({delta_pct:+.1f}%)")
+        return 1
+
+    print(f"\nAll benchmarks within {args.threshold_pct}% of baseline.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/chains/stellar/mod.rs
+++ b/src/chains/stellar/mod.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod config;
 pub mod errors;
 pub mod types;
+pub mod xdr_parser;
 
 pub use client::StellarClient;
 pub use config::StellarConfig;

--- a/src/chains/stellar/xdr_parser.rs
+++ b/src/chains/stellar/xdr_parser.rs
@@ -1,0 +1,290 @@
+//! Zero-copy parser for the header fields of a Stellar `TransactionV1Envelope`
+//! (issue #345). Benchmarked in `benches/xdr_parser.rs`.
+//!
+//! Scope: this decodes the fixed-shape envelope header — envelope type,
+//! source account, fee, sequence number, preconditions, and memo — reading
+//! primitives straight out of the input slice with no intermediate
+//! allocation; variable-length fields (the source account key, memo bytes)
+//! are returned as borrows into the original buffer.
+//!
+//! It does not decode operation bodies. XDR does not length-prefix array
+//! elements, so skipping past the operations array requires fully
+//! type-aware decoding of every operation variant, which is out of scope
+//! for this header parser. Envelopes with one or more operations return
+//! [`XdrParseError::UnsupportedOperations`].
+
+use std::convert::TryInto;
+
+/// XDR discriminant for `ENVELOPE_TYPE_TX` (`TransactionV1Envelope`).
+pub const ENVELOPE_TYPE_TX: u32 = 2;
+
+/// Minimum byte length of a `TransactionV1Envelope` with no time bounds,
+/// no memo, and no operations (envelope type + account type + 32-byte key
+/// + fee + sequence number + preconditions discriminant + memo discriminant
+/// + operation count + ext discriminant + signature count).
+pub const MIN_TX_V1_LEN: usize = 72;
+
+const ACCOUNT_TYPE_ED25519: u32 = 0;
+
+const PRECOND_NONE: u32 = 0;
+const PRECOND_TIME: u32 = 1;
+
+const MEMO_NONE: u32 = 0;
+const MEMO_TEXT: u32 = 1;
+const MEMO_ID: u32 = 2;
+const MEMO_HASH: u32 = 3;
+const MEMO_RETURN: u32 = 4;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum XdrParseError {
+    #[error("buffer too short: need at least {need} bytes, have {have}")]
+    Truncated { need: usize, have: usize },
+    #[error("unsupported envelope type: {0}")]
+    UnsupportedEnvelopeType(u32),
+    #[error("unsupported source account type: {0}")]
+    UnsupportedAccountType(u32),
+    #[error("unsupported preconditions discriminant: {0}")]
+    UnsupportedPreconditions(u32),
+    #[error("unsupported memo discriminant: {0}")]
+    UnsupportedMemo(u32),
+    #[error("operation decoding is out of scope for this header parser ({0} present)")]
+    UnsupportedOperations(u32),
+}
+
+/// Borrowed view over a parsed `TransactionV1Envelope` header. Variable-length
+/// data are slices into the original input — parsing performs no allocation.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Envelope<'a> {
+    pub source_account: &'a [u8; 32],
+    pub fee: u32,
+    pub sequence_number: i64,
+    pub time_bounds: Option<(u64, u64)>,
+    pub memo: Memo<'a>,
+    pub operation_count: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Memo<'a> {
+    None,
+    Text(&'a [u8]),
+    Id(u64),
+    Hash(&'a [u8; 32]),
+    Return(&'a [u8; 32]),
+}
+
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], XdrParseError> {
+        if self.buf.len() - self.pos < n {
+            return Err(XdrParseError::Truncated { need: self.pos + n, have: self.buf.len() });
+        }
+        let slice = &self.buf[self.pos..self.pos + n];
+        self.pos += n;
+        Ok(slice)
+    }
+
+    fn u32(&mut self) -> Result<u32, XdrParseError> {
+        let s = self.take(4)?;
+        Ok(u32::from_be_bytes([s[0], s[1], s[2], s[3]]))
+    }
+
+    fn i64(&mut self) -> Result<i64, XdrParseError> {
+        let s = self.take(8)?;
+        Ok(i64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]))
+    }
+
+    fn u64(&mut self) -> Result<u64, XdrParseError> {
+        let s = self.take(8)?;
+        Ok(u64::from_be_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]]))
+    }
+
+    fn array32(&mut self) -> Result<&'a [u8; 32], XdrParseError> {
+        let slice = self.take(32)?;
+        slice
+            .try_into()
+            .map_err(|_| XdrParseError::Truncated { need: 32, have: slice.len() })
+    }
+}
+
+/// XDR pads opaque/string data out to a 4-byte boundary.
+fn padding(len: usize) -> usize {
+    (4 - (len % 4)) % 4
+}
+
+/// Parse the header of a `TransactionV1Envelope` out of raw XDR bytes.
+pub fn parse_envelope(raw: &[u8]) -> Result<Envelope<'_>, XdrParseError> {
+    let mut cur = Cursor::new(raw);
+
+    let envelope_type = cur.u32()?;
+    if envelope_type != ENVELOPE_TYPE_TX {
+        return Err(XdrParseError::UnsupportedEnvelopeType(envelope_type));
+    }
+
+    let account_type = cur.u32()?;
+    if account_type != ACCOUNT_TYPE_ED25519 {
+        return Err(XdrParseError::UnsupportedAccountType(account_type));
+    }
+    let source_account = cur.array32()?;
+
+    let fee = cur.u32()?;
+    let sequence_number = cur.i64()?;
+
+    let precond = cur.u32()?;
+    let time_bounds = match precond {
+        PRECOND_NONE => None,
+        PRECOND_TIME => Some((cur.u64()?, cur.u64()?)),
+        other => return Err(XdrParseError::UnsupportedPreconditions(other)),
+    };
+
+    let memo_type = cur.u32()?;
+    let memo = match memo_type {
+        MEMO_NONE => Memo::None,
+        MEMO_TEXT => {
+            let len = cur.u32()? as usize;
+            let bytes = cur.take(len)?;
+            cur.take(padding(len))?;
+            Memo::Text(bytes)
+        }
+        MEMO_ID => Memo::Id(cur.u64()?),
+        MEMO_HASH => Memo::Hash(cur.array32()?),
+        MEMO_RETURN => Memo::Return(cur.array32()?),
+        other => return Err(XdrParseError::UnsupportedMemo(other)),
+    };
+
+    let operation_count = cur.u32()?;
+    if operation_count != 0 {
+        return Err(XdrParseError::UnsupportedOperations(operation_count));
+    }
+
+    Ok(Envelope { source_account, fee, sequence_number, time_bounds, memo, operation_count })
+}
+
+/// Pool of reusable byte buffers so repeated parse/build cycles (e.g. request
+/// handling under load) avoid re-allocating a fresh `Vec` every time.
+pub mod pool {
+    use std::sync::Mutex;
+
+    pub struct BufferPool {
+        capacity: usize,
+        buffers: Mutex<Vec<Vec<u8>>>,
+    }
+
+    impl BufferPool {
+        pub fn new(capacity: usize) -> Self {
+            Self { capacity, buffers: Mutex::new(Vec::with_capacity(capacity)) }
+        }
+
+        pub fn acquire(&self) -> Vec<u8> {
+            self.buffers
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .pop()
+                .unwrap_or_default()
+        }
+
+        pub fn release(&self, mut buf: Vec<u8>) {
+            buf.clear();
+            let mut buffers = self.buffers.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            if buffers.len() < self.capacity {
+                buffers.push(buf);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BufMut;
+
+    fn minimal_envelope_bytes() -> Vec<u8> {
+        let mut buf = Vec::with_capacity(MIN_TX_V1_LEN);
+        buf.put_u32(ENVELOPE_TYPE_TX);
+        buf.put_u32(0);
+        buf.put_bytes(0x42, 32);
+        buf.put_u32(100);
+        buf.put_i64(9_999_999);
+        buf.put_u32(0);
+        buf.put_u32(0);
+        buf.put_u32(0);
+        buf.put_u32(0);
+        buf.put_u32(0);
+        buf
+    }
+
+    #[test]
+    fn parses_minimal_envelope() {
+        let raw = minimal_envelope_bytes();
+        let env = parse_envelope(&raw).expect("parse failed");
+        assert_eq!(env.fee, 100);
+        assert_eq!(env.sequence_number, 9_999_999);
+        assert_eq!(env.source_account, &[0x42u8; 32]);
+        assert_eq!(env.time_bounds, None);
+        assert_eq!(env.memo, Memo::None);
+        assert_eq!(env.operation_count, 0);
+        assert_eq!(raw.len(), MIN_TX_V1_LEN);
+    }
+
+    #[test]
+    fn rejects_truncated_buffer() {
+        let raw = minimal_envelope_bytes();
+        let err = parse_envelope(&raw[..10]).unwrap_err();
+        assert!(matches!(err, XdrParseError::Truncated { .. }));
+    }
+
+    #[test]
+    fn rejects_unsupported_envelope_type() {
+        let mut raw = minimal_envelope_bytes();
+        raw[3] = 5; // envelope type = TX_FEE_BUMP
+        let err = parse_envelope(&raw).unwrap_err();
+        assert_eq!(err, XdrParseError::UnsupportedEnvelopeType(5));
+    }
+
+    #[test]
+    fn rejects_nonzero_operations() {
+        let mut raw = minimal_envelope_bytes();
+        let ops_offset = raw.len() - 8; // operation count precedes ext discriminant
+        raw[ops_offset + 3] = 1;
+        let err = parse_envelope(&raw).unwrap_err();
+        assert_eq!(err, XdrParseError::UnsupportedOperations(1));
+    }
+
+    #[test]
+    fn parses_time_bounds_precondition() {
+        let mut buf = Vec::new();
+        buf.put_u32(ENVELOPE_TYPE_TX);
+        buf.put_u32(0);
+        buf.put_bytes(0x01, 32);
+        buf.put_u32(100);
+        buf.put_i64(1);
+        buf.put_u32(PRECOND_TIME);
+        buf.put_u64(1_000);
+        buf.put_u64(2_000);
+        buf.put_u32(MEMO_NONE);
+        buf.put_u32(0);
+
+        let env = parse_envelope(&buf).expect("parse failed");
+        assert_eq!(env.time_bounds, Some((1_000, 2_000)));
+    }
+
+    #[test]
+    fn buffer_pool_reuses_released_buffers() {
+        let pool = pool::BufferPool::new(2);
+        let mut buf = pool.acquire();
+        buf.put_slice(b"hello");
+        let cap = buf.capacity();
+        pool.release(buf);
+
+        let reused = pool.acquire();
+        assert!(reused.is_empty());
+        assert_eq!(reused.capacity(), cap);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,12 @@ pub mod recurring;
 #[cfg(feature = "database")]
 pub mod stellar;
 
+// Exposes chains::stellar::xdr_parser to benches/xdr_parser.rs, which links
+// against this library crate (main.rs's own `mod chains;` only reaches the
+// binary target and isn't visible to bench/test crates).
+#[cfg(feature = "database")]
+pub mod chains;
+
 // ── Wallet ─────────────────────────────────────────────────────────────────────
 #[cfg(feature = "database")]
 pub mod wallet;

--- a/test_snapshots/benchmarks/README.md
+++ b/test_snapshots/benchmarks/README.md
@@ -1,0 +1,32 @@
+# Benchmark baselines
+
+This directory holds committed `cargo bench --output-format bencher` output
+used as the performance baseline for the `benchmarks` CI job in
+`.github/workflows/ci-cd.yml`. It runs on every pull request touching
+`src/stellar/`, `src/chains/stellar/`, or `benches/xdr_parser.rs`, and fails
+the build if any benchmark regresses by more than 10% relative to the
+committed baseline (`scripts/compare_benchmarks.py`).
+
+## Creating or updating a baseline
+
+Benchmarks are timing-sensitive, so baselines must be generated on quiet,
+dedicated hardware — not a shared CI runner, whose noisy-neighbor variance
+would make the 10% threshold meaningless in either direction. Generate
+locally:
+
+```bash
+cargo bench --bench xdr_parser --features database -- --output-format bencher \
+  | tee test_snapshots/benchmarks/xdr_parser.bench.txt
+```
+
+Review the diff before committing — a large unexplained swing usually means
+a regression (or noise from a busy machine), not license to relax the
+baseline.
+
+## Bootstrap status
+
+`xdr_parser.bench.txt` has not been generated yet: it must be produced by
+running the command above on real hardware and committed once, after which
+the `benchmarks` CI job will compare future PRs against it and start
+enforcing the 10% threshold. Until then, the CI job only warns (it does not
+fail the build) when it can't find a baseline.


### PR DESCRIPTION
closes #739 
closes #742 
closes #743 
closes #744 




Problem
src/cache/multi_level.rs creates an L1Cache but the maximum number of entries and max memory usage for the moka cache are not shown as configured per category. Unbounded L1 caches can consume the entire JVM heap under load.

Location
src/cache/l1.rs, src/cache/multi_level.rs, src/config.rs

Proposed Fix
Add CacheConfig.l1_max_capacity, l1_time_to_live_secs, l1_time_to_idle_secs per L1Category
Configure moka CacheBuilder with explicit max_capacity
Emit aframp_l1_cache_size_bytes metric via size_metrics
Alert when L1 cache hit rate drops below 70%
Acceptance Criteria
 Configurable max capacity per L1 category
 Size metrics emitted
 Alert rule for low hit rate