### PR TITLE
fix: am done with all issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "lazy_static",
  "lettre",
  "maxminddb",
+ "mimalloc",
  "moka",
  "nuban",
  "once_cell",
@@ -66,6 +67,7 @@ dependencies = [
  "stellar-xdr 25.0.0",
  "stellar_sdk",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -1497,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -2509,6 +2511,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2639,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -5247,6 +5267,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/migrations/20270702000000_travel_rule_threshold_update.sql
+++ b/migrations/20270702000000_travel_rule_threshold_update.sql
@@ -1,0 +1,20 @@
+-- Migration: Update Travel Rule threshold to ₦1,500,000 / $1,000 (Issue: Travel Rule enforcement)
+-- Raises the previously-seeded ₦500,000 threshold and adds an explicit onramp
+-- threshold row (onramp checks are keyed on fiat currency "NGN", not "cNGN").
+
+UPDATE travel_rule_thresholds
+SET threshold_amount = 1500000, updated_at = NOW()
+WHERE currency = 'cNGN'
+  AND transaction_type IN ('cngn_transfer', 'offramp')
+  AND jurisdiction = 'NG'
+  AND threshold_amount = 500000;
+
+INSERT INTO travel_rule_thresholds (currency, transaction_type, jurisdiction, threshold_amount)
+VALUES
+    ('NGN', 'onramp', 'NG', 1500000)
+ON CONFLICT (currency, transaction_type, jurisdiction) DO UPDATE
+    SET threshold_amount = EXCLUDED.threshold_amount, updated_at = NOW();
+
+UPDATE travel_rule_unhosted_wallet_policy
+SET threshold_amount = 1500000, updated_at = NOW()
+WHERE threshold_currency = 'cNGN' AND threshold_amount = 500000;

--- a/src/aml/case_management.rs
+++ b/src/aml/case_management.rs
@@ -3,10 +3,9 @@
 //! Flagged transactions are moved to PENDING_COMPLIANCE_REVIEW.
 //! Compliance officers can Clear or Permanently Block them.
 
-use super::models::{AmlCaseStatus, AmlFlag, AmlFlagLevel, AmlScreeningResult};
+use super::models::{AmlCaseStatus, AmlFlagLevel, AmlScreeningResult};
 use super::repository::AmlRepository;
 use crate::services::notification::NotificationService;
-// REMOVED: use crate::sar::SarService;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
@@ -32,7 +31,6 @@ pub struct AmlCase {
 pub struct AmlCaseManager {
     repo: AmlRepository,
     notifications: Arc<NotificationService>,
-    sar_svc: Option<Arc<SarService>>,
 }
 
 impl AmlCaseManager {
@@ -40,14 +38,7 @@ impl AmlCaseManager {
         Self {
             repo: AmlRepository::new(pool),
             notifications,
-            sar_svc: None,
         }
-    }
-
-    /// Attach a SAR service so Critical/Medium cases auto-generate a SAR draft.
-    pub fn with_sar(mut self, sar_svc: Arc<SarService>) -> Self {
-        self.sar_svc = Some(sar_svc);
-        self
     }
 
     /// Open a new compliance case for a flagged transaction.
@@ -95,49 +86,9 @@ impl AmlCaseManager {
                 .await;
         }
 
-        // Auto-generate SAR draft for Critical or Medium flags
-        let should_draft = matches!(
-            result.flag_level,
-            Some(AmlFlagLevel::Critical) | Some(AmlFlagLevel::Medium)
-        );
-        if should_draft {
-            if let Some(ref sar_svc) = self.sar_svc {
-                let svc = Arc::clone(sar_svc);
-                let case_id = case.id;
-                let wallet = wallet_address.to_owned();
-                let risk_score = result.risk_score;
-                let tx_id = result.transaction_id;
-                let flags_json_clone = serde_json::to_value(&result.flags).unwrap_or_default();
-                let detection_method = if result.flags.iter().any(|f| matches!(f, AmlFlag::SanctionsHit { .. })) {
-                    crate::sar::DetectionMethod::SanctionsMatch
-                } else {
-                    crate::sar::DetectionMethod::AmlRuleTrigger
-                };
-                let today = chrono::Utc::now().date_naive();
-                tokio::spawn(async move {
-                    match svc.auto_initiate(
-                        case_id,
-                        detection_method,
-                        None,
-                        vec![wallet],
-                        format!("Automated SAR from AML engine. Risk score: {risk_score:.2}"),
-                        today - chrono::Duration::days(1),
-                        today,
-                        rust_decimal::Decimal::ZERO,
-                        0,
-                        vec![tx_id],
-                        flags_json_clone,
-                        Some(risk_score),
-                        None,
-                    ).await {
-                        Ok(sar) => {
-                            tracing::info!(sar_id = %sar.id, aml_case_id = %case_id, "SAR auto-initiated from AML case");
-                        }
-                        Err(e) => error!(aml_case_id = %case_id, error = %e, "SAR auto-initiation failed"),
-                    }
-                });
-            }
-        }
+        // NOTE: Critical/Medium flags previously auto-generated a SAR draft via
+        // the `sar` module. That module was removed (see dd3c49f) and hasn't
+        // been restored; auto-SAR-drafting is currently unavailable.
 
         Ok(case)
     }

--- a/src/aml/enhanced_case_management.rs
+++ b/src/aml/enhanced_case_management.rs
@@ -19,8 +19,6 @@ use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 use rust_decimal::Decimal;
-// REMOVED: use crate::sar::service::SarService;
-// REMOVED: use crate::sar::models::DetectionMethod as SarDetectionMethod;
 
 #[derive(Debug, Clone)]
 pub struct EnhancedAMLCaseManager {
@@ -1032,71 +1030,19 @@ impl EnhancedAMLCaseManager {
         Ok(())
     }
 
-    async fn initiate_sar_filing(&self, case_id: &Uuid, decision: &CaseDecisionRequest) -> Result<(), anyhow::Error> {
-        // Load case details
-        let case = match self.get_case_by_id(case_id).await {
-            Ok(c) => c,
-            Err(e) => return Err(e),
-        };
-
-        // Determine activity window (last 30 days by default)
-        let end = Utc::now();
-        let start = end - Duration::days(30);
-        let date_range = ActivityDateRange { start_date: start, end_date: end };
-
-        // Load subject transactions for the activity window (best-effort)
-        let txns = match self.load_subject_transactions(&case.subject_kyc_id, &date_range).await {
-            Ok(t) => t,
-            Err(_) => Vec::new(),
-        };
-
-        // Compute totals
-        let total_amount_f64: f64 = txns.iter().map(|t| t.amount).sum();
-        let total_amount = Decimal::from_f64(total_amount_f64).unwrap_or(Decimal::ZERO);
-        let transaction_count = txns.len() as i32;
-
-        // Collect linked transaction IDs when available
-        let linked_transaction_ids: Vec<Uuid> = txns.iter().map(|t| t.id).collect();
-
-        // Prepare triggered rules placeholder (if no explicit rules available)
-        let triggered_rules = serde_json::json!([]);
-
-        // Parse assigned investigator UUID if present
-        let assigned_investigator_id = case
-            .assigned_investigator_id
-            .as_deref()
-            .and_then(|s| Uuid::parse_str(s).ok());
-
-        // Instantiate SAR service and auto-initiate a SAR (idempotent)
-        let sar_svc = SarService::new(self.database.clone());
-        let _ = sar_svc
-            .auto_initiate(
-                *case_id,
-                SarDetectionMethod::ComplianceOfficerJudgment,
-                Some(case.subject_kyc_id),
-                case.subject_wallet_addresses.clone(),
-                decision.rationale.clone(),
-                start.date_naive(),
-                end.date_naive(),
-                total_amount,
-                transaction_count,
-                linked_transaction_ids,
-                triggered_rules,
-                Some(case.risk_score_at_opening),
-                assigned_investigator_id,
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to auto-initiate SAR: {}", e))?;
-
-        // Notify assigned investigator (if any)
+    async fn initiate_sar_filing(&self, case_id: &Uuid, _decision: &CaseDecisionRequest) -> Result<(), anyhow::Error> {
+        // TODO: Implement SAR filing. Previously delegated to the `sar` module,
+        // which was removed (see dd3c49f) and hasn't been restored; auto-SAR
+        // filing is currently unavailable. Still notify the assigned
+        // investigator so a suspicious decision doesn't pass silently.
+        let case = self.get_case_by_id(case_id).await?;
         if let Some(ref inv) = case.assigned_investigator_id {
             let _ = self.notifications.send_user_notification(
                 inv,
-                &format!("New SAR initiated for case {}", case.id),
-                &format!("A SAR has been created for case {}. Please review in the compliance portal.", case.id),
+                &format!("SAR filing required for case {}", case.id),
+                &format!("Case {} was marked suspicious but automated SAR filing is currently unavailable — file manually.", case.id),
             ).await;
         }
-
         Ok(())
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,7 +15,9 @@ pub mod partner;
 pub mod por;
 pub mod rates;
 pub mod recurring;
-pub mod service_admin;
+// service_admin: depends on the deleted service_auth module (never restored
+// after the dd3c49f cleanup) and isn't mounted in main.rs — excluded from
+// compilation rather than restoring service_auth wholesale.
 pub mod transaction_history;
 pub mod transparency;
 pub mod wallet;

--- a/src/api/offramp.rs
+++ b/src/api/offramp.rs
@@ -526,7 +526,7 @@ pub async fn initiate_withdrawal(
     //     conversion) and high-risk corridor. pending_travel_rule on the exchange
     //     record is the operator-visible hold indicator.
     if let Some(tr_svc) = &state.travel_rule_service {
-// REMOVED:         use crate::travel_rule::models::{
+        use crate::travel_rule::models::{
             InitiateTravelRuleRequest, Ivms101NaturalPerson, Ivms101Person,
         };
         use rust_decimal::Decimal;
@@ -579,10 +579,20 @@ pub async fn initiate_withdrawal(
                 destination_address: None,
             };
             if let Err(e) = tr_svc.initiate_outbound(tr_req).await {
-                warn!(
+                error!(
                     transaction_id = %tx_id,
                     error = %e,
-                    "Travel Rule initiation failed for offramp — proceeding with enhanced monitoring"
+                    "Travel Rule compliance check failed for offramp — blocking withdrawal"
+                );
+                let tx_repo = TransactionRepository::new((*state.db_pool).clone());
+                let _ = tx_repo
+                    .update_error(&tx_id, &format!("Travel Rule compliance check failed: {}", e))
+                    .await;
+                return create_error_response(
+                    422,
+                    "TRAVEL_RULE_REQUIRED",
+                    "This transfer requires originator and beneficiary information to be verified before it can proceed".to_string(),
+                    Some(e.to_string()),
                 );
             }
         }
@@ -667,6 +677,30 @@ pub async fn initiate_withdrawal(
 }
 
 // ===== ERROR HANDLING =====
+
+/// Build a raw structured error response with a given HTTP status code.
+fn create_error_response(
+    status: u16,
+    code: &str,
+    message: String,
+    details: Option<String>,
+) -> Response {
+    let detail = ErrorResponseDetail {
+        code: code.to_string(),
+        message,
+        details,
+        quote_id: None,
+        bank_code: None,
+        account_number: None,
+        provided_name: None,
+        actual_name: None,
+    };
+    (
+        StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+        Json(ErrorResponse { error: detail }),
+    )
+        .into_response()
+}
 
 /// Handle offramp-specific errors
 fn handle_offramp_error(error: AppError) -> Response {

--- a/src/api/onramp/initiate.rs
+++ b/src/api/onramp/initiate.rs
@@ -31,6 +31,8 @@ pub struct OnrampInitiateState {
     pub cngn_issuer: String,
     pub circuit_breaker: Arc<CircuitBreakerMiddleware>,
     pub anomaly_service: Arc<AnomalyDetectionService>,
+    /// Optional Travel Rule service — None in test/dev without DB
+    pub travel_rule_service: Option<Arc<crate::travel_rule::TravelRuleService>>,
 }
 
 // ── Request / Response ────────────────────────────────────────────────────────
@@ -270,6 +272,71 @@ pub async fn initiate_onramp(
         })?;
 
     let tx_id = transaction.transaction_id.to_string();
+
+    // 7b. Travel Rule gate — checks threshold and blocks the mint until originator
+    //     identification is present. Onramp mints go to the requesting customer's own
+    //     wallet (self-custodial, no counterparty VASP), so originator and beneficiary
+    //     both describe the same customer.
+    if let Some(tr_svc) = &state.travel_rule_service {
+        use crate::travel_rule::models::{
+            InitiateTravelRuleRequest, Ivms101NaturalPerson, Ivms101Person,
+        };
+        use rust_decimal::Decimal;
+        use std::str::FromStr;
+
+        let amount_dec = Decimal::from_str(&amount_ngn.to_string()).unwrap_or(Decimal::ZERO);
+        let requires_tr = tr_svc
+            .requires_travel_rule(amount_dec, "NGN", "onramp", "NG")
+            .await;
+
+        if requires_tr {
+            let customer_name = req
+                .customer_email
+                .as_deref()
+                .and_then(|e| e.split('@').next())
+                .or(req.customer_phone.as_deref())
+                .unwrap_or("onramp-customer")
+                .to_string();
+
+            let customer = Ivms101Person::Natural(Ivms101NaturalPerson {
+                first_name: customer_name,
+                last_name: "".into(),
+                date_of_birth: None,
+                national_id: None,
+                address: None,
+                country_of_residence: Some("NG".into()),
+                account_number: Some(req.wallet_address.clone()),
+            });
+
+            let tr_req = InitiateTravelRuleRequest {
+                transaction_id: tx_id.clone(),
+                beneficiary_vasp_id: "unhosted".into(),
+                originator: customer.clone(),
+                beneficiary: customer,
+                transfer_amount: amount_ngn.to_string(),
+                asset_code: "cNGN".into(),
+                destination_address: Some(req.wallet_address.clone()),
+            };
+
+            if let Err(e) = tr_svc.initiate_outbound(tr_req).await {
+                error!(
+                    transaction_id = %tx_id,
+                    error = %e,
+                    "Travel Rule compliance check failed for onramp — blocking mint"
+                );
+                let _ = state
+                    .transaction_repo
+                    .update_error(&tx_id, &format!("Travel Rule compliance check failed: {}", e))
+                    .await;
+                return Err(AppError::new(AppErrorKind::Domain(DomainError::Forbidden {
+                    message: format!(
+                        "This transfer requires originator information to be verified before it can proceed: {}",
+                        e
+                    ),
+                })));
+            }
+        }
+    }
 
     // Record mint event for anomaly detection (velocity tracking)
     if let Ok(amount_ngn_u64) = amount_ngn.to_string().parse::<u64>() {

--- a/src/api/partner/mod.rs
+++ b/src/api/partner/mod.rs
@@ -280,7 +280,7 @@ pub async fn initiate_transfer(
         Ok(t) => {
             // Travel Rule gate — applies to cross-border transfers and high-risk corridors
             if let Some(tr_svc) = &state.travel_rule_service {
-// REMOVED:                 use crate::travel_rule::models::{
+                use crate::travel_rule::models::{
                     InitiateTravelRuleRequest, Ivms101NaturalPerson, Ivms101Person,
                 };
                 use rust_decimal::Decimal;
@@ -334,11 +334,20 @@ pub async fn initiate_transfer(
                         destination_address: None,
                     };
                     if let Err(e) = tr_svc.initiate_outbound(tr_req).await {
-                        tracing::warn!(
+                        tracing::error!(
                             transfer_id = %t.id,
                             error = %e,
                             high_risk,
-                            "Travel Rule initiation failed for partner transfer — proceeding with monitoring"
+                            "Travel Rule compliance check failed for partner transfer — blocking"
+                        );
+                        let _ = state
+                            .repo
+                            .update_transfer_status(t.id, "failed", None, Some(&e.to_string()))
+                            .await;
+                        return err_resp(
+                            StatusCode::UNPROCESSABLE_ENTITY,
+                            "TRAVEL_RULE_REQUIRED",
+                            "This transfer requires originator and beneficiary information to be verified before it can proceed",
                         );
                     }
                 }

--- a/src/banking/fiat_settlement.rs
+++ b/src/banking/fiat_settlement.rs
@@ -2,8 +2,8 @@
 //! Automatically mints or transfers equivalent cNGN upon verified bank deposit
 
 use crate::banking::integrations::{FiatSettlement, SettlementStatus};
-// REMOVED: use crate::chains::ChainService;
 use crate::wallet::WalletService;
+use chrono::Utc;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -54,19 +54,13 @@ pub struct SettlementExecutionResult {
 pub struct FiatSettlementExecutor {
     config: FiatSettlementConfig,
     wallet_service: Arc<WalletService>,
-    chain_service: Option<Arc<ChainService>>,
 }
 
 impl FiatSettlementExecutor {
-    pub fn new(
-        config: FiatSettlementConfig,
-        wallet_service: Arc<WalletService>,
-        chain_service: Option<Arc<ChainService>>,
-    ) -> Self {
+    pub fn new(config: FiatSettlementConfig, wallet_service: Arc<WalletService>) -> Self {
         Self {
             config,
             wallet_service,
-            chain_service,
         }
     }
 
@@ -100,7 +94,7 @@ impl FiatSettlementExecutor {
         let transaction_hash = self.mint_cngn(&wallet_address, cngn_amount).await?;
 
         // 6. Update settlement record
-        settlement.cn gn_minted = true;
+        settlement.cngn_minted = true;
         settlement.settlement_status = SettlementStatus::Completed;
         settlement.completed_at = Some(Utc::now());
 

--- a/src/cache/single_flight.rs
+++ b/src/cache/single_flight.rs
@@ -72,18 +72,11 @@ impl<T: Clone + Send + 'static> SingleFlight<T> {
         match role {
             Role::Waiter(mut rx) => {
                 debug!(key, "single-flight: waiting for in-flight rebuild");
-                match rx.recv().await {
-                    Ok(result) => (*result).clone().map_err(|e| e.clone()),
-                    Err(_) => Err(format!(
+                match timeout(DEFAULT_IN_FLIGHT_TIMEOUT, rx.recv()).await {
+                    Ok(Ok(result)) => (*result).clone().map_err(|e| e.clone()),
+                    Ok(Err(_)) => Err(format!(
                         "single-flight leader for {key} ended without producing a result"
                     )),
-                match timeout(DEFAULT_IN_FLIGHT_TIMEOUT, rx.recv()).await {
-                    Ok(Ok(result)) => {
-                        return (*result).clone().map_err(|e| e.clone());
-                    }
-                    Ok(Err(_)) => {
-                        // Sender dropped without sending — treat as miss and rebuild.
-                    }
                     Err(_) => {
                         // The leader has been rebuilding longer than the
                         // self-heal timeout. Clear the stale entry so this
@@ -95,24 +88,50 @@ impl<T: Clone + Send + 'static> SingleFlight<T> {
                             "single-flight: in-flight rebuild timed out; self-healing"
                         );
                         self.in_flight.lock().await.remove(key);
+                        Err(format!(
+                            "single-flight leader for {key} timed out after {}s",
+                            DEFAULT_IN_FLIGHT_TIMEOUT.as_secs()
+                        ))
                     }
                 }
             }
             Role::Leader(tx) => {
                 info!(key, "single-flight: leader rebuilding cache entry");
-                let result = rebuild().await;
-                let shared: SharedResult<T> = Arc::new(result.clone().map_err(|e| e.to_string()));
+                let result: Result<T, String> = match AssertUnwindSafe(rebuild()).catch_unwind().await
+                {
+                    Ok(result) => result,
+                    Err(panic) => {
+                        let msg = panic_message(panic.as_ref());
+                        error!(key, error = %msg, "single-flight: rebuilder panicked");
+                        Err(format!("rebuild panicked: {}", msg))
+                    }
+                };
+
+                let shared: SharedResult<T> = Arc::new(result.clone());
 
                 // Broadcast result to all waiters (ignore send errors — no subscribers is fine).
                 let _ = tx.send(shared);
 
-                // Remove from in-flight map.
+                // Remove from in-flight map — always, whether the rebuild succeeded,
+                // returned Err, or panicked, so the key is never stuck.
                 let mut map = self.in_flight.lock().await;
                 map.remove(key);
 
                 result
             }
         }
+    }
+}
+
+/// Best-effort extraction of a human-readable message from a caught panic
+/// payload (`std::panic::catch_unwind`'s `Box<dyn Any + Send>`).
+fn panic_message(panic: &(dyn Any + Send)) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
     }
 }
 
@@ -144,17 +163,6 @@ mod tests {
         for h in handles {
             assert_eq!(h.await.unwrap().unwrap(), 42);
         }
-        info!(key, "single-flight: leader rebuilding cache entry");
-        let result: Result<T, String> = match AssertUnwindSafe(rebuild()).catch_unwind().await {
-            Ok(result) => result,
-            Err(panic) => {
-                let msg = panic_message(panic.as_ref());
-                error!(key, error = %msg, "single-flight: rebuilder panicked");
-                Err(format!("rebuild panicked: {}", msg))
-            }
-        };
-
-        let shared: SharedResult<T> = Arc::new(result.clone());
 
         assert_eq!(
             calls.load(Ordering::SeqCst),
@@ -170,10 +178,6 @@ mod tests {
         let b = sf.get_or_rebuild("b", || async { Ok(2) }).await.unwrap();
         assert_eq!((a, b), (1, 2));
     }
-        // Remove from in-flight map — always, whether the rebuild succeeded,
-        // returned Err, or panicked, so the key is never stuck.
-        let mut map = self.in_flight.lock().await;
-        map.remove(key);
 
     #[tokio::test]
     async fn test_rebuild_error_is_propagated() {
@@ -183,23 +187,6 @@ mod tests {
             .await;
         assert_eq!(result, Err("boom".to_string()));
     }
-}
-
-/// Best-effort extraction of a human-readable message from a caught panic
-/// payload (`std::panic::catch_unwind`'s `Box<dyn Any + Send>`).
-fn panic_message(panic: &(dyn Any + Send)) -> String {
-    if let Some(s) = panic.downcast_ref::<&str>() {
-        s.to_string()
-    } else if let Some(s) = panic.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "non-string panic payload".to_string()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
 
     #[tokio::test]
     async fn test_successful_rebuild_returns_value() {

--- a/src/chains/stellar/client.rs
+++ b/src/chains/stellar/client.rs
@@ -26,6 +26,16 @@ pub struct StellarBalance {
     pub asset_code: Option<String>,
     #[serde(default)]
     pub asset_issuer: Option<String>,
+    #[serde(default)]
+    pub limit: Option<String>,
+    #[serde(default = "default_authorized", rename = "is_authorized")]
+    pub is_authorized: bool,
+}
+
+/// Horizon omits `is_authorized` entirely for the native XLM balance line
+/// (only relevant for trustlines); treat a missing field as authorized.
+fn default_authorized() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/chains/stellar/mod.rs
+++ b/src/chains/stellar/mod.rs
@@ -1,8 +1,10 @@
 pub mod client;
 pub mod config;
 pub mod errors;
+pub mod trustline;
 pub mod types;
 
 pub use client::StellarClient;
 pub use config::StellarConfig;
 pub use errors::StellarError;
+pub use trustline::CngnTrustlineManager;

--- a/src/chains/stellar/trustline.rs
+++ b/src/chains/stellar/trustline.rs
@@ -1,0 +1,45 @@
+//! Compatibility shim for the historical `chains::stellar::trustline::CngnTrustlineManager`.
+//!
+//! Call sites across the onramp flow (`api/onramp/*`, `workers/onramp_processor.rs`,
+//! `services/onramp_quote.rs`, `api/mint/validator.rs`) only ever use
+//! `CngnTrustlineManager::new(stellar_client)` and `.check_trustline(account_id)`,
+//! reading `.has_trustline` / `.is_authorized` off the result. This delegates to
+//! [`crate::services::cngn_trustline::CngnTrustlineService`] — the actively
+//! maintained implementation already built against the current
+//! [`super::client::StellarClient`] — translating its `TrustlineStatus.exists`
+//! field to the historical `has_trustline` name these call sites expect.
+use super::client::StellarClient;
+use crate::error::AppError;
+use crate::services::cngn_trustline::CngnTrustlineService;
+
+/// Trustline check result, field-compatible with the pre-migration
+/// `CngnTrustlineManager::check_trustline` return shape.
+#[derive(Debug, Clone)]
+pub struct TrustlineCheckResult {
+    pub has_trustline: bool,
+    pub is_authorized: bool,
+    pub balance: Option<String>,
+    pub limit: Option<String>,
+}
+
+pub struct CngnTrustlineManager {
+    inner: CngnTrustlineService,
+}
+
+impl CngnTrustlineManager {
+    pub fn new(stellar_client: StellarClient) -> Self {
+        Self {
+            inner: CngnTrustlineService::new(stellar_client),
+        }
+    }
+
+    pub async fn check_trustline(&self, account_id: &str) -> Result<TrustlineCheckResult, AppError> {
+        let status = self.inner.check_trustline(account_id).await?;
+        Ok(TrustlineCheckResult {
+            has_trustline: status.exists,
+            is_authorized: status.is_authorized,
+            balance: status.balance,
+            limit: status.limit,
+        })
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,12 @@ pub struct StellarConfig {
     pub request_timeout: u64, // seconds
     pub max_retries: u32,
     pub health_check_interval: u64, // seconds
+    /// Max idle connections per host kept open by the Horizon reqwest client pool
+    pub horizon_max_connections: usize,
+    /// Per-request timeout for the underlying Horizon HTTP client (seconds)
+    pub horizon_request_timeout_secs: u64,
+    /// TCP keep-alive interval for pooled Horizon connections (seconds)
+    pub horizon_keep_alive_secs: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -414,6 +420,24 @@ impl StellarConfig {
                 .map_err(|_| {
                     ConfigError::InvalidValue("STELLAR_HEALTH_CHECK_INTERVAL".to_string())
                 })?,
+            horizon_max_connections: env::var("STELLAR_HORIZON_MAX_CONNECTIONS")
+                .unwrap_or_else(|_| "32".to_string())
+                .parse()
+                .map_err(|_| {
+                    ConfigError::InvalidValue("STELLAR_HORIZON_MAX_CONNECTIONS".to_string())
+                })?,
+            horizon_request_timeout_secs: env::var("STELLAR_HORIZON_REQUEST_TIMEOUT_SECS")
+                .unwrap_or_else(|_| "15".to_string())
+                .parse()
+                .map_err(|_| {
+                    ConfigError::InvalidValue("STELLAR_HORIZON_REQUEST_TIMEOUT_SECS".to_string())
+                })?,
+            horizon_keep_alive_secs: env::var("STELLAR_HORIZON_KEEP_ALIVE_SECS")
+                .unwrap_or_else(|_| "90".to_string())
+                .parse()
+                .map_err(|_| {
+                    ConfigError::InvalidValue("STELLAR_HORIZON_KEEP_ALIVE_SECS".to_string())
+                })?,
         })
     }
 
@@ -436,6 +460,18 @@ impl StellarConfig {
         if self.request_timeout == 0 {
             return Err(ConfigError::InvalidValue(
                 "STELLAR_REQUEST_TIMEOUT".to_string(),
+            ));
+        }
+
+        if self.horizon_max_connections == 0 {
+            return Err(ConfigError::InvalidValue(
+                "STELLAR_HORIZON_MAX_CONNECTIONS".to_string(),
+            ));
+        }
+
+        if self.horizon_request_timeout_secs == 0 {
+            return Err(ConfigError::InvalidValue(
+                "STELLAR_HORIZON_REQUEST_TIMEOUT_SECS".to_string(),
             ));
         }
 

--- a/src/corridors/ghana/service.rs
+++ b/src/corridors/ghana/service.rs
@@ -1,6 +1,5 @@
 //! Ghana corridor service — orchestrates the full NG→GH transfer flow.
 
-// REMOVED: use crate::compliance_registry::repository::ComplianceRegistryRepository;
 use crate::corridors::ghana::models::*;
 use crate::payments::provider::PaymentProvider;
 use crate::payments::providers::ghana::{
@@ -54,7 +53,6 @@ pub enum GhanaCorridorError {
 
 pub struct GhanaCorridorService {
     pool: PgPool,
-    compliance_repo: Arc<ComplianceRegistryRepository>,
     exchange_rate_svc: Arc<ExchangeRateService>,
     #[allow(dead_code)]
     fee_svc: Arc<FeeCalculationService>,
@@ -65,7 +63,6 @@ pub struct GhanaCorridorService {
 impl GhanaCorridorService {
     pub fn new(
         pool: PgPool,
-        compliance_repo: Arc<ComplianceRegistryRepository>,
         exchange_rate_svc: Arc<ExchangeRateService>,
         fee_svc: Arc<FeeCalculationService>,
         provider_config: GhanaProviderConfig,
@@ -73,7 +70,6 @@ impl GhanaCorridorService {
     ) -> Self {
         Self {
             pool,
-            compliance_repo,
             exchange_rate_svc,
             fee_svc,
             provider_config,

--- a/src/corridors/kenya/service.rs
+++ b/src/corridors/kenya/service.rs
@@ -1,6 +1,5 @@
 //! Kenya corridor service — orchestrates the full NG→KE transfer flow.
 
-// REMOVED: use crate::compliance_registry::repository::ComplianceRegistryRepository;
 use crate::corridors::kenya::models::*;
 use crate::payments::provider::PaymentProvider;
 use crate::payments::providers::mpesa_kenya::{
@@ -55,7 +54,6 @@ pub enum KenyaCorridorError {
 
 pub struct KenyaCorridorService {
     pool: PgPool,
-    compliance_repo: Arc<ComplianceRegistryRepository>,
     exchange_rate_svc: Arc<ExchangeRateService>,
     fee_svc: Arc<FeeCalculationService>,
     mpesa_config: MpesaKenyaConfig,
@@ -66,7 +64,6 @@ pub struct KenyaCorridorService {
 impl KenyaCorridorService {
     pub fn new(
         pool: PgPool,
-        compliance_repo: Arc<ComplianceRegistryRepository>,
         exchange_rate_svc: Arc<ExchangeRateService>,
         fee_svc: Arc<FeeCalculationService>,
         mpesa_config: MpesaKenyaConfig,
@@ -74,7 +71,6 @@ impl KenyaCorridorService {
     ) -> Self {
         Self {
             pool,
-            compliance_repo,
             exchange_rate_svc,
             fee_svc,
             mpesa_config,

--- a/src/corridors/router/models.rs
+++ b/src/corridors/router/models.rs
@@ -6,9 +6,29 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
-// Re-export compliance registry status types
+// Corridor status
+//
+// Originally defined in the `compliance_registry` module, which was removed
+// (see dd3c49f) and hasn't been restored. Defined locally here since it's a
+// DB-backed enum (`corridor_status`) actively used by corridor routing
+// queries, not something that can simply be dropped.
 // ---------------------------------------------------------------------------
-pub use crate::compliance_registry::models::CorridorStatus;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "corridor_status", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum CorridorStatus {
+    Active,
+    Suspended,
+    BlockedLicenseExpired,
+    BlockedLicenseSuspended,
+    BlockedRegulatory,
+}
+
+impl CorridorStatus {
+    pub fn is_open(&self) -> bool {
+        matches!(self, CorridorStatus::Active)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Core corridor config

--- a/src/corridors/router/repository.rs
+++ b/src/corridors/router/repository.rs
@@ -1,6 +1,5 @@
 //! Database repository for the corridor router.
 
-// REMOVED: use crate::compliance_registry::models::CorridorStatus;
 use crate::corridors::router::models::*;
 use crate::database::error::DatabaseError;
 use chrono::Utc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ use soroban_sdk::{
 
 // ── Core infrastructure ────────────────────────────────────────────────────────
 #[cfg(feature = "database")]
+pub mod chains;
+
+#[cfg(feature = "database")]
 pub mod database;
 
 #[cfg(feature = "database")]
@@ -107,6 +110,9 @@ pub mod compliance_effectiveness;
 
 #[cfg(feature = "database")]
 pub mod risk;
+
+#[cfg(feature = "database")]
+pub mod travel_rule;
 
 // ── API layer ─────────────────────────────────────────────────────────────────
 #[cfg(feature = "database")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1100,6 +1100,51 @@ async fn main() -> anyhow::Result<()> {
         oracle::routes::oracle_routes(svc)
     };
 
+    // ── Travel Rule service — built once, shared by onramp, offramp, partner, and TR routes ──
+    let shared_travel_rule_service: Option<std::sync::Arc<crate::travel_rule::TravelRuleService>> =
+        if let (Some(ref pool), Some(ref redis)) = (&db_pool, &redis_cache) {
+            use crate::aml::screening::{AmlProviderConfig, SanctionsScreeningService};
+            use crate::aml::case_management::AmlCaseManager;
+            use crate::travel_rule::{TravelRuleRepository, TravelRuleService};
+
+            let tr_repo = std::sync::Arc::new(TravelRuleRepository::new(pool.clone()));
+            let aml_cfg = AmlProviderConfig::default();
+            let sanctions = std::sync::Arc::new(SanctionsScreeningService::new(
+                aml_cfg,
+                std::sync::Arc::new(redis.clone()),
+            ));
+            let aml_case_manager = std::sync::Arc::new(
+                AmlCaseManager::new(pool.clone(), notification_service.clone())
+            );
+
+            // Build ExchangeRateService for NGN threshold conversion
+            let rate_repo = database::exchange_rate_repository::ExchangeRateRepository::new(pool.clone());
+            let rate_config = services::exchange_rate::ExchangeRateServiceConfig::default();
+            let exchange_rate_svc = std::sync::Arc::new(
+                services::exchange_rate::ExchangeRateService::new(rate_repo, rate_config)
+            );
+
+            let event_bus_arc = std::sync::Arc::new(crate::event_bus::bus::EventBus::new(pool.clone()));
+            let our_vasp_id = std::env::var("PLATFORM_VASP_ID").unwrap_or_else(|_| "aframp-ng".into());
+
+            let tr_svc = std::sync::Arc::new(TravelRuleService::new(
+                tr_repo.clone(),
+                sanctions,
+                aml_case_manager,
+                event_bus_arc,
+                exchange_rate_svc,
+                our_vasp_id,
+            ));
+
+            // Start SLA worker
+            crate::travel_rule::TravelRuleSlaWorker::new(tr_repo).start();
+            info!("✅ Travel Rule service initialised");
+            Some(tr_svc)
+        } else {
+            info!("⏭️  Travel Rule service skipped (no database or Redis)");
+            None
+        };
+
     // Setup onramp routes (quote service)
     let onramp_routes = if let (Some(pool), Some(cache), Some(client)) =
         (db_pool.clone(), redis_cache.clone(), stellar_client.clone())
@@ -1222,6 +1267,7 @@ async fn main() -> anyhow::Result<()> {
             cngn_issuer: cngn_issuer_for_initiate,
             circuit_breaker: circuit_breaker.clone().expect("circuit breaker missing"),
             anomaly_service: anomaly_service.clone().expect("anomaly service missing"),
+            travel_rule_service: shared_travel_rule_service.clone(),
         });
 
         let onramp_integrity_state = crate::middleware::request_integrity::RequestIntegrityState {
@@ -1363,50 +1409,6 @@ async fn main() -> anyhow::Result<()> {
         Router::new()
     };
 
-    // ── Travel Rule service — built once, shared by offramp, partner, and TR routes ──
-    let shared_travel_rule_service: Option<std::sync::Arc<crate::travel_rule::TravelRuleService>> =
-        if let (Some(ref pool), Some(ref redis)) = (&db_pool, &redis_cache) {
-            use crate::aml::screening::{AmlProviderConfig, SanctionsScreeningService};
-            use crate::aml::case_management::AmlCaseManager;
-// REMOVED:             use crate::travel_rule::{TravelRuleRepository, TravelRuleService};
-
-            let tr_repo = std::sync::Arc::new(TravelRuleRepository::new(pool.clone()));
-            let aml_cfg = AmlProviderConfig::default();
-            let sanctions = std::sync::Arc::new(SanctionsScreeningService::new(
-                aml_cfg,
-                std::sync::Arc::new(redis.clone()),
-            ));
-            let aml_case_manager = std::sync::Arc::new(
-                AmlCaseManager::new(pool.clone(), notification_service.clone())
-            );
-
-            // Build ExchangeRateService for NGN threshold conversion
-            let rate_repo = database::exchange_rate_repository::ExchangeRateRepository::new(pool.clone());
-            let rate_config = services::exchange_rate::ExchangeRateServiceConfig::default();
-            let exchange_rate_svc = std::sync::Arc::new(
-                services::exchange_rate::ExchangeRateService::new(rate_repo, rate_config)
-            );
-
-            let event_bus_arc = std::sync::Arc::new(crate::event_bus::bus::EventBus::new(pool.clone()));
-            let our_vasp_id = std::env::var("PLATFORM_VASP_ID").unwrap_or_else(|_| "aframp-ng".into());
-
-            let tr_svc = std::sync::Arc::new(TravelRuleService::new(
-                tr_repo.clone(),
-                sanctions,
-                aml_case_manager,
-                event_bus_arc,
-                exchange_rate_svc,
-                our_vasp_id,
-            ));
-
-            // Start SLA worker
-            crate::travel_rule::TravelRuleSlaWorker::new(tr_repo).start();
-            info!("✅ Travel Rule service initialised");
-            Some(tr_svc)
-        } else {
-            info!("⏭️  Travel Rule service skipped (no database or Redis)");
-            None
-        };
 
     // Setup offramp routes (withdrawal initiation)
     let offramp_routes = if let (Some(pool), Some(cache)) = (db_pool.clone(), redis_cache.clone()) {
@@ -1451,6 +1453,7 @@ async fn main() -> anyhow::Result<()> {
             system_wallet_address,
             cngn_issuer_address,
             circuit_breaker: circuit_breaker.clone().expect("circuit breaker missing"),
+            travel_rule_service: shared_travel_rule_service.clone(),
         };
 
         let offramp_integrity_state = crate::middleware::request_integrity::RequestIntegrityState {
@@ -1941,7 +1944,7 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Travel Rule API routes — reuse the already-initialised shared service ──
     let travel_rule_routes = if let (Some(ref pool), Some(_redis)) = (&db_pool, &redis_cache) {
-// REMOVED:         use crate::travel_rule::{TravelRuleRepository, TravelRuleState};
+        use crate::travel_rule::{TravelRuleRepository, TravelRuleState};
 
         // Repository is lightweight — create fresh for the state (shares pool)
         let tr_repo = std::sync::Arc::new(TravelRuleRepository::new(pool.clone()));

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -375,6 +375,8 @@ pub mod stellar {
     static STELLAR_TX_SUBMISSIONS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
     static STELLAR_TX_SUBMISSION_DURATION_SECONDS: OnceLock<HistogramVec> = OnceLock::new();
     static STELLAR_TRUSTLINE_ATTEMPTS_TOTAL: OnceLock<CounterVec> = OnceLock::new();
+    static STELLAR_QUEUE_DEPTH: OnceLock<Gauge> = OnceLock::new();
+    static STELLAR_QUEUE_TIMEOUT_TOTAL: OnceLock<CounterVec> = OnceLock::new();
 
     pub fn tx_submissions_total() -> &'static CounterVec {
         STELLAR_TX_SUBMISSIONS_TOTAL
@@ -390,6 +392,20 @@ pub mod stellar {
 
     pub fn trustline_attempts_total() -> &'static CounterVec {
         STELLAR_TRUSTLINE_ATTEMPTS_TOTAL
+            .get()
+            .expect("metrics not initialised")
+    }
+
+    /// Number of submissions currently waiting in the channel pool's bounded
+    /// backpressure queue for a channel slot.
+    pub fn queue_depth() -> &'static Gauge {
+        STELLAR_QUEUE_DEPTH.get().expect("metrics not initialised")
+    }
+
+    /// Total submissions rejected because they waited longer than the queue
+    /// timeout for a channel slot.
+    pub fn queue_timeout_total() -> &'static CounterVec {
+        STELLAR_QUEUE_TIMEOUT_TOTAL
             .get()
             .expect("metrics not initialised")
     }
@@ -431,6 +447,29 @@ pub mod stellar {
                 .unwrap(),
             )
             .ok();
+
+        STELLAR_QUEUE_DEPTH
+            .set(
+                register_gauge_with_registry!(
+                    "aframp_stellar_queue_depth",
+                    "Submissions currently waiting in the channel pool's backpressure queue",
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        STELLAR_QUEUE_TIMEOUT_TOTAL
+            .set(
+                register_counter_vec_with_registry!(
+                    "aframp_stellar_queue_timeout_total",
+                    "Total submissions rejected after exceeding the queue timeout waiting for a channel slot",
+                    &[],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
     }
 }
 
@@ -443,6 +482,7 @@ pub mod stellar_horizon {
 
     static HORIZON_ENDPOINT_SUCCESS_RATE: OnceLock<GaugeVec> = OnceLock::new();
     static HORIZON_ENDPOINT_HEALTHY: OnceLock<GaugeVec> = OnceLock::new();
+    static HORIZON_ACTIVE_CONNECTIONS: OnceLock<Gauge> = OnceLock::new();
 
     /// EWMA success rate (0.0-1.0) per Horizon/RPC endpoint.
     pub fn endpoint_success_rate() -> &'static GaugeVec {
@@ -454,6 +494,14 @@ pub mod stellar_horizon {
     /// Whether an endpoint is currently in rotation (1) or circuit-broken out (0).
     pub fn endpoint_healthy() -> &'static GaugeVec {
         HORIZON_ENDPOINT_HEALTHY
+            .get()
+            .expect("metrics not initialised")
+    }
+
+    /// Number of in-flight HTTP requests currently held by the Horizon client's
+    /// connection pool, across all endpoints.
+    pub fn active_connections() -> &'static Gauge {
+        HORIZON_ACTIVE_CONNECTIONS
             .get()
             .expect("metrics not initialised")
     }
@@ -477,6 +525,17 @@ pub mod stellar_horizon {
                     "aframp_horizon_endpoint_healthy",
                     "Whether a Horizon/RPC endpoint is in rotation (1) or circuit-broken out (0)",
                     &["endpoint"],
+                    r
+                )
+                .unwrap(),
+            )
+            .ok();
+
+        HORIZON_ACTIVE_CONNECTIONS
+            .set(
+                register_gauge_with_registry!(
+                    "aframp_horizon_active_connections",
+                    "In-flight HTTP requests currently held by the Horizon client connection pool",
                     r
                 )
                 .unwrap(),
@@ -1088,8 +1147,6 @@ fn register_all(r: &Registry) {
     por::register(r);
     #[cfg(feature = "database")]
     crate::analytics::metrics::register(r);
-    crate::adaptive_rate_limit::metrics::register(r);
-    crate::security_compliance::metrics::register(r);
     crate::liquidity::metrics::register(r);
     crate::travel_rule::metrics::register(r);
     spawn::register(r);

--- a/src/services/cngn_trustline.rs
+++ b/src/services/cngn_trustline.rs
@@ -3,7 +3,7 @@
 //! Handles checking, creating, and verifying trustlines for the cNGN stablecoin.
 //! A trustline is required for Stellar accounts to hold custom assets like cNGN.
 
-// REMOVED: use crate::chains::stellar::{
+use crate::chains::stellar::{
     client::StellarClient,
     errors::StellarError,
     types::{AssetBalance, StellarAccountInfo},

--- a/src/stellar/admin.rs
+++ b/src/stellar/admin.rs
@@ -189,6 +189,7 @@ pub enum AdminError {
     BadRequest(String),
     InternalError(String),
     Unauthorized,
+    TooManyRequests(String),
 }
 
 impl IntoResponse for AdminError {
@@ -198,6 +199,7 @@ impl IntoResponse for AdminError {
             AdminError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             AdminError::InternalError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             AdminError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized".to_string()),
+            AdminError::TooManyRequests(msg) => (StatusCode::TOO_MANY_REQUESTS, msg),
         };
 
         (
@@ -220,7 +222,12 @@ impl From<sqlx::Error> for AdminError {
 
 impl From<crate::stellar::error::SubmissionError> for AdminError {
     fn from(err: crate::stellar::error::SubmissionError) -> Self {
-        AdminError::InternalError(err.to_string())
+        match err {
+            crate::stellar::error::SubmissionError::QueueTimeout { .. } => {
+                AdminError::TooManyRequests(err.to_string())
+            }
+            other => AdminError::InternalError(other.to_string()),
+        }
     }
 }
 

--- a/src/stellar/channel_pool.rs
+++ b/src/stellar/channel_pool.rs
@@ -8,7 +8,35 @@ use chrono::Utc;
 use sqlx::PgPool;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Semaphore;
 use uuid::Uuid;
+
+/// Default number of callers allowed to wait concurrently for a channel slot
+/// once every channel is at its in-flight cap.
+pub const DEFAULT_QUEUE_DEPTH: usize = 500;
+/// Default time a caller will wait in the queue before giving up.
+pub const DEFAULT_QUEUE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Backoff between retries while waiting for a channel to free up.
+const QUEUE_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// RAII guard: increments `aframp_stellar_queue_depth` on creation, decrements
+/// it on drop — covers every exit path (success, error, or the caller
+/// dropping the future early).
+struct QueueDepthGuard;
+
+impl QueueDepthGuard {
+    fn new() -> Self {
+        crate::metrics::stellar::queue_depth().inc();
+        Self
+    }
+}
+
+impl Drop for QueueDepthGuard {
+    fn drop(&mut self) {
+        crate::metrics::stellar::queue_depth().dec();
+    }
+}
 
 /// Pool of submission channels with load balancing and circuit breaking
 pub struct ChannelPool {
@@ -18,15 +46,42 @@ pub struct ChannelPool {
     current_index: Arc<std::sync::atomic::AtomicUsize>,
     circuit_breaker_threshold: u32,
     max_in_flight_per_channel: u32,
+    /// Bounds how many callers may wait concurrently for a channel slot —
+    /// the backpressure queue's "depth".
+    queue: Arc<Semaphore>,
+    queue_timeout: Duration,
 }
 
 impl ChannelPool {
-    /// Create a new channel pool for an issuer
+    /// Create a new channel pool for an issuer, using the default queue depth
+    /// (500) and queue timeout (10s). Use [`ChannelPool::with_queue_config`]
+    /// to configure these explicitly.
     pub async fn new(
         pool: PgPool,
         issuer_id: Uuid,
         circuit_breaker_threshold: u32,
         max_in_flight_per_channel: u32,
+    ) -> SubmissionResult<Self> {
+        Self::with_queue_config(
+            pool,
+            issuer_id,
+            circuit_breaker_threshold,
+            max_in_flight_per_channel,
+            DEFAULT_QUEUE_DEPTH,
+            DEFAULT_QUEUE_TIMEOUT,
+        )
+        .await
+    }
+
+    /// Create a new channel pool with an explicit backpressure queue depth
+    /// and timeout.
+    pub async fn with_queue_config(
+        pool: PgPool,
+        issuer_id: Uuid,
+        circuit_breaker_threshold: u32,
+        max_in_flight_per_channel: u32,
+        queue_depth: usize,
+        queue_timeout: Duration,
     ) -> SubmissionResult<Self> {
         let channels = Arc::new(tokio::sync::RwLock::new(Vec::new()));
         let pool_obj = Self {
@@ -36,6 +91,8 @@ impl ChannelPool {
             current_index: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             circuit_breaker_threshold,
             max_in_flight_per_channel,
+            queue: Arc::new(Semaphore::new(queue_depth)),
+            queue_timeout,
         };
 
         pool_obj.reload_from_database().await?;
@@ -163,6 +220,56 @@ impl ChannelPool {
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         Ok((channel, reserved))
+    }
+
+    /// Reserve a sequence number, applying bounded backpressure: when every
+    /// channel is at its in-flight cap, wait for one to free up (retrying
+    /// with a short backoff) instead of failing the caller immediately.
+    ///
+    /// The pool's `queue` semaphore bounds how many callers may be waiting
+    /// concurrently to `queue_depth` — once that's full, callers fail fast
+    /// with [`SubmissionError::QueueTimeout`] rather than piling up
+    /// unboundedly. A caller that does get a queue slot still gives up and
+    /// returns [`SubmissionError::QueueTimeout`] if no channel frees up
+    /// within `queue_timeout`.
+    ///
+    /// [`SubmissionError::NoActiveChannels`] (no channels registered, or
+    /// every circuit breaker open) is not retried — waiting cannot help.
+    pub async fn reserve_sequence_with_backpressure(&self) -> SubmissionResult<(ChannelHandle, i64)> {
+        let start = Instant::now();
+
+        let _permit = match timeout(self.queue_timeout, self.queue.acquire()).await {
+            Ok(Ok(permit)) => permit,
+            _ => {
+                crate::metrics::stellar::queue_timeout_total()
+                    .with_label_values(&[])
+                    .inc();
+                return Err(SubmissionError::QueueTimeout {
+                    waited_ms: start.elapsed().as_millis() as u64,
+                    timeout_ms: self.queue_timeout.as_millis() as u64,
+                });
+            }
+        };
+        let _depth_guard = QueueDepthGuard::new();
+
+        loop {
+            match self.reserve_sequence().await {
+                Ok(result) => return Ok(result),
+                Err(SubmissionError::ChannelExhausted(_)) => {
+                    if start.elapsed() >= self.queue_timeout {
+                        crate::metrics::stellar::queue_timeout_total()
+                            .with_label_values(&[])
+                            .inc();
+                        return Err(SubmissionError::QueueTimeout {
+                            waited_ms: start.elapsed().as_millis() as u64,
+                            timeout_ms: self.queue_timeout.as_millis() as u64,
+                        });
+                    }
+                    tokio::time::sleep(QUEUE_POLL_INTERVAL).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     /// Rotate to next channel (used after errors)

--- a/src/stellar/error.rs
+++ b/src/stellar/error.rs
@@ -56,6 +56,9 @@ pub enum SubmissionError {
 
     #[error("Channel rotation error: {0}")]
     ChannelRotationError(String),
+
+    #[error("Submission queue saturated: waited {waited_ms}ms for a channel slot (timeout after {timeout_ms}ms)")]
+    QueueTimeout { waited_ms: u64, timeout_ms: u64 },
 }
 
 pub type SubmissionResult<T> = Result<T, SubmissionError>;

--- a/src/stellar/horizon.rs
+++ b/src/stellar/horizon.rs
@@ -20,6 +20,11 @@ const UNHEALTHY_THRESHOLD: f64 = 0.5;
 const RECOVERY_THRESHOLD: f64 = 0.8;
 /// How often the background prober re-checks circuit-broken endpoints.
 const RECOVERY_PROBE_INTERVAL: Duration = Duration::from_secs(30);
+/// Consecutive Horizon *timeouts* (not just any failure) above which an
+/// endpoint is circuit-broken immediately, bypassing the slower
+/// EWMA/`MIN_SAMPLES_BEFORE_TRIP` gate — a run of timeouts means the
+/// endpoint is unresponsive right now and should stop taking traffic fast.
+const TIMEOUT_CIRCUIT_THRESHOLD: u32 = 3;
 
 /// Per-endpoint health tracking state.
 struct EndpointHealthState {
@@ -30,6 +35,9 @@ struct EndpointHealthState {
     samples: u32,
     healthy: bool,
     consecutive_failures: u32,
+    /// Consecutive request *timeouts* — reset on any success or any
+    /// non-timeout failure, since it tracks a pure timeout streak.
+    consecutive_timeouts: u32,
 }
 
 impl EndpointHealthState {
@@ -39,6 +47,46 @@ impl EndpointHealthState {
             samples: 0,
             healthy: true,
             consecutive_failures: 0,
+            consecutive_timeouts: 0,
+        }
+    }
+}
+
+/// RAII guard that increments `aframp_horizon_active_connections` on
+/// creation and decrements it on drop (including early-return via `?`).
+struct ActiveConnectionGuard;
+
+impl ActiveConnectionGuard {
+    fn new() -> Self {
+        crate::metrics::stellar_horizon::active_connections().inc();
+        Self
+    }
+}
+
+impl Drop for ActiveConnectionGuard {
+    fn drop(&mut self) {
+        crate::metrics::stellar_horizon::active_connections().dec();
+    }
+}
+
+/// Tunables for the underlying reqwest HTTP client backing [`HorizonClient`].
+#[derive(Debug, Clone)]
+pub struct HorizonClientConfig {
+    /// Max idle connections kept open per host by the connection pool.
+    pub max_connections: usize,
+    /// Per-request timeout.
+    pub request_timeout: Duration,
+    /// TCP keep-alive interval for pooled connections (also used as the
+    /// pool's idle-connection timeout).
+    pub keep_alive: Duration,
+}
+
+impl Default for HorizonClientConfig {
+    fn default() -> Self {
+        Self {
+            max_connections: 32,
+            request_timeout: Duration::from_secs(15),
+            keep_alive: Duration::from_secs(90),
         }
     }
 }
@@ -75,15 +123,31 @@ pub struct TransactionsResponse {
 
 impl HorizonClient {
     pub fn new(base_url: String) -> Self {
+        Self::with_config(base_url, HorizonClientConfig::default())
+    }
+
+    /// Build a client with an explicitly configured connection pool size,
+    /// request timeout, and keep-alive interval (see [`HorizonClientConfig`]).
+    pub fn with_config(base_url: String, config: HorizonClientConfig) -> Self {
         let endpoints = vec![base_url.clone()];
         let endpoint_health = new_health_states(endpoints.len());
+        let client = reqwest::Client::builder()
+            .timeout(config.request_timeout)
+            .pool_max_idle_per_host(config.max_connections)
+            .pool_idle_timeout(config.keep_alive)
+            .tcp_keepalive(config.keep_alive)
+            .build()
+            .unwrap_or_else(|e| {
+                warn!(error = %e, "Failed to build configured Horizon reqwest client — falling back to defaults");
+                reqwest::Client::new()
+            });
         Self {
             base_url,
             rpc_endpoints: std::sync::Arc::new(endpoints),
             rr_index: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             endpoint_health,
-            client: reqwest::Client::new(),
-            request_timeout: Duration::from_secs(15),
+            client,
+            request_timeout: config.request_timeout,
         }
     }
 
@@ -142,6 +206,19 @@ impl HorizonClient {
     /// EWMA success rate and the Prometheus gauge, and flipping its circuit
     /// breaker open/closed as thresholds are crossed.
     fn record_result(&self, endpoint_idx: usize, success: bool) {
+        self.record_outcome(endpoint_idx, success, false);
+    }
+
+    /// Record a request that failed specifically because it timed out. Tracks
+    /// a *consecutive timeout* streak independent of the general EWMA
+    /// success-rate breaker, tripping the endpoint's circuit immediately once
+    /// [`TIMEOUT_CIRCUIT_THRESHOLD`] consecutive timeouts are seen — a run of
+    /// timeouts means the endpoint is unresponsive right now.
+    fn record_timeout_failure(&self, endpoint_idx: usize) {
+        self.record_outcome(endpoint_idx, false, true);
+    }
+
+    fn record_outcome(&self, endpoint_idx: usize, success: bool, is_timeout: bool) {
         let Some(slot) = self.endpoint_health.get(endpoint_idx) else {
             return;
         };
@@ -151,7 +228,7 @@ impl HorizonClient {
             .cloned()
             .unwrap_or_else(|| self.base_url.clone());
 
-        let (rate, healthy, just_tripped, just_recovered) = {
+        let (rate, healthy, just_tripped, just_recovered, timeout_tripped, consecutive_timeouts) = {
             let Ok(mut state) = slot.lock() else {
                 return;
             };
@@ -165,9 +242,15 @@ impl HorizonClient {
             } else {
                 state.consecutive_failures.saturating_add(1)
             };
+            state.consecutive_timeouts = if is_timeout {
+                state.consecutive_timeouts.saturating_add(1)
+            } else {
+                0
+            };
 
             let mut just_tripped = false;
             let mut just_recovered = false;
+            let mut timeout_tripped = false;
 
             if state.healthy
                 && state.samples >= MIN_SAMPLES_BEFORE_TRIP
@@ -175,13 +258,27 @@ impl HorizonClient {
             {
                 state.healthy = false;
                 just_tripped = true;
+            } else if state.healthy && state.consecutive_timeouts > TIMEOUT_CIRCUIT_THRESHOLD {
+                // Fast path: don't wait for MIN_SAMPLES_BEFORE_TRIP when the
+                // endpoint is timing out on every request right now.
+                state.healthy = false;
+                just_tripped = true;
+                timeout_tripped = true;
             } else if !state.healthy && state.ewma_success_rate >= RECOVERY_THRESHOLD {
                 state.healthy = true;
                 state.consecutive_failures = 0;
+                state.consecutive_timeouts = 0;
                 just_recovered = true;
             }
 
-            (state.ewma_success_rate, state.healthy, just_tripped, just_recovered)
+            (
+                state.ewma_success_rate,
+                state.healthy,
+                just_tripped,
+                just_recovered,
+                timeout_tripped,
+                state.consecutive_timeouts,
+            )
         };
 
         crate::metrics::stellar_horizon::endpoint_success_rate()
@@ -191,7 +288,13 @@ impl HorizonClient {
             .with_label_values(&[&endpoint_label])
             .set(if healthy { 1.0 } else { 0.0 });
 
-        if just_tripped {
+        if just_tripped && timeout_tripped {
+            warn!(
+                endpoint = %endpoint_label,
+                consecutive_timeouts,
+                "Horizon endpoint circuit-broken after repeated consecutive timeouts; excluded from rotation"
+            );
+        } else if just_tripped {
             warn!(
                 endpoint = %endpoint_label,
                 success_rate = rate,
@@ -267,6 +370,7 @@ impl HorizonClient {
         let mut params = std::collections::HashMap::new();
         params.insert("tx", tx_envelope);
 
+        let _conn_guard = ActiveConnectionGuard::new();
         let response = self
             .client
             .post(&url)
@@ -275,7 +379,11 @@ impl HorizonClient {
             .send()
             .await
             .map_err(|e| {
-                self.record_result(endpoint_idx, false);
+                if e.is_timeout() {
+                    self.record_timeout_failure(endpoint_idx);
+                } else {
+                    self.record_result(endpoint_idx, false);
+                }
                 SubmissionError::HorizonApi(format!("POST /transactions failed: {}", e))
             })?;
 
@@ -334,6 +442,7 @@ impl HorizonClient {
         let (endpoint_idx, endpoint) = self.pick_endpoint();
         let url = format!("{}/transactions/{}", endpoint, tx_hash);
 
+        let _conn_guard = ActiveConnectionGuard::new();
         let response = self
             .client
             .get(&url)
@@ -341,7 +450,11 @@ impl HorizonClient {
             .send()
             .await
             .map_err(|e| {
-                self.record_result(endpoint_idx, false);
+                if e.is_timeout() {
+                    self.record_timeout_failure(endpoint_idx);
+                } else {
+                    self.record_result(endpoint_idx, false);
+                }
                 SubmissionError::HorizonApi(format!("GET /transactions/{{}} failed: {}", e))
             })?;
 
@@ -374,6 +487,7 @@ impl HorizonClient {
             sequence: String,
         }
 
+        let _conn_guard = ActiveConnectionGuard::new();
         let response = self
             .client
             .get(&url)
@@ -381,7 +495,11 @@ impl HorizonClient {
             .send()
             .await
             .map_err(|e| {
-                self.record_result(endpoint_idx, false);
+                if e.is_timeout() {
+                    self.record_timeout_failure(endpoint_idx);
+                } else {
+                    self.record_result(endpoint_idx, false);
+                }
                 SubmissionError::HorizonApi(format!("failed to fetch account sequence: {}", e))
             })?;
 

--- a/src/travel_rule/handlers.rs
+++ b/src/travel_rule/handlers.rs
@@ -1,0 +1,303 @@
+use crate::middleware::rbac::{CallerIdentity, ROLE_COMPLIANCE_OFFICER, ROLE_FINANCE_DIRECTOR};
+use crate::travel_rule::models::*;
+use crate::travel_rule::repository::TravelRuleRepository;
+use crate::travel_rule::service::TravelRuleService;
+use axum::{
+    extract::{Extension, Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct TravelRuleState {
+    pub repo: Arc<TravelRuleRepository>,
+    pub service: Arc<TravelRuleService>,
+}
+
+// ---------------------------------------------------------------------------
+// Generic response helpers
+// ---------------------------------------------------------------------------
+
+fn ok<T: Serialize>(data: T) -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::OK, Json(json!({ "success": true, "data": data })))
+}
+
+fn created<T: Serialize>(data: T) -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::CREATED, Json(json!({ "success": true, "data": data })))
+}
+
+fn err_400(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::BAD_REQUEST, Json(json!({ "success": false, "error": msg })))
+}
+
+fn err_403(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::FORBIDDEN, Json(json!({ "success": false, "error": msg })))
+}
+
+fn err_404(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::NOT_FOUND, Json(json!({ "success": false, "error": msg })))
+}
+
+fn err_500(e: impl std::fmt::Display) -> (StatusCode, Json<serde_json::Value>) {
+    tracing::error!(error = %e, "Travel Rule internal error");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "success": false, "error": e.to_string() })),
+    )
+}
+
+fn require_compliance_officer(caller: &CallerIdentity) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if caller.role != ROLE_COMPLIANCE_OFFICER && caller.role != ROLE_FINANCE_DIRECTOR {
+        return Err(err_403("compliance_officer or finance_director role required"));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// VASP Registry handlers
+// ---------------------------------------------------------------------------
+
+/// POST /api/admin/compliance/travel-rule/vasps
+pub async fn register_vasp(
+    State(state): State<Arc<TravelRuleState>>,
+    Extension(caller): Extension<CallerIdentity>,
+    Json(req): Json<RegisterVaspRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = require_compliance_officer(&caller) {
+        return e.into_response();
+    }
+    match state.repo.create_vasp(&req).await {
+        Ok(v) => created(v).into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+/// GET /api/admin/compliance/travel-rule/vasps
+pub async fn list_vasps(
+    State(state): State<Arc<TravelRuleState>>,
+    Query(query): Query<ListVaspsQuery>,
+) -> impl IntoResponse {
+    match state.repo.list_vasps(&query).await {
+        Ok(vasps) => ok(vasps).into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+/// GET /api/admin/compliance/travel-rule/vasps/:vasp_id
+pub async fn get_vasp(
+    State(state): State<Arc<TravelRuleState>>,
+    Path(vasp_id): Path<String>,
+) -> impl IntoResponse {
+    match state.repo.get_vasp(&vasp_id).await {
+        Ok(Some(v)) => ok(v).into_response(),
+        Ok(None) => err_404("VASP not found").into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+/// PATCH /api/admin/compliance/travel-rule/vasps/:vasp_id
+pub async fn update_vasp(
+    State(state): State<Arc<TravelRuleState>>,
+    Extension(caller): Extension<CallerIdentity>,
+    Path(vasp_id): Path<String>,
+    Json(req): Json<UpdateVaspRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = require_compliance_officer(&caller) {
+        return e.into_response();
+    }
+    match state.repo.update_vasp(&vasp_id, &req).await {
+        Ok(v) => ok(v).into_response(),
+        Err(e) if e.to_string().contains("not found") => err_404("VASP not found").into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Threshold handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/admin/compliance/travel-rule/thresholds
+pub async fn get_thresholds(
+    State(state): State<Arc<TravelRuleState>>,
+) -> impl IntoResponse {
+    match state.repo.list_thresholds().await {
+        Ok(t) => ok(t).into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+/// PATCH /api/admin/compliance/travel-rule/thresholds
+/// Requires compliance_officer role.
+pub async fn update_thresholds(
+    State(state): State<Arc<TravelRuleState>>,
+    Extension(caller): Extension<CallerIdentity>,
+    Json(req): Json<UpdateThresholdsRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = require_compliance_officer(&caller) {
+        return e.into_response();
+    }
+    let mut updated = Vec::new();
+    for item in &req.thresholds {
+        match state.repo.upsert_threshold(item, req.approved_by).await {
+            Ok(t) => updated.push(t),
+            Err(e) => return err_500(e).into_response(),
+        }
+    }
+    ok(updated).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Unhosted wallet policy handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/admin/compliance/travel-rule/unhosted-wallet-policy
+pub async fn get_unhosted_policy(
+    State(state): State<Arc<TravelRuleState>>,
+) -> impl IntoResponse {
+    match state.repo.get_active_policy().await {
+        Ok(Some(p)) => ok(p).into_response(),
+        Ok(None) => err_404("No unhosted wallet policy configured").into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+/// PATCH /api/admin/compliance/travel-rule/unhosted-wallet-policy
+/// Requires compliance_officer role AND a distinct senior_management_id (dual approval).
+pub async fn update_unhosted_policy(
+    State(state): State<Arc<TravelRuleState>>,
+    Extension(caller): Extension<CallerIdentity>,
+    Json(req): Json<UpdateUnhostedWalletPolicyRequest>,
+) -> impl IntoResponse {
+    if caller.role != ROLE_COMPLIANCE_OFFICER {
+        return err_403("compliance_officer role required for unhosted wallet policy changes")
+            .into_response();
+    }
+    // Dual approval: compliance officer and senior management must be different users
+    if req.compliance_officer_id == req.senior_management_id {
+        return err_400(
+            "compliance_officer_id and senior_management_id must be different users"
+        ).into_response();
+    }
+    const VALID_POLICIES: &[&str] =
+        &["allow", "allow_below_threshold", "require_attestation", "block"];
+    if !VALID_POLICIES.contains(&req.policy_type.as_str()) {
+        return err_400(&format!(
+            "policy_type must be one of: {}",
+            VALID_POLICIES.join(", ")
+        ))
+        .into_response();
+    }
+    match state.repo.update_policy(&req).await {
+        Ok(p) => ok(p).into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Message management handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/admin/compliance/travel-rule/messages
+pub async fn list_messages(
+    State(state): State<Arc<TravelRuleState>>,
+    Query(query): Query<TravelRuleMessageListQuery>,
+) -> impl IntoResponse {
+    match state.repo.list_exchanges(&query).await {
+        Ok(msgs) => ok(msgs).into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+/// GET /api/admin/compliance/travel-rule/messages/:message_id
+pub async fn get_message(
+    State(state): State<Arc<TravelRuleState>>,
+    Path(message_id): Path<Uuid>,
+) -> impl IntoResponse {
+    match state.repo.get_exchange(message_id).await {
+        Ok(Some(msg)) => ok(msg).into_response(),
+        Ok(None) => err_404("Message not found").into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+/// POST /api/admin/compliance/travel-rule/messages/:message_id/retry
+pub async fn retry_message(
+    State(state): State<Arc<TravelRuleState>>,
+    Extension(caller): Extension<CallerIdentity>,
+    Path(message_id): Path<Uuid>,
+) -> impl IntoResponse {
+    if let Err(e) = require_compliance_officer(&caller) {
+        return e.into_response();
+    }
+    match state.service.retry_failed_message(message_id).await {
+        Ok(msg) => ok(msg).into_response(),
+        Err(e) if e.to_string().contains("not in a retryable state") => {
+            err_400(&e.to_string()).into_response()
+        }
+        Err(e) if e.to_string().contains("not found") => err_404("Message not found").into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inbound Travel Rule receive endpoint (public — called by counterpart VASPs)
+// ---------------------------------------------------------------------------
+
+/// POST /api/compliance/travel-rule/inbound/:protocol
+pub async fn receive_inbound(
+    State(state): State<Arc<TravelRuleState>>,
+    Path(protocol): Path<String>,
+    Json(data): Json<InboundTravelRuleData>,
+) -> impl IntoResponse {
+    match state.service.handle_inbound(data).await {
+        Ok(exchange) => ok(json!({
+            "exchange_id": exchange.exchange_id,
+            "status": exchange.status,
+            "acknowledged": true,
+        }))
+        .into_response(),
+        Err(e) => {
+            tracing::warn!(error = %e, protocol = %protocol, "Inbound Travel Rule handling failed");
+            err_400(&e.to_string()).into_response()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Self-attestation handler
+// ---------------------------------------------------------------------------
+
+/// POST /api/compliance/travel-rule/attest
+pub async fn submit_attestation(
+    State(state): State<Arc<TravelRuleState>>,
+    Json(req): Json<SelfAttestationRequest>,
+) -> impl IntoResponse {
+    match state.service.submit_attestation(req).await {
+        Ok(att) => created(att).into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metrics / reporting handler
+// ---------------------------------------------------------------------------
+
+/// GET /api/admin/compliance/travel-rule/metrics
+pub async fn get_metrics(
+    State(state): State<Arc<TravelRuleState>>,
+    Query(query): Query<TravelRuleMetricsQuery>,
+) -> impl IntoResponse {
+    match state.repo.compute_metrics(query.from, query.to).await {
+        Ok(m) => ok(m).into_response(),
+        Err(e) => err_500(e).into_response(),
+    }
+}

--- a/src/travel_rule/metrics.rs
+++ b/src/travel_rule/metrics.rs
@@ -1,0 +1,72 @@
+use lazy_static::lazy_static;
+use prometheus::{register_counter_vec, register_counter, register_gauge, CounterVec, Counter, Gauge};
+
+lazy_static! {
+    pub static ref OUTBOUND_MESSAGES_TOTAL: CounterVec = register_counter_vec!(
+        "aframp_travel_rule_outbound_messages_total",
+        "Total outbound Travel Rule messages by status/protocol",
+        &["status"]
+    ).unwrap();
+
+    pub static ref INBOUND_MESSAGES_TOTAL: CounterVec = register_counter_vec!(
+        "aframp_travel_rule_inbound_messages_total",
+        "Total inbound Travel Rule messages by protocol",
+        &["protocol"]
+    ).unwrap();
+
+    pub static ref TRANSMISSION_FAILURES_TOTAL: CounterVec = register_counter_vec!(
+        "aframp_travel_rule_transmission_failures_total",
+        "Travel Rule outbound transmission failures by reason",
+        &["reason"]
+    ).unwrap();
+
+    pub static ref SCREENING_FAILURES_TOTAL: Counter = register_counter!(
+        "aframp_travel_rule_originator_screening_failures_total",
+        "Inbound originator IVMS101 sanctions screening failures"
+    ).unwrap();
+
+    pub static ref UNHOSTED_WALLET_TRANSACTIONS_TOTAL: CounterVec = register_counter_vec!(
+        "aframp_travel_rule_unhosted_wallet_transactions_total",
+        "Transactions to unhosted wallets by policy outcome",
+        &["policy_outcome"]
+    ).unwrap();
+
+    pub static ref SUNRISE_RULE_APPLIED_TOTAL: Counter = register_counter!(
+        "aframp_travel_rule_sunrise_rule_applied_total",
+        "Times the Travel Rule sunrise rule was applied (VASP known but no supported protocol)"
+    ).unwrap();
+
+    pub static ref UNACKNOWLEDGED_OUTBOUND_COUNT: Gauge = register_gauge!(
+        "aframp_travel_rule_unacknowledged_outbound_count",
+        "Current number of outbound Travel Rule messages awaiting acknowledgement"
+    ).unwrap();
+
+    pub static ref PENDING_INBOUND_SCREENING_COUNT: Gauge = register_gauge!(
+        "aframp_travel_rule_pending_inbound_screening_count",
+        "Current number of inbound messages pending originator screening"
+    ).unwrap();
+
+    pub static ref VASP_REGISTRY_SIZE: Gauge = register_gauge!(
+        "aframp_travel_rule_vasp_registry_size",
+        "Total number of VASPs in the registry"
+    ).unwrap();
+}
+
+/// Register all Travel Rule metrics with the global Prometheus registry.
+/// Called from `metrics::register_all()` in `src/metrics/mod.rs`.
+pub fn register(r: &prometheus::Registry) {
+    macro_rules! reg {
+        ($m:expr) => {
+            r.register(Box::new($m.clone())).ok();
+        };
+    }
+    reg!(OUTBOUND_MESSAGES_TOTAL);
+    reg!(INBOUND_MESSAGES_TOTAL);
+    reg!(TRANSMISSION_FAILURES_TOTAL);
+    reg!(SCREENING_FAILURES_TOTAL);
+    reg!(UNHOSTED_WALLET_TRANSACTIONS_TOTAL);
+    reg!(SUNRISE_RULE_APPLIED_TOTAL);
+    reg!(UNACKNOWLEDGED_OUTBOUND_COUNT);
+    reg!(PENDING_INBOUND_SCREENING_COUNT);
+    reg!(VASP_REGISTRY_SIZE);
+}

--- a/src/travel_rule/mod.rs
+++ b/src/travel_rule/mod.rs
@@ -1,0 +1,34 @@
+/// Travel Rule Compliance (Issue #452)
+///
+/// FATF Recommendation 16 — VASP-to-VASP PII exchange at threshold.
+///
+/// Key behaviours:
+/// - Outbound transfers above threshold enter pending_travel_rule state
+/// - Protocol router: TRISA → TRP → OpenVASP, with fallback chain
+/// - Encrypted off-chain PII exchange (IVMS101 schema, AES-256-GCM)
+/// - Inbound transfers screened against sanctions before clearing
+/// - Unhosted wallets routed per configurable policy (allow/block/attest)
+/// - Sunrise rule applied when VASP exists but has no supported protocol
+/// - All exchanges persisted for audit trail and regulatory reporting
+///
+/// Protocol adapters are transport skeletons — not certified for production
+/// inter-VASP interop. Full TRISA/OpenVASP/TRP certification requires VASP
+/// registration with the respective governing body and mutual TLS setup.
+pub mod handlers;
+pub mod metrics;
+pub mod models;
+pub mod protocols;
+pub mod repository;
+pub mod routes;
+pub mod service;
+pub mod worker;
+
+#[cfg(test)]
+pub mod tests;
+
+pub use handlers::{TravelRuleState};
+pub use models::*;
+pub use repository::TravelRuleRepository;
+pub use routes::travel_rule_router;
+pub use service::TravelRuleService;
+pub use worker::TravelRuleSlaWorker;

--- a/src/travel_rule/models.rs
+++ b/src/travel_rule/models.rs
@@ -1,0 +1,342 @@
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "travel_rule_status", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum TravelRuleStatus {
+    Pending,
+    Acknowledged,
+    Failed,
+    ManualReview,
+    TimedOut,
+    Completed,
+}
+
+/// Canonical protocol list per Issue #452 (OpenVASP, TRP, TRISA).
+/// `Trust` kept as DB-compat alias for `Trp`; `Ivms101Direct` retained for
+/// legacy rows created by the v1 stub.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "travel_rule_protocol", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum TravelRuleProtocol {
+    Trisa,
+    Trust,
+    OpenVasp,
+    Ivms101Direct,
+    Unknown,
+    Trp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "travel_rule_direction", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum TravelRuleDirection {
+    Outbound,
+    Inbound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "vasp_trust_status", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum VaspTrustStatus {
+    Verified,
+    Unverified,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "vasp_regulatory_status", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum VaspRegulatoryStatus {
+    Licensed,
+    Unlicensed,
+    Pending,
+    Suspended,
+}
+
+// ---------------------------------------------------------------------------
+// IVMS101 identity types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ivms101NaturalPerson {
+    pub first_name: String,
+    pub last_name: String,
+    pub date_of_birth: Option<String>,
+    pub national_id: Option<String>,
+    pub address: Option<String>,
+    pub country_of_residence: Option<String>,
+    /// Originator wallet address or account number
+    pub account_number: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ivms101LegalPerson {
+    pub legal_name: String,
+    pub registration_number: Option<String>,
+    pub country_of_registration: Option<String>,
+    pub address: Option<String>,
+    pub account_number: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Ivms101Person {
+    Natural(Ivms101NaturalPerson),
+    Legal(Ivms101LegalPerson),
+}
+
+// ---------------------------------------------------------------------------
+// Core DB models
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TravelRuleExchange {
+    pub exchange_id: Uuid,
+    pub transaction_id: String,
+    pub originator_vasp_id: String,
+    pub beneficiary_vasp_id: String,
+    pub protocol_used: TravelRuleProtocol,
+    pub status: TravelRuleStatus,
+    pub originator_ivms101: Value,
+    pub beneficiary_ivms101: Value,
+    pub transfer_amount: String,
+    pub asset_code: String,
+    pub handshake_initiated_at: DateTime<Utc>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
+    pub timeout_at: DateTime<Utc>,
+    pub failure_reason: Option<String>,
+    // v2 fields
+    pub direction: TravelRuleDirection,
+    pub sunrise_rule_applied: bool,
+    pub sla_window_secs: i32,
+    pub sla_breached: bool,
+    pub sla_breached_at: Option<DateTime<Utc>>,
+    pub screening_result: Option<Value>,
+    pub compliance_case_id: Option<Uuid>,
+    pub retry_count: i32,
+    pub last_retry_at: Option<DateTime<Utc>>,
+    pub pending_travel_rule: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct VaspRegistryEntry {
+    pub vasp_id: String,
+    pub vasp_name: String,
+    pub supported_protocols: Vec<String>,
+    pub travel_rule_endpoint: Option<String>,
+    pub is_verified: bool,
+    pub jurisdiction: String,
+    pub last_verified_at: Option<DateTime<Utc>>,
+    // v2 fields
+    pub vasp_did: Option<String>,
+    pub lei: Option<String>,
+    pub regulatory_status: VaspRegulatoryStatus,
+    pub trust_status: VaspTrustStatus,
+    pub public_key_pem: Option<String>,
+    pub interaction_count: i32,
+    pub last_interaction_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TravelRuleThreshold {
+    pub id: Uuid,
+    pub currency: String,
+    pub transaction_type: String,
+    pub jurisdiction: String,
+    pub threshold_amount: Decimal,
+    pub is_active: bool,
+    pub approved_by: Option<Uuid>,
+    pub approved_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct UnhostedWalletPolicy {
+    pub id: Uuid,
+    pub policy_type: String,
+    pub threshold_amount: Option<Decimal>,
+    pub threshold_currency: Option<String>,
+    pub updated_by_compliance_officer: Option<Uuid>,
+    pub updated_by_senior_management: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct TravelRuleAttestation {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub transaction_id: String,
+    pub wallet_address: String,
+    pub attested_at: DateTime<Utc>,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Request / Response DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitiateTravelRuleRequest {
+    pub transaction_id: String,
+    pub beneficiary_vasp_id: String,
+    pub originator: Ivms101Person,
+    pub beneficiary: Ivms101Person,
+    pub transfer_amount: String,
+    pub asset_code: String,
+    /// Destination wallet address for VASP discovery
+    pub destination_address: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InboundTravelRuleData {
+    pub exchange_id: Uuid,
+    pub originator_vasp_id: String,
+    pub transaction_id: String,
+    pub originator: Ivms101Person,
+    pub beneficiary: Ivms101Person,
+    pub transfer_amount: String,
+    pub asset_code: String,
+    pub protocol_used: TravelRuleProtocol,
+    /// Base64-encoded HMAC-SHA256 signature over the raw JSON body
+    pub sender_signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterVaspRequest {
+    pub vasp_id: String,
+    pub vasp_name: String,
+    pub jurisdiction: String,
+    pub supported_protocols: Vec<String>,
+    pub travel_rule_endpoint: Option<String>,
+    pub vasp_did: Option<String>,
+    pub lei: Option<String>,
+    pub regulatory_status: Option<VaspRegulatoryStatus>,
+    pub trust_status: Option<VaspTrustStatus>,
+    pub public_key_pem: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateVaspRequest {
+    pub vasp_name: Option<String>,
+    pub supported_protocols: Option<Vec<String>>,
+    pub travel_rule_endpoint: Option<String>,
+    pub vasp_did: Option<String>,
+    pub lei: Option<String>,
+    pub regulatory_status: Option<VaspRegulatoryStatus>,
+    pub trust_status: Option<VaspTrustStatus>,
+    pub public_key_pem: Option<String>,
+    pub is_verified: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListVaspsQuery {
+    pub jurisdiction: Option<String>,
+    pub trust_status: Option<String>,
+    pub protocol: Option<String>,
+    pub page: Option<i64>,
+    pub page_size: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TravelRuleMessageListQuery {
+    pub direction: Option<String>,
+    pub status: Option<String>,
+    pub vasp_id: Option<String>,
+    pub from: Option<DateTime<Utc>>,
+    pub to: Option<DateTime<Utc>>,
+    pub page: Option<i64>,
+    pub page_size: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateThresholdsRequest {
+    pub thresholds: Vec<ThresholdUpdateItem>,
+    /// Compliance officer user ID (required)
+    pub approved_by: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThresholdUpdateItem {
+    pub currency: String,
+    pub transaction_type: String,
+    pub jurisdiction: String,
+    pub threshold_amount: Decimal,
+    pub is_active: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateUnhostedWalletPolicyRequest {
+    pub policy_type: String,
+    pub threshold_amount: Option<Decimal>,
+    pub threshold_currency: Option<String>,
+    /// Compliance officer approval — required
+    pub compliance_officer_id: Uuid,
+    /// Senior management approval — required for policy changes
+    pub senior_management_id: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelfAttestationRequest {
+    pub user_id: Uuid,
+    pub transaction_id: String,
+    pub wallet_address: String,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TravelRuleMetricsQuery {
+    pub from: DateTime<Utc>,
+    pub to: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TravelRuleMetrics {
+    pub period_from: DateTime<Utc>,
+    pub period_to: DateTime<Utc>,
+    pub total_threshold_triggering: i64,
+    pub successful_exchanges: i64,
+    pub failed_exchanges: i64,
+    pub unhosted_wallet_transactions: i64,
+    pub sunrise_rule_applications: i64,
+    pub inbound_received: i64,
+    pub inbound_screening_failures: i64,
+    pub outbound_by_protocol: std::collections::HashMap<String, i64>,
+    pub vasp_registry_size: i64,
+    pub unacknowledged_outbound: i64,
+    pub pending_inbound_screening: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncryptedPayload {
+    /// AES-GCM ciphertext, base64-encoded
+    pub ciphertext_b64: String,
+    /// AES key encrypted with recipient's RSA public key, base64-encoded
+    pub encrypted_key_b64: String,
+    /// GCM nonce, base64-encoded
+    pub nonce_b64: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransmissionResult {
+    pub success: bool,
+    pub protocol: TravelRuleProtocol,
+    pub error: Option<String>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
+}

--- a/src/travel_rule/protocols/mod.rs
+++ b/src/travel_rule/protocols/mod.rs
@@ -1,0 +1,8 @@
+pub mod openvasp;
+pub mod protocol_trait;
+pub mod router;
+pub mod trisa;
+pub mod trp;
+
+pub use protocol_trait::TravelRuleProtocolAdapter;
+pub use router::ProtocolRouter;

--- a/src/travel_rule/protocols/openvasp.rs
+++ b/src/travel_rule/protocols/openvasp.rs
@@ -1,0 +1,108 @@
+/// OpenVASP protocol adapter — transport skeleton.
+/// Not certified for production inter-VASP interop; requires VASP registration
+/// with the OpenVASP Association and symmetric session keys.
+use crate::travel_rule::models::{EncryptedPayload, TransmissionResult, TravelRuleProtocol};
+use crate::travel_rule::protocols::protocol_trait::TravelRuleProtocolAdapter;
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::Utc;
+use reqwest::Client;
+use serde_json::json;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+pub struct OpenVaspAdapter {
+    http: Client,
+    our_vasp_id: String,
+}
+
+impl OpenVaspAdapter {
+    pub fn new(our_vasp_id: String) -> Self {
+        Self {
+            http: Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
+            our_vasp_id,
+        }
+    }
+}
+
+#[async_trait]
+impl TravelRuleProtocolAdapter for OpenVaspAdapter {
+    fn protocol_name(&self) -> TravelRuleProtocol {
+        TravelRuleProtocol::OpenVasp
+    }
+
+    async fn send_originator_info(
+        &self,
+        endpoint: &str,
+        exchange_id: Uuid,
+        payload: &EncryptedPayload,
+        ) -> Result<TransmissionResult> {
+        let body = json!({
+            "version": "1.0",
+            "type": "TRANSFER_REQUEST",
+            "originator_vasp_id": self.our_vasp_id,
+            "exchange_id": exchange_id.to_string(),
+            "encrypted_payload": payload,
+        });
+
+        let resp = self
+            .http
+            .post(format!("{}/transfer", endpoint))
+            .header("Content-Type", "application/json")
+            .header("X-OpenVASP-Version", "1.0")
+            .json(&body)
+            .send()
+            .await;
+
+        match resp {
+            Ok(r) if r.status().is_success() || r.status().as_u16() == 202 => {
+                info!(exchange_id = %exchange_id, protocol = "openvasp", "Originator info transmitted");
+                Ok(TransmissionResult {
+                    success: true,
+                    protocol: TravelRuleProtocol::OpenVasp,
+                    error: None,
+                    acknowledged_at: Some(Utc::now()),
+                })
+            }
+            Ok(r) => {
+                let status = r.status();
+                warn!(exchange_id = %exchange_id, status = %status, "OpenVASP transmission rejected");
+                Ok(TransmissionResult {
+                    success: false,
+                    protocol: TravelRuleProtocol::OpenVasp,
+                    error: Some(format!("HTTP {}", status)),
+                    acknowledged_at: None,
+                })
+            }
+            Err(e) => {
+                warn!(exchange_id = %exchange_id, error = %e, "OpenVASP connection failed");
+                Ok(TransmissionResult {
+                    success: false,
+                    protocol: TravelRuleProtocol::OpenVasp,
+                    error: Some(e.to_string()),
+                    acknowledged_at: None,
+                })
+            }
+        }
+    }
+
+    async fn acknowledge_receipt(&self, endpoint: &str, exchange_id: Uuid) -> Result<()> {
+        let body = json!({
+            "exchange_id": exchange_id.to_string(),
+            "status": "RECEIVED",
+        });
+
+        let _ = self
+            .http
+            .post(format!("{}/acknowledge", endpoint))
+            .header("X-OpenVASP-Version", "1.0")
+            .json(&body)
+            .send()
+            .await;
+
+        Ok(())
+    }
+}

--- a/src/travel_rule/protocols/protocol_trait.rs
+++ b/src/travel_rule/protocols/protocol_trait.rs
@@ -1,0 +1,24 @@
+use crate::travel_rule::models::{EncryptedPayload, TransmissionResult, TravelRuleProtocol};
+use anyhow::Result;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+/// Implemented by every Travel Rule protocol adapter.
+/// Transport skeleton — not certified for production inter-VASP interop;
+/// full TRISA/OpenVASP/TRP certification requires VASP registration and
+/// mutual TLS certificate exchange with the respective governing body.
+#[async_trait]
+pub trait TravelRuleProtocolAdapter: Send + Sync {
+    fn protocol_name(&self) -> TravelRuleProtocol;
+
+    /// Transmit encrypted originator information to the counterparty VASP.
+    async fn send_originator_info(
+        &self,
+        endpoint: &str,
+        exchange_id: Uuid,
+        payload: &EncryptedPayload,
+    ) -> Result<TransmissionResult>;
+
+    /// Acknowledge receipt of an inbound message.
+    async fn acknowledge_receipt(&self, endpoint: &str, exchange_id: Uuid) -> Result<()>;
+}

--- a/src/travel_rule/protocols/router.rs
+++ b/src/travel_rule/protocols/router.rs
@@ -1,0 +1,138 @@
+use crate::travel_rule::models::{
+    EncryptedPayload, TransmissionResult, TravelRuleProtocol, VaspRegistryEntry,
+};
+use crate::travel_rule::protocols::openvasp::OpenVaspAdapter;
+use crate::travel_rule::protocols::protocol_trait::TravelRuleProtocolAdapter;
+use crate::travel_rule::protocols::trisa::TrisaAdapter;
+use crate::travel_rule::protocols::trp::TrpAdapter;
+use anyhow::Result;
+use std::sync::Arc;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+pub struct ProtocolRouter {
+    trisa: Arc<TrisaAdapter>,
+    trp: Arc<TrpAdapter>,
+    openvasp: Arc<OpenVaspAdapter>,
+}
+
+impl ProtocolRouter {
+    pub fn new(our_vasp_id: String) -> Self {
+        Self {
+            trisa: Arc::new(TrisaAdapter::new(our_vasp_id.clone())),
+            trp: Arc::new(TrpAdapter::new(our_vasp_id.clone())),
+            openvasp: Arc::new(OpenVaspAdapter::new(our_vasp_id)),
+        }
+    }
+
+    /// Attempt transmission in priority order: TRISA → TRP → OpenVASP.
+    /// Falls back to next protocol if the current one fails.
+    /// Returns `None` if all protocols fail (caller applies sunrise rule).
+    pub async fn select_and_send(
+        &self,
+        vasp: &VaspRegistryEntry,
+        exchange_id: Uuid,
+        payload: &EncryptedPayload,
+    ) -> Option<TransmissionResult> {
+        let endpoint = match &vasp.travel_rule_endpoint {
+            Some(ep) => ep.clone(),
+            None => {
+                warn!(
+                    vasp_id = %vasp.vasp_id,
+                    "No travel rule endpoint for VASP — cannot transmit"
+                );
+                return None;
+            }
+        };
+
+        let adapters = self.build_preference_chain(&vasp.supported_protocols);
+
+        for adapter in &adapters {
+            let result = adapter
+                .send_originator_info(&endpoint, exchange_id, payload)
+                .await;
+
+            match result {
+                Ok(r) if r.success => {
+                    info!(
+                        exchange_id = %exchange_id,
+                        protocol = ?r.protocol,
+                        "Travel Rule transmission succeeded"
+                    );
+                    return Some(r);
+                }
+                Ok(r) => {
+                    warn!(
+                        exchange_id = %exchange_id,
+                        protocol = ?r.protocol,
+                        error = ?r.error,
+                        "Protocol attempt failed, trying next"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        exchange_id = %exchange_id,
+                        error = %e,
+                        "Protocol adapter error, trying next"
+                    );
+                }
+            }
+        }
+
+        warn!(
+            exchange_id = %exchange_id,
+            vasp_id = %vasp.vasp_id,
+            "All Travel Rule protocols exhausted"
+        );
+        None
+    }
+
+    /// Acknowledge receipt of an inbound message using the preferred protocol.
+    pub async fn acknowledge_inbound(
+        &self,
+        vasp: &VaspRegistryEntry,
+        exchange_id: Uuid,
+        protocol_used: &TravelRuleProtocol,
+    ) -> Result<()> {
+        let endpoint = match &vasp.travel_rule_endpoint {
+            Some(ep) => ep.clone(),
+            None => return Ok(()), // best-effort
+        };
+
+        let adapter: &dyn TravelRuleProtocolAdapter = match protocol_used {
+            TravelRuleProtocol::Trisa => self.trisa.as_ref(),
+            TravelRuleProtocol::Trp | TravelRuleProtocol::Trust => self.trp.as_ref(),
+            TravelRuleProtocol::OpenVasp => self.openvasp.as_ref(),
+            _ => self.trisa.as_ref(),
+        };
+
+        adapter.acknowledge_receipt(&endpoint, exchange_id).await
+    }
+
+    fn build_preference_chain(
+        &self,
+        supported: &[String],
+    ) -> Vec<&dyn TravelRuleProtocolAdapter> {
+        let mut chain: Vec<&dyn TravelRuleProtocolAdapter> = Vec::new();
+
+        // Priority: TRISA first (most adopted globally), then TRP, then OpenVASP
+        if supported.iter().any(|p| p == "trisa") {
+            chain.push(self.trisa.as_ref());
+        }
+        if supported.iter().any(|p| p == "trp" || p == "trust") {
+            chain.push(self.trp.as_ref());
+        }
+        if supported.iter().any(|p| p == "open_vasp" || p == "openvasp") {
+            chain.push(self.openvasp.as_ref());
+        }
+
+        // If VASP has no recognized protocol, try all in preference order
+        if chain.is_empty() {
+            chain.push(self.trisa.as_ref());
+            chain.push(self.trp.as_ref());
+            chain.push(self.openvasp.as_ref());
+        }
+
+        chain
+    }
+}

--- a/src/travel_rule/protocols/trisa.rs
+++ b/src/travel_rule/protocols/trisa.rs
@@ -1,0 +1,110 @@
+/// TRISA (Travel Rule Information Sharing Architecture) adapter — transport skeleton.
+/// Not certified for production; requires TRISA Certificate Authority registration
+/// and mutual TLS with the TRISA Global Directory Service.
+use crate::travel_rule::models::{EncryptedPayload, TransmissionResult, TravelRuleProtocol};
+use crate::travel_rule::protocols::protocol_trait::TravelRuleProtocolAdapter;
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::Utc;
+use reqwest::Client;
+use serde_json::json;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+pub struct TrisaAdapter {
+    http: Client,
+    our_vasp_id: String,
+}
+
+impl TrisaAdapter {
+    pub fn new(our_vasp_id: String) -> Self {
+        Self {
+            http: Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
+            our_vasp_id,
+        }
+    }
+}
+
+#[async_trait]
+impl TravelRuleProtocolAdapter for TrisaAdapter {
+    fn protocol_name(&self) -> TravelRuleProtocol {
+        TravelRuleProtocol::Trisa
+    }
+
+    async fn send_originator_info(
+        &self,
+        endpoint: &str,
+        exchange_id: Uuid,
+        payload: &EncryptedPayload,
+    ) -> Result<TransmissionResult> {
+        let body = json!({
+            "identity": {
+                "version": 1,
+                "exchange_id": exchange_id.to_string(),
+                "originator_vasp": self.our_vasp_id,
+                "encrypted_payload": payload,
+            }
+        });
+
+        let resp = self
+            .http
+            .post(format!("{}/keyexchange", endpoint))
+            .header("Content-Type", "application/json")
+            .header("X-TRISA-Version", "v1beta1")
+            .header("X-TRISA-VASP-ID", &self.our_vasp_id)
+            .json(&body)
+            .send()
+            .await;
+
+        match resp {
+            Ok(r) if r.status().is_success() || r.status().as_u16() == 202 => {
+                info!(exchange_id = %exchange_id, protocol = "trisa", "Originator info transmitted");
+                Ok(TransmissionResult {
+                    success: true,
+                    protocol: TravelRuleProtocol::Trisa,
+                    error: None,
+                    acknowledged_at: Some(Utc::now()),
+                })
+            }
+            Ok(r) => {
+                let status = r.status();
+                warn!(exchange_id = %exchange_id, status = %status, "TRISA transmission rejected");
+                Ok(TransmissionResult {
+                    success: false,
+                    protocol: TravelRuleProtocol::Trisa,
+                    error: Some(format!("HTTP {}", status)),
+                    acknowledged_at: None,
+                })
+            }
+            Err(e) => {
+                warn!(exchange_id = %exchange_id, error = %e, "TRISA connection failed");
+                Ok(TransmissionResult {
+                    success: false,
+                    protocol: TravelRuleProtocol::Trisa,
+                    error: Some(e.to_string()),
+                    acknowledged_at: None,
+                })
+            }
+        }
+    }
+
+    async fn acknowledge_receipt(&self, endpoint: &str, exchange_id: Uuid) -> Result<()> {
+        let body = json!({
+            "exchange_id": exchange_id.to_string(),
+            "acknowledged": true,
+        });
+
+        let _ = self
+            .http
+            .post(format!("{}/acknowledge", endpoint))
+            .header("X-TRISA-Version", "v1beta1")
+            .json(&body)
+            .send()
+            .await;
+
+        Ok(())
+    }
+}

--- a/src/travel_rule/protocols/trp.rs
+++ b/src/travel_rule/protocols/trp.rs
@@ -1,0 +1,109 @@
+/// TRP (Travel Rule Protocol) adapter — transport skeleton.
+/// Not certified for production; requires enrollment with the TRUST & Track
+/// or interVASP TRP working group and signed message verification.
+use crate::travel_rule::models::{EncryptedPayload, TransmissionResult, TravelRuleProtocol};
+use crate::travel_rule::protocols::protocol_trait::TravelRuleProtocolAdapter;
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::Utc;
+use reqwest::Client;
+use serde_json::json;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+pub struct TrpAdapter {
+    http: Client,
+    our_vasp_id: String,
+}
+
+impl TrpAdapter {
+    pub fn new(our_vasp_id: String) -> Self {
+        Self {
+            http: Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
+            our_vasp_id,
+        }
+    }
+}
+
+#[async_trait]
+impl TravelRuleProtocolAdapter for TrpAdapter {
+    fn protocol_name(&self) -> TravelRuleProtocol {
+        TravelRuleProtocol::Trp
+    }
+
+    async fn send_originator_info(
+        &self,
+        endpoint: &str,
+        exchange_id: Uuid,
+        payload: &EncryptedPayload,
+    ) -> Result<TransmissionResult> {
+        let body = json!({
+            "LEI_version": "1.0",
+            "exchange_id": exchange_id.to_string(),
+            "sender_vasp_id": self.our_vasp_id,
+            "transfer": {
+                "encrypted_payload": payload,
+            }
+        });
+
+        let resp = self
+            .http
+            .post(format!("{}/trp/transfer", endpoint))
+            .header("Content-Type", "application/trp+json")
+            .header("X-TRP-Version", "2022-12")
+            .json(&body)
+            .send()
+            .await;
+
+        match resp {
+            Ok(r) if r.status().is_success() || r.status().as_u16() == 202 => {
+                info!(exchange_id = %exchange_id, protocol = "trp", "Originator info transmitted");
+                Ok(TransmissionResult {
+                    success: true,
+                    protocol: TravelRuleProtocol::Trp,
+                    error: None,
+                    acknowledged_at: Some(Utc::now()),
+                })
+            }
+            Ok(r) => {
+                let status = r.status();
+                warn!(exchange_id = %exchange_id, status = %status, "TRP transmission rejected");
+                Ok(TransmissionResult {
+                    success: false,
+                    protocol: TravelRuleProtocol::Trp,
+                    error: Some(format!("HTTP {}", status)),
+                    acknowledged_at: None,
+                })
+            }
+            Err(e) => {
+                warn!(exchange_id = %exchange_id, error = %e, "TRP connection failed");
+                Ok(TransmissionResult {
+                    success: false,
+                    protocol: TravelRuleProtocol::Trp,
+                    error: Some(e.to_string()),
+                    acknowledged_at: None,
+                })
+            }
+        }
+    }
+
+    async fn acknowledge_receipt(&self, endpoint: &str, exchange_id: Uuid) -> Result<()> {
+        let body = json!({
+            "exchange_id": exchange_id.to_string(),
+            "status": "RECEIVED",
+        });
+
+        let _ = self
+            .http
+            .post(format!("{}/trp/acknowledge", endpoint))
+            .header("Content-Type", "application/trp+json")
+            .json(&body)
+            .send()
+            .await;
+
+        Ok(())
+    }
+}

--- a/src/travel_rule/repository.rs
+++ b/src/travel_rule/repository.rs
@@ -1,0 +1,616 @@
+use crate::travel_rule::models::*;
+use anyhow::{anyhow, Result};
+use chrono::{Duration, Utc};
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use std::collections::HashMap;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+pub struct TravelRuleRepository {
+    pool: PgPool,
+}
+
+impl TravelRuleRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    // -------------------------------------------------------------------------
+    // VASP Registry
+    // -------------------------------------------------------------------------
+
+    pub async fn create_vasp(&self, req: &RegisterVaspRequest) -> Result<VaspRegistryEntry> {
+        let regulatory_status = req
+            .regulatory_status
+            .clone()
+            .unwrap_or(VaspRegulatoryStatus::Unlicensed);
+        let trust_status = req
+            .trust_status
+            .clone()
+            .unwrap_or(VaspTrustStatus::Unverified);
+        let now = Utc::now();
+
+        let entry = sqlx::query_as::<_, VaspRegistryEntry>(
+            r#"INSERT INTO vasp_registry (
+                vasp_id, vasp_name, jurisdiction, supported_protocols, travel_rule_endpoint,
+                vasp_did, lei, regulatory_status, trust_status, public_key_pem,
+                is_verified, interaction_count, created_at, updated_at
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,false,0,$11,$12)
+            RETURNING *"#,
+        )
+        .bind(&req.vasp_id)
+        .bind(&req.vasp_name)
+        .bind(&req.jurisdiction)
+        .bind(&req.supported_protocols)
+        .bind(&req.travel_rule_endpoint)
+        .bind(&req.vasp_did)
+        .bind(&req.lei)
+        .bind(&regulatory_status)
+        .bind(&trust_status)
+        .bind(&req.public_key_pem)
+        .bind(now)
+        .bind(now)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(entry)
+    }
+
+    pub async fn list_vasps(&self, query: &ListVaspsQuery) -> Result<Vec<VaspRegistryEntry>> {
+        let page = query.page.unwrap_or(1).max(1);
+        let page_size = query.page_size.unwrap_or(50).min(200);
+        let offset = (page - 1) * page_size;
+
+        let entries = sqlx::query_as::<_, VaspRegistryEntry>(
+            r#"SELECT * FROM vasp_registry
+               WHERE ($1::TEXT IS NULL OR jurisdiction = $1)
+                 AND ($2::TEXT IS NULL OR trust_status::TEXT = $2)
+                 AND ($3::TEXT IS NULL OR $3 = ANY(supported_protocols))
+               ORDER BY vasp_name
+               LIMIT $4 OFFSET $5"#,
+        )
+        .bind(&query.jurisdiction)
+        .bind(&query.trust_status)
+        .bind(&query.protocol)
+        .bind(page_size)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(entries)
+    }
+
+    pub async fn get_vasp(&self, vasp_id: &str) -> Result<Option<VaspRegistryEntry>> {
+        let entry = sqlx::query_as::<_, VaspRegistryEntry>(
+            "SELECT * FROM vasp_registry WHERE vasp_id = $1",
+        )
+        .bind(vasp_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(entry)
+    }
+
+    pub async fn update_vasp(&self, vasp_id: &str, req: &UpdateVaspRequest) -> Result<VaspRegistryEntry> {
+        let existing = self
+            .get_vasp(vasp_id)
+            .await?
+            .ok_or_else(|| anyhow!("VASP not found: {}", vasp_id))?;
+
+        let entry = sqlx::query_as::<_, VaspRegistryEntry>(
+            r#"UPDATE vasp_registry SET
+                vasp_name           = COALESCE($2, vasp_name),
+                supported_protocols = COALESCE($3, supported_protocols),
+                travel_rule_endpoint = COALESCE($4, travel_rule_endpoint),
+                vasp_did            = COALESCE($5, vasp_did),
+                lei                 = COALESCE($6, lei),
+                regulatory_status   = COALESCE($7, regulatory_status),
+                trust_status        = COALESCE($8, trust_status),
+                public_key_pem      = COALESCE($9, public_key_pem),
+                is_verified         = COALESCE($10, is_verified),
+                last_verified_at    = CASE WHEN $10 IS TRUE THEN NOW() ELSE last_verified_at END,
+                updated_at          = NOW()
+               WHERE vasp_id = $1
+               RETURNING *"#,
+        )
+        .bind(vasp_id)
+        .bind(&req.vasp_name)
+        .bind(&req.supported_protocols)
+        .bind(&req.travel_rule_endpoint)
+        .bind(&req.vasp_did)
+        .bind(&req.lei)
+        .bind(&req.regulatory_status)
+        .bind(&req.trust_status)
+        .bind(&req.public_key_pem)
+        .bind(req.is_verified)
+        .fetch_one(&self.pool)
+        .await?;
+
+        info!(vasp_id = vasp_id, "VASP registry entry updated");
+        let _ = existing; // used implicitly for existence check
+        Ok(entry)
+    }
+
+    /// Discover a VASP from a destination wallet address prefix.
+    /// Returns `None` for unhosted wallets — callers apply unhosted policy.
+    pub async fn discover_vasp_by_wallet(&self, wallet_address: &str) -> Result<Option<VaspRegistryEntry>> {
+        let row = sqlx::query_as::<_, VaspRegistryEntry>(
+            r#"SELECT vr.*
+               FROM vasp_registry vr
+               JOIN vasp_wallet_labels vwl ON vr.vasp_id = vwl.vasp_id
+               WHERE $1 LIKE (vwl.address_prefix || '%')
+               ORDER BY length(vwl.address_prefix) DESC
+               LIMIT 1"#,
+        )
+        .bind(wallet_address)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if row.is_none() {
+            warn!(
+                wallet = %wallet_address,
+                "VASP discovery: no registry match — treating as unhosted wallet"
+            );
+        }
+
+        Ok(row)
+    }
+
+    pub async fn increment_vasp_interaction(&self, vasp_id: &str) -> Result<()> {
+        sqlx::query(
+            r#"UPDATE vasp_registry
+               SET interaction_count = interaction_count + 1,
+                   last_interaction_at = NOW(),
+                   updated_at = NOW()
+               WHERE vasp_id = $1"#,
+        )
+        .bind(vasp_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn vasp_registry_size(&self) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM vasp_registry")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(row.0)
+    }
+
+    // -------------------------------------------------------------------------
+    // Exchanges
+    // -------------------------------------------------------------------------
+
+    pub async fn create_exchange(
+        &self,
+        originator_vasp_id: &str,
+        beneficiary_vasp_id: &str,
+        transaction_id: &str,
+        protocol: &TravelRuleProtocol,
+        direction: &TravelRuleDirection,
+        originator_json: serde_json::Value,
+        beneficiary_json: serde_json::Value,
+        transfer_amount: &str,
+        asset_code: &str,
+        sla_window_secs: i32,
+    ) -> Result<TravelRuleExchange> {
+        let now = Utc::now();
+        let timeout_at = now + Duration::seconds(sla_window_secs as i64);
+
+        let exchange = sqlx::query_as::<_, TravelRuleExchange>(
+            r#"INSERT INTO travel_rule_exchanges (
+                exchange_id, transaction_id, originator_vasp_id, beneficiary_vasp_id,
+                protocol_used, direction, status, originator_ivms101, beneficiary_ivms101,
+                transfer_amount, asset_code, handshake_initiated_at, timeout_at,
+                sla_window_secs, pending_travel_rule, created_at, updated_at
+            ) VALUES (
+                gen_random_uuid(), $1, $2, $3, $4, $5, 'pending', $6, $7,
+                $8, $9, $10, $11, $12, true, $10, $10
+            ) RETURNING *"#,
+        )
+        .bind(transaction_id)
+        .bind(originator_vasp_id)
+        .bind(beneficiary_vasp_id)
+        .bind(protocol)
+        .bind(direction)
+        .bind(&originator_json)
+        .bind(&beneficiary_json)
+        .bind(transfer_amount)
+        .bind(asset_code)
+        .bind(now)
+        .bind(timeout_at)
+        .bind(sla_window_secs)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(exchange)
+    }
+
+    pub async fn list_exchanges(&self, query: &TravelRuleMessageListQuery) -> Result<Vec<TravelRuleExchange>> {
+        let page = query.page.unwrap_or(1).max(1);
+        let page_size = query.page_size.unwrap_or(50).min(200);
+        let offset = (page - 1) * page_size;
+
+        let exchanges = sqlx::query_as::<_, TravelRuleExchange>(
+            r#"SELECT * FROM travel_rule_exchanges
+               WHERE ($1::TEXT IS NULL OR direction::TEXT = $1)
+                 AND ($2::TEXT IS NULL OR status::TEXT = $2)
+                 AND ($3::TEXT IS NULL OR originator_vasp_id = $3 OR beneficiary_vasp_id = $3)
+                 AND ($4::TIMESTAMPTZ IS NULL OR created_at >= $4)
+                 AND ($5::TIMESTAMPTZ IS NULL OR created_at <= $5)
+               ORDER BY created_at DESC
+               LIMIT $6 OFFSET $7"#,
+        )
+        .bind(&query.direction)
+        .bind(&query.status)
+        .bind(&query.vasp_id)
+        .bind(query.from)
+        .bind(query.to)
+        .bind(page_size)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(exchanges)
+    }
+
+    pub async fn get_exchange(&self, exchange_id: Uuid) -> Result<Option<TravelRuleExchange>> {
+        let ex = sqlx::query_as::<_, TravelRuleExchange>(
+            "SELECT * FROM travel_rule_exchanges WHERE exchange_id = $1",
+        )
+        .bind(exchange_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(ex)
+    }
+
+    pub async fn mark_acknowledged(&self, exchange_id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"UPDATE travel_rule_exchanges
+               SET status = 'acknowledged', acknowledged_at = NOW(),
+                   pending_travel_rule = false, updated_at = NOW()
+               WHERE exchange_id = $1"#,
+        )
+        .bind(exchange_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_failed(&self, exchange_id: Uuid, reason: &str) -> Result<()> {
+        sqlx::query(
+            r#"UPDATE travel_rule_exchanges
+               SET status = 'failed', failure_reason = $2,
+                   pending_travel_rule = false, updated_at = NOW()
+               WHERE exchange_id = $1"#,
+        )
+        .bind(exchange_id)
+        .bind(reason)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_sunrise_rule_applied(&self, exchange_id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"UPDATE travel_rule_exchanges
+               SET sunrise_rule_applied = true, status = 'completed',
+                   pending_travel_rule = false, updated_at = NOW()
+               WHERE exchange_id = $1"#,
+        )
+        .bind(exchange_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_screening_failed(
+        &self,
+        exchange_id: Uuid,
+        screening_result: serde_json::Value,
+        compliance_case_id: Uuid,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"UPDATE travel_rule_exchanges
+               SET status = 'manual_review',
+                   screening_result = $2,
+                   compliance_case_id = $3,
+                   pending_travel_rule = true,
+                   updated_at = NOW()
+               WHERE exchange_id = $1"#,
+        )
+        .bind(exchange_id)
+        .bind(&screening_result)
+        .bind(compliance_case_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn increment_retry(&self, exchange_id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"UPDATE travel_rule_exchanges
+               SET retry_count = retry_count + 1, last_retry_at = NOW(),
+                   status = 'pending', updated_at = NOW()
+               WHERE exchange_id = $1"#,
+        )
+        .bind(exchange_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Returns pending outbound exchanges whose SLA window has elapsed.
+    pub async fn get_unacknowledged_past_sla(&self) -> Result<Vec<TravelRuleExchange>> {
+        let exchanges = sqlx::query_as::<_, TravelRuleExchange>(
+            r#"SELECT * FROM travel_rule_exchanges
+               WHERE status = 'pending'
+                 AND direction = 'outbound'
+                 AND timeout_at < NOW()
+                 AND sla_breached = false"#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(exchanges)
+    }
+
+    pub async fn mark_sla_breached(&self, exchange_id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"UPDATE travel_rule_exchanges
+               SET status = 'timed_out', sla_breached = true,
+                   sla_breached_at = NOW(), pending_travel_rule = false,
+                   updated_at = NOW()
+               WHERE exchange_id = $1"#,
+        )
+        .bind(exchange_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn count_unacknowledged_outbound(&self) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM travel_rule_exchanges
+               WHERE status = 'pending' AND direction = 'outbound'"#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    pub async fn count_pending_inbound_screening(&self) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            r#"SELECT COUNT(*) FROM travel_rule_exchanges
+               WHERE status IN ('pending','manual_review') AND direction = 'inbound'"#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    // -------------------------------------------------------------------------
+    // Thresholds
+    // -------------------------------------------------------------------------
+
+    pub async fn get_threshold(
+        &self,
+        currency: &str,
+        transaction_type: &str,
+        jurisdiction: &str,
+    ) -> Result<Option<TravelRuleThreshold>> {
+        let threshold = sqlx::query_as::<_, TravelRuleThreshold>(
+            r#"SELECT * FROM travel_rule_thresholds
+               WHERE currency = $1
+                 AND transaction_type = $2
+                 AND jurisdiction = $3
+                 AND is_active = true
+               LIMIT 1"#,
+        )
+        .bind(currency)
+        .bind(transaction_type)
+        .bind(jurisdiction)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(threshold)
+    }
+
+    pub async fn list_thresholds(&self) -> Result<Vec<TravelRuleThreshold>> {
+        let thresholds = sqlx::query_as::<_, TravelRuleThreshold>(
+            "SELECT * FROM travel_rule_thresholds ORDER BY currency, transaction_type, jurisdiction",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(thresholds)
+    }
+
+    pub async fn upsert_threshold(&self, item: &ThresholdUpdateItem, approved_by: Uuid) -> Result<TravelRuleThreshold> {
+        let threshold = sqlx::query_as::<_, TravelRuleThreshold>(
+            r#"INSERT INTO travel_rule_thresholds
+                (currency, transaction_type, jurisdiction, threshold_amount, is_active, approved_by, approved_at, updated_at)
+               VALUES ($1,$2,$3,$4,$5,$6,NOW(),NOW())
+               ON CONFLICT (currency, transaction_type, jurisdiction)
+               DO UPDATE SET
+                   threshold_amount = EXCLUDED.threshold_amount,
+                   is_active = EXCLUDED.is_active,
+                   approved_by = EXCLUDED.approved_by,
+                   approved_at = NOW(),
+                   updated_at = NOW()
+               RETURNING *"#,
+        )
+        .bind(&item.currency)
+        .bind(&item.transaction_type)
+        .bind(&item.jurisdiction)
+        .bind(item.threshold_amount)
+        .bind(item.is_active)
+        .bind(approved_by)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(threshold)
+    }
+
+    // -------------------------------------------------------------------------
+    // Unhosted wallet policy
+    // -------------------------------------------------------------------------
+
+    pub async fn get_active_policy(&self) -> Result<Option<UnhostedWalletPolicy>> {
+        let policy = sqlx::query_as::<_, UnhostedWalletPolicy>(
+            "SELECT * FROM travel_rule_unhosted_wallet_policy ORDER BY updated_at DESC LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(policy)
+    }
+
+    pub async fn update_policy(&self, req: &UpdateUnhostedWalletPolicyRequest) -> Result<UnhostedWalletPolicy> {
+        // Insert a new row (full audit trail — old rows remain for history)
+        let policy = sqlx::query_as::<_, UnhostedWalletPolicy>(
+            r#"INSERT INTO travel_rule_unhosted_wallet_policy
+                (policy_type, threshold_amount, threshold_currency,
+                 updated_by_compliance_officer, updated_by_senior_management,
+                 created_at, updated_at)
+               VALUES ($1,$2,$3,$4,$5,NOW(),NOW())
+               RETURNING *"#,
+        )
+        .bind(&req.policy_type)
+        .bind(req.threshold_amount)
+        .bind(&req.threshold_currency)
+        .bind(req.compliance_officer_id)
+        .bind(req.senior_management_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(policy)
+    }
+
+    // -------------------------------------------------------------------------
+    // Attestations
+    // -------------------------------------------------------------------------
+
+    pub async fn create_attestation(&self, req: &SelfAttestationRequest) -> Result<TravelRuleAttestation> {
+        let attestation = sqlx::query_as::<_, TravelRuleAttestation>(
+            r#"INSERT INTO travel_rule_attestations
+                (user_id, transaction_id, wallet_address, ip_address, user_agent)
+               VALUES ($1,$2,$3,$4,$5)
+               RETURNING *"#,
+        )
+        .bind(req.user_id)
+        .bind(&req.transaction_id)
+        .bind(&req.wallet_address)
+        .bind(&req.ip_address)
+        .bind(&req.user_agent)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(attestation)
+    }
+
+    pub async fn get_attestation_by_transaction(&self, transaction_id: &str) -> Result<Option<TravelRuleAttestation>> {
+        let att = sqlx::query_as::<_, TravelRuleAttestation>(
+            "SELECT * FROM travel_rule_attestations WHERE transaction_id = $1 ORDER BY attested_at DESC LIMIT 1",
+        )
+        .bind(transaction_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(att)
+    }
+
+    // -------------------------------------------------------------------------
+    // Metrics aggregation
+    // -------------------------------------------------------------------------
+
+    pub async fn compute_metrics(
+        &self,
+        from: chrono::DateTime<Utc>,
+        to: chrono::DateTime<Utc>,
+    ) -> Result<TravelRuleMetrics> {
+        let (total,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM travel_rule_exchanges WHERE created_at BETWEEN $1 AND $2",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let (successful,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM travel_rule_exchanges WHERE status = 'acknowledged' AND created_at BETWEEN $1 AND $2",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let (failed,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM travel_rule_exchanges WHERE status = 'failed' AND created_at BETWEEN $1 AND $2",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let (sunrise,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM travel_rule_exchanges WHERE sunrise_rule_applied = true AND created_at BETWEEN $1 AND $2",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let (inbound,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM travel_rule_exchanges WHERE direction = 'inbound' AND created_at BETWEEN $1 AND $2",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let (screening_failures,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM travel_rule_exchanges WHERE direction = 'inbound' AND status = 'manual_review' AND compliance_case_id IS NOT NULL AND created_at BETWEEN $1 AND $2",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Protocol breakdown for outbound
+        let proto_rows: Vec<(String, i64)> = sqlx::query_as(
+            r#"SELECT protocol_used::TEXT, COUNT(*) AS cnt
+               FROM travel_rule_exchanges
+               WHERE direction = 'outbound' AND created_at BETWEEN $1 AND $2
+               GROUP BY protocol_used"#,
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let outbound_by_protocol: HashMap<String, i64> = proto_rows.into_iter().collect();
+
+        let registry_size = self.vasp_registry_size().await.unwrap_or(0);
+        let unacknowledged = self.count_unacknowledged_outbound().await.unwrap_or(0);
+        let pending_inbound = self.count_pending_inbound_screening().await.unwrap_or(0);
+
+        // Unhosted wallet transactions = those whose beneficiary_vasp_id is 'unhosted'
+        let (unhosted,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM travel_rule_exchanges WHERE beneficiary_vasp_id = 'unhosted' AND created_at BETWEEN $1 AND $2",
+        )
+        .bind(from)
+        .bind(to)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(TravelRuleMetrics {
+            period_from: from,
+            period_to: to,
+            total_threshold_triggering: total,
+            successful_exchanges: successful,
+            failed_exchanges: failed,
+            unhosted_wallet_transactions: unhosted,
+            sunrise_rule_applications: sunrise,
+            inbound_received: inbound,
+            inbound_screening_failures: screening_failures,
+            outbound_by_protocol,
+            vasp_registry_size: registry_size,
+            unacknowledged_outbound: unacknowledged,
+            pending_inbound_screening: pending_inbound,
+        })
+    }
+}

--- a/src/travel_rule/routes.rs
+++ b/src/travel_rule/routes.rs
@@ -1,0 +1,62 @@
+use crate::middleware::rbac::extract_identity;
+use crate::travel_rule::handlers::*;
+use axum::{
+    middleware,
+    routing::{get, patch, post},
+    Router,
+};
+use std::sync::Arc;
+
+pub fn travel_rule_router(state: Arc<TravelRuleState>) -> Router {
+    // ── Admin routes — require X-User-Id / X-User-Role headers ───────────────
+    let admin_routes = Router::new()
+        .route(
+            "/api/admin/compliance/travel-rule/vasps",
+            post(register_vasp).get(list_vasps),
+        )
+        .route(
+            "/api/admin/compliance/travel-rule/vasps/:vasp_id",
+            get(get_vasp).patch(update_vasp),
+        )
+        .route(
+            "/api/admin/compliance/travel-rule/thresholds",
+            get(get_thresholds).patch(update_thresholds),
+        )
+        .route(
+            "/api/admin/compliance/travel-rule/unhosted-wallet-policy",
+            get(get_unhosted_policy).patch(update_unhosted_policy),
+        )
+        .route(
+            "/api/admin/compliance/travel-rule/messages",
+            get(list_messages),
+        )
+        .route(
+            "/api/admin/compliance/travel-rule/messages/:message_id",
+            get(get_message),
+        )
+        .route(
+            "/api/admin/compliance/travel-rule/messages/:message_id/retry",
+            post(retry_message),
+        )
+        .route(
+            "/api/admin/compliance/travel-rule/metrics",
+            get(get_metrics),
+        )
+        // Inject CallerIdentity extension on all admin routes
+        .route_layer(middleware::from_fn(extract_identity))
+        .with_state(state.clone());
+
+    // ── Public routes — no auth (called by counterpart VASPs and users) ───────
+    let public_routes = Router::new()
+        .route(
+            "/api/compliance/travel-rule/inbound/:protocol",
+            post(receive_inbound),
+        )
+        .route(
+            "/api/compliance/travel-rule/attest",
+            post(submit_attestation),
+        )
+        .with_state(state);
+
+    admin_routes.merge(public_routes)
+}

--- a/src/travel_rule/service.rs
+++ b/src/travel_rule/service.rs
@@ -1,0 +1,705 @@
+use crate::aml::case_management::AmlCaseManager;
+use crate::aml::models::{AmlScreeningRequest, AmlScreeningResult};
+use crate::aml::screening::SanctionsScreeningService;
+use crate::event_bus::bus::EventBus;
+use crate::event_bus::models::{EventType, PlatformEvent};
+use crate::services::exchange_rate::ExchangeRateService;
+use crate::travel_rule::metrics;
+use crate::travel_rule::models::*;
+use crate::travel_rule::protocols::ProtocolRouter;
+use crate::travel_rule::repository::TravelRuleRepository;
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use bigdecimal::BigDecimal;
+use chrono::Utc;
+use rand::RngCore;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+const DEFAULT_SLA_WINDOW_SECS: i32 = 300;
+
+pub struct TravelRuleService {
+    repo: Arc<TravelRuleRepository>,
+    protocol_router: Arc<ProtocolRouter>,
+    sanctions: Arc<SanctionsScreeningService>,
+    aml_case_manager: Arc<AmlCaseManager>,
+    event_bus: Arc<EventBus>,
+    exchange_rate_svc: Arc<ExchangeRateService>,
+    our_vasp_id: String,
+    platform_aes_key: [u8; 32],
+}
+
+impl TravelRuleService {
+    pub fn new(
+        repo: Arc<TravelRuleRepository>,
+        sanctions: Arc<SanctionsScreeningService>,
+        aml_case_manager: Arc<AmlCaseManager>,
+        event_bus: Arc<EventBus>,
+        exchange_rate_svc: Arc<ExchangeRateService>,
+        our_vasp_id: String,
+    ) -> Self {
+        let key_b64 = std::env::var("TRAVEL_RULE_AES_KEY_B64").unwrap_or_default();
+        let platform_aes_key = if key_b64.is_empty() {
+            [0u8; 32] // dev/test only — zero key
+        } else {
+            let decoded = BASE64.decode(&key_b64).unwrap_or_default();
+            let mut k = [0u8; 32];
+            let len = decoded.len().min(32);
+            k[..len].copy_from_slice(&decoded[..len]);
+            k
+        };
+
+        let protocol_router = Arc::new(ProtocolRouter::new(our_vasp_id.clone()));
+
+        Self {
+            repo,
+            protocol_router,
+            sanctions,
+            aml_case_manager,
+            event_bus,
+            exchange_rate_svc,
+            our_vasp_id,
+            platform_aes_key,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Threshold checking — converts amount to NGN via ExchangeRateService
+    // -------------------------------------------------------------------------
+
+    /// Returns `true` when this transaction must carry Travel Rule information.
+    /// `amount` is in `currency`; we convert to NGN for comparison using the
+    /// live ExchangeRateService (falls back to raw amount if rate unavailable).
+    pub async fn requires_travel_rule(
+        &self,
+        amount: Decimal,
+        currency: &str,
+        transaction_type: &str,
+        jurisdiction: &str,
+    ) -> bool {
+        // Cross-border below-threshold transactions still require TR (FATF threshold = 0)
+        // so check that first before doing any conversion.
+        if let Ok(Some(cb)) = self.repo.get_threshold(currency, "cross_border", jurisdiction).await {
+            if cb.threshold_amount == Decimal::ZERO {
+                return true;
+            }
+        }
+
+        // Convert amount to NGN equivalent for threshold comparison
+        let amount_ngn = self.to_ngn_equivalent(amount, currency).await;
+
+        // Try jurisdiction-specific threshold, then fall back to "NG"
+        if let Ok(Some(t)) = self.repo.get_threshold(currency, transaction_type, jurisdiction).await {
+            return amount_ngn >= t.threshold_amount;
+        }
+        if let Ok(Some(t)) = self.repo.get_threshold(currency, transaction_type, "NG").await {
+            return amount_ngn >= t.threshold_amount;
+        }
+
+        // No threshold configured — default to requiring Travel Rule (safe default)
+        warn!(
+            currency, transaction_type, jurisdiction,
+            "No Travel Rule threshold configured — defaulting to require"
+        );
+        true
+    }
+
+    /// Convert an amount in `from_currency` to NGN using ExchangeRateService.
+    /// Falls back to the raw amount on any error.
+    async fn to_ngn_equivalent(&self, amount: Decimal, from_currency: &str) -> Decimal {
+        if from_currency == "NGN" || from_currency == "cNGN" {
+            return amount;
+        }
+        match self.exchange_rate_svc.get_rate(from_currency, "NGN").await {
+            Ok(rate) => {
+                let rate_dec = Decimal::from_str(&rate.to_string()).unwrap_or(Decimal::ONE);
+                amount * rate_dec
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    from_currency,
+                    "ExchangeRateService unavailable for NGN conversion — using raw amount"
+                );
+                amount
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Corridor high-risk override
+    // -------------------------------------------------------------------------
+
+    /// Returns `true` for FATF grey-list / high-risk jurisdictions.
+    /// Travel Rule applies regardless of amount when this returns true.
+    pub fn is_high_risk_corridor(&self, _origin: &str, destination: &str) -> bool {
+        const HIGH_RISK: &[&str] = &[
+            "IR", "KP", "MM", "BY", "CF", "CD", "HT", "IQ", "LY", "ML", "NI",
+            "PK", "RU", "SO", "SS", "SY", "TZ", "UG", "VE", "YE",
+        ];
+        HIGH_RISK.contains(&destination)
+    }
+
+    // -------------------------------------------------------------------------
+    // Outbound flow
+    // -------------------------------------------------------------------------
+
+    pub async fn initiate_outbound(
+        &self,
+        req: InitiateTravelRuleRequest,
+    ) -> Result<TravelRuleExchange> {
+        // Hard gate: reject before any exchange record is created (and before the
+        // caller is allowed to proceed to disbursement) when originator/beneficiary
+        // identification is incomplete. See `validate_minimum_fields` for why this
+        // is a lighter bar than `validate_completeness` (used for inbound VASP-to-VASP
+        // exchanges, where full IVMS101 government-ID data is expected).
+        Self::validate_minimum_fields(&req.originator)?;
+        Self::validate_minimum_fields(&req.beneficiary)?;
+
+        // Discover counterparty VASP
+        let destination_vasp = if let Some(addr) = &req.destination_address {
+            self.repo.discover_vasp_by_wallet(addr).await.unwrap_or(None)
+        } else {
+            self.repo.get_vasp(&req.beneficiary_vasp_id).await.unwrap_or(None)
+        };
+
+        let (vasp_id, should_send) = match &destination_vasp {
+            Some(v) => {
+                if v.trust_status == VaspTrustStatus::Blocked {
+                    return Err(anyhow!("Destination VASP is blocked: {}", v.vasp_id));
+                }
+                (v.vasp_id.clone(), true)
+            }
+            None => {
+                // Unhosted wallet — apply policy check
+                self.apply_unhosted_policy_check(
+                    req.destination_address.as_deref().unwrap_or("unknown"),
+                    &req.transaction_id,
+                )
+                .await?;
+                ("unhosted".to_string(), false)
+            }
+        };
+
+        let originator_json = serde_json::to_value(&req.originator)?;
+        let beneficiary_json = serde_json::to_value(&req.beneficiary)?;
+
+        let exchange = self
+            .repo
+            .create_exchange(
+                &self.our_vasp_id,
+                &vasp_id,
+                &req.transaction_id,
+                &TravelRuleProtocol::Unknown,
+                &TravelRuleDirection::Outbound,
+                originator_json.clone(),
+                beneficiary_json.clone(),
+                &req.transfer_amount,
+                &req.asset_code,
+                DEFAULT_SLA_WINDOW_SECS,
+            )
+            .await?;
+
+        metrics::OUTBOUND_MESSAGES_TOTAL
+            .with_label_values(&["pending"])
+            .inc();
+
+        let _ = self
+            .event_bus
+            .publish(PlatformEvent::new(
+                EventType::TravelRuleTriggered,
+                exchange.exchange_id.to_string(),
+                "travel_rule_exchange",
+                serde_json::json!({
+                    "transaction_id": req.transaction_id,
+                    "vasp_id": vasp_id,
+                    "direction": "outbound",
+                }),
+            ))
+            .await;
+
+        if !should_send {
+            info!(
+                exchange_id = %exchange.exchange_id,
+                "Unhosted wallet: Travel Rule data not sent, enhanced monitoring applied"
+            );
+            metrics::UNHOSTED_WALLET_TRANSACTIONS_TOTAL
+                .with_label_values(&["allowed_unhosted"])
+                .inc();
+            return Ok(exchange);
+        }
+
+        let vasp = destination_vasp.unwrap();
+
+        let has_protocol = vasp.supported_protocols.iter().any(|p| {
+            matches!(p.as_str(), "trisa" | "trp" | "trust" | "open_vasp" | "openvasp")
+        });
+
+        if !has_protocol {
+            self.repo.mark_sunrise_rule_applied(exchange.exchange_id).await?;
+            warn!(
+                exchange_id = %exchange.exchange_id,
+                vasp_id = %vasp.vasp_id,
+                "Sunrise rule applied — VASP has no recognized Travel Rule protocol"
+            );
+            metrics::SUNRISE_RULE_APPLIED_TOTAL.inc();
+            return self.repo.get_exchange(exchange.exchange_id).await?
+                .ok_or_else(|| anyhow!("Exchange not found after sunrise rule"));
+        }
+
+        let pii_bytes = serde_json::to_vec(&originator_json)?;
+        let encrypted = self.encrypt_pii(&pii_bytes, &vasp)?;
+
+        let tx_result = self
+            .protocol_router
+            .select_and_send(&vasp, exchange.exchange_id, &encrypted)
+            .await;
+
+        match tx_result {
+            Some(result) if result.success => {
+                self.repo.mark_acknowledged(exchange.exchange_id).await?;
+                self.repo.increment_vasp_interaction(&vasp.vasp_id).await?;
+
+                metrics::OUTBOUND_MESSAGES_TOTAL
+                    .with_label_values(&[&format!("{:?}", result.protocol)])
+                    .inc();
+
+                let _ = self
+                    .event_bus
+                    .publish(PlatformEvent::new(
+                        EventType::TravelRuleAcknowledged,
+                        exchange.exchange_id.to_string(),
+                        "travel_rule_exchange",
+                        serde_json::json!({
+                            "protocol": format!("{:?}", result.protocol),
+                            "vasp_id": vasp.vasp_id,
+                        }),
+                    ))
+                    .await;
+            }
+            Some(result) => {
+                self.repo.mark_failed(
+                    exchange.exchange_id,
+                    &result.error.unwrap_or_else(|| "transmission failed".into()),
+                ).await?;
+                metrics::TRANSMISSION_FAILURES_TOTAL
+                    .with_label_values(&["all_protocols_failed"])
+                    .inc();
+            }
+            None => {
+                self.repo.mark_sunrise_rule_applied(exchange.exchange_id).await?;
+                metrics::SUNRISE_RULE_APPLIED_TOTAL.inc();
+                warn!(
+                    exchange_id = %exchange.exchange_id,
+                    "All protocols exhausted — sunrise rule applied"
+                );
+            }
+        }
+
+        self.repo.get_exchange(exchange.exchange_id).await?
+            .ok_or_else(|| anyhow!("Exchange not found after initiation"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Inbound flow
+    // -------------------------------------------------------------------------
+
+    pub async fn handle_inbound(&self, data: InboundTravelRuleData) -> Result<TravelRuleExchange> {
+        self.verify_sender_signature(&data).await?;
+        self.validate_completeness(&data.originator)?;
+
+        let originator_json = serde_json::to_value(&data.originator)?;
+        let beneficiary_json = serde_json::to_value(&data.beneficiary)?;
+
+        let exchange = self
+            .repo
+            .create_exchange(
+                &data.originator_vasp_id,
+                &self.our_vasp_id,
+                &data.transaction_id,
+                &data.protocol_used,
+                &TravelRuleDirection::Inbound,
+                originator_json,
+                beneficiary_json,
+                &data.transfer_amount,
+                &data.asset_code,
+                DEFAULT_SLA_WINDOW_SECS,
+            )
+            .await?;
+
+        metrics::INBOUND_MESSAGES_TOTAL
+            .with_label_values(&[&format!("{:?}", data.protocol_used)])
+            .inc();
+
+        // Sanctions screen originator
+        let screen_req = self.build_screening_request(&data, exchange.exchange_id)?;
+        let screen_result = self.sanctions.screen(&screen_req).await;
+
+        if !screen_result.cleared {
+            // Hold transaction + create AML compliance case via AmlCaseManager
+            let wallet_address = match &data.originator {
+                Ivms101Person::Natural(p) => p.account_number.clone().unwrap_or_default(),
+                Ivms101Person::Legal(p) => p.account_number.clone().unwrap_or_default(),
+            };
+
+            let aml_case = self
+                .aml_case_manager
+                .open_case(&screen_result, &wallet_address)
+                .await
+                .map_err(|e| {
+                    error!(error = %e, "Failed to open AML case for Travel Rule screening failure");
+                    e
+                })?;
+
+            let case_id = aml_case.id;
+            let screening_json = serde_json::to_value(&screen_result).unwrap_or_default();
+
+            self.repo
+                .mark_screening_failed(exchange.exchange_id, screening_json, case_id)
+                .await?;
+
+            metrics::SCREENING_FAILURES_TOTAL.inc();
+
+            error!(
+                exchange_id = %exchange.exchange_id,
+                originator_vasp = %data.originator_vasp_id,
+                case_id = %case_id,
+                "Inbound TR originator failed sanctions screening — transaction held, AML case opened"
+            );
+
+            return self.repo.get_exchange(exchange.exchange_id).await?
+                .ok_or_else(|| anyhow!("Exchange not found after screening failure"));
+        }
+
+        // All checks pass — acknowledge
+        self.repo.mark_acknowledged(exchange.exchange_id).await?;
+
+        if let Some(vasp) = self.repo.get_vasp(&data.originator_vasp_id).await.unwrap_or(None) {
+            let _ = self.protocol_router
+                .acknowledge_inbound(&vasp, exchange.exchange_id, &data.protocol_used)
+                .await;
+        }
+
+        let _ = self
+            .event_bus
+            .publish(PlatformEvent::new(
+                EventType::TravelRuleAcknowledged,
+                exchange.exchange_id.to_string(),
+                "travel_rule_exchange",
+                serde_json::json!({
+                    "direction": "inbound",
+                    "originator_vasp": data.originator_vasp_id,
+                }),
+            ))
+            .await;
+
+        self.repo.get_exchange(exchange.exchange_id).await?
+            .ok_or_else(|| anyhow!("Exchange not found after inbound handling"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Retry
+    // -------------------------------------------------------------------------
+
+    pub async fn retry_failed_message(&self, exchange_id: Uuid) -> Result<TravelRuleExchange> {
+        let exchange = self.repo.get_exchange(exchange_id).await?
+            .ok_or_else(|| anyhow!("Exchange not found: {}", exchange_id))?;
+
+        if exchange.status != TravelRuleStatus::Failed
+            && exchange.status != TravelRuleStatus::TimedOut
+        {
+            return Err(anyhow!(
+                "Exchange {} is not in a retryable state: {:?}",
+                exchange_id,
+                exchange.status
+            ));
+        }
+
+        self.repo.increment_retry(exchange_id).await?;
+
+        let vasp = self.repo.get_vasp(&exchange.beneficiary_vasp_id).await?
+            .ok_or_else(|| anyhow!("VASP not found for retry: {}", exchange.beneficiary_vasp_id))?;
+
+        let pii_bytes = serde_json::to_vec(&exchange.originator_ivms101)?;
+        let encrypted = self.encrypt_pii(&pii_bytes, &vasp)?;
+
+        match self.protocol_router.select_and_send(&vasp, exchange_id, &encrypted).await {
+            Some(r) if r.success => {
+                self.repo.mark_acknowledged(exchange_id).await?;
+                info!(exchange_id = %exchange_id, "Travel Rule retry succeeded");
+            }
+            _ => {
+                self.repo.mark_failed(exchange_id, "retry failed — all protocols exhausted").await?;
+                metrics::TRANSMISSION_FAILURES_TOTAL
+                    .with_label_values(&["retry_failed"])
+                    .inc();
+            }
+        }
+
+        self.repo.get_exchange(exchange_id).await?
+            .ok_or_else(|| anyhow!("Exchange not found after retry"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Unhosted wallet policy
+    // -------------------------------------------------------------------------
+
+    /// Enforces unhosted wallet policy. Validates pre-existing attestation when
+    /// policy = require_attestation.
+    async fn apply_unhosted_policy_check(
+        &self,
+        wallet_address: &str,
+        transaction_id: &str,
+    ) -> Result<()> {
+        let policy = self.repo.get_active_policy().await?;
+
+        let policy_type = policy
+            .as_ref()
+            .map(|p| p.policy_type.as_str())
+            .unwrap_or("allow_below_threshold");
+
+        metrics::UNHOSTED_WALLET_TRANSACTIONS_TOTAL
+            .with_label_values(&[policy_type])
+            .inc();
+
+        match policy_type {
+            "block" => {
+                warn!(wallet = %wallet_address, "Unhosted wallet transaction blocked by policy");
+                Err(anyhow!(
+                    "Transaction to unhosted wallet {} is blocked by compliance policy",
+                    wallet_address
+                ))
+            }
+            "require_attestation" => {
+                // Verify the user has already submitted self-attestation for this tx
+                let att = self.repo.get_attestation_by_transaction(transaction_id).await?;
+                if att.is_none() {
+                    warn!(
+                        wallet = %wallet_address,
+                        transaction_id = %transaction_id,
+                        "Unhosted wallet requires self-attestation — none found"
+                    );
+                    return Err(anyhow!(
+                        "Unhosted wallet transaction requires self-attestation. \
+                         Submit POST /api/compliance/travel-rule/attest first."
+                    ));
+                }
+                info!(
+                    wallet = %wallet_address,
+                    transaction_id = %transaction_id,
+                    "Unhosted wallet: attestation verified"
+                );
+                Ok(())
+            }
+            _ => Ok(()), // allow / allow_below_threshold
+        }
+    }
+
+    pub async fn submit_attestation(
+        &self,
+        req: SelfAttestationRequest,
+    ) -> Result<TravelRuleAttestation> {
+        let attestation = self.repo.create_attestation(&req).await?;
+        info!(
+            user_id = %req.user_id,
+            transaction_id = %req.transaction_id,
+            wallet = %req.wallet_address,
+            "Self-attestation recorded for unhosted wallet"
+        );
+        Ok(attestation)
+    }
+
+    // -------------------------------------------------------------------------
+    // Encryption helpers
+    // -------------------------------------------------------------------------
+
+    pub fn encrypt_pii(&self, plaintext: &[u8], _vasp: &VaspRegistryEntry) -> Result<EncryptedPayload> {
+        let mut aes_key_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut aes_key_bytes);
+
+        let key = Key::<Aes256Gcm>::from_slice(&aes_key_bytes);
+        let cipher = Aes256Gcm::new(key);
+
+        let mut nonce_bytes = [0u8; 12];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext)
+            .map_err(|e| anyhow!("AES-GCM encrypt failed: {:?}", e))?;
+
+        // Wrap AES key with platform key (XOR stub — production: RSA-OAEP per VASP public key)
+        let encrypted_key = self.wrap_aes_key_with_platform_key(&aes_key_bytes)?;
+
+        Ok(EncryptedPayload {
+            ciphertext_b64: BASE64.encode(&ciphertext),
+            encrypted_key_b64: BASE64.encode(&encrypted_key),
+            nonce_b64: BASE64.encode(nonce_bytes),
+        })
+    }
+
+    pub fn decrypt_pii(&self, payload: &EncryptedPayload) -> Result<Vec<u8>> {
+        let ciphertext = BASE64.decode(&payload.ciphertext_b64)?;
+        let encrypted_key = BASE64.decode(&payload.encrypted_key_b64)?;
+        let nonce_bytes = BASE64.decode(&payload.nonce_b64)?;
+
+        let aes_key_bytes = self.unwrap_aes_key(&encrypted_key)?;
+        let key = Key::<Aes256Gcm>::from_slice(&aes_key_bytes);
+        let cipher = Aes256Gcm::new(key);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        cipher
+            .decrypt(nonce, ciphertext.as_ref())
+            .map_err(|e| anyhow!("AES-GCM decrypt failed: {:?}", e))
+    }
+
+    fn wrap_aes_key_with_platform_key(&self, aes_key: &[u8]) -> Result<Vec<u8>> {
+        Ok(aes_key
+            .iter()
+            .zip(self.platform_aes_key.iter().cycle())
+            .map(|(a, b)| a ^ b)
+            .collect())
+    }
+
+    fn unwrap_aes_key(&self, wrapped: &[u8]) -> Result<Vec<u8>> {
+        Ok(wrapped
+            .iter()
+            .zip(self.platform_aes_key.iter().cycle())
+            .map(|(a, b)| a ^ b)
+            .collect())
+    }
+
+    // -------------------------------------------------------------------------
+    // IVMS101 validation
+    // -------------------------------------------------------------------------
+
+    /// Minimum field validation for outbound transfers: name + account/wallet
+    /// identification. This is deliberately lighter than `validate_completeness`
+    /// (DOB + national ID are not yet sourced at offramp/partner-transfer
+    /// initiation — see callers) but still enforces that a transfer above the
+    /// Travel Rule threshold cannot proceed with an unidentified counterparty.
+    pub fn validate_minimum_fields(person: &Ivms101Person) -> Result<()> {
+        match person {
+            Ivms101Person::Natural(p) => {
+                if p.first_name.trim().is_empty() && p.last_name.trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: originator/beneficiary name is required"));
+                }
+                if p.account_number.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: account_number is required"));
+                }
+                Ok(())
+            }
+            Ivms101Person::Legal(p) => {
+                if p.legal_name.trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: legal_name is required"));
+                }
+                if p.account_number.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: account_number is required"));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn validate_completeness(&self, person: &Ivms101Person) -> Result<()> {
+        match person {
+            Ivms101Person::Natural(p) => {
+                if p.first_name.trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: first_name is required"));
+                }
+                if p.last_name.trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: last_name is required"));
+                }
+                if p.account_number.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: account_number is required"));
+                }
+                if p.national_id.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: national_id is required"));
+                }
+                if p.date_of_birth.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: date_of_birth is required"));
+                }
+                if p.country_of_residence.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: country_of_residence is required"));
+                }
+                Ok(())
+            }
+            Ivms101Person::Legal(p) => {
+                if p.legal_name.trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: legal_name is required"));
+                }
+                if p.account_number.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow!("IVMS101 validation: account_number is required"));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    async fn verify_sender_signature(&self, data: &InboundTravelRuleData) -> Result<()> {
+        let vasp = self.repo.get_vasp(&data.originator_vasp_id).await?
+            .ok_or_else(|| anyhow!("Unknown originator VASP: {}", data.originator_vasp_id))?;
+
+        if vasp.trust_status == VaspTrustStatus::Blocked {
+            return Err(anyhow!("Originator VASP is blocked: {}", vasp.vasp_id));
+        }
+
+        // Production: verify HMAC-SHA256 over body using vasp.public_key_pem
+        // Stub: registry membership + non-blocked status is the gate
+        if data.sender_signature.is_none() {
+            warn!(
+                vasp_id = %data.originator_vasp_id,
+                "No sender signature present — accepted on registry membership"
+            );
+        }
+        Ok(())
+    }
+
+    fn build_screening_request(
+        &self,
+        data: &InboundTravelRuleData,
+        exchange_id: Uuid,
+    ) -> Result<AmlScreeningRequest> {
+        let (sender_name, sender_id, wallet_address) = match &data.originator {
+            Ivms101Person::Natural(p) => (
+                format!("{} {}", p.first_name, p.last_name),
+                p.national_id.clone().unwrap_or_default(),
+                p.account_number.clone().unwrap_or_default(),
+            ),
+            Ivms101Person::Legal(p) => (
+                p.legal_name.clone(),
+                p.registration_number.clone().unwrap_or_default(),
+                p.account_number.clone().unwrap_or_default(),
+            ),
+        };
+
+        let recipient_name = match &data.beneficiary {
+            Ivms101Person::Natural(p) => format!("{} {}", p.first_name, p.last_name),
+            Ivms101Person::Legal(p) => p.legal_name.clone(),
+        };
+
+        Ok(AmlScreeningRequest {
+            transaction_id: exchange_id,
+            wallet_address,
+            sender_name,
+            sender_id,
+            recipient_name,
+            recipient_id: self.our_vasp_id.clone(),
+            amount: data.transfer_amount.clone(),
+            from_currency: data.asset_code.clone(),
+            to_currency: data.asset_code.clone(),
+            origin_country: "NG".into(),
+            destination_country: "NG".into(),
+            created_at: Utc::now(),
+        })
+    }
+}

--- a/src/travel_rule/tests.rs
+++ b/src/travel_rule/tests.rs
@@ -1,0 +1,347 @@
+#[cfg(test)]
+mod tests {
+    use crate::travel_rule::models::*;
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    fn make_complete_natural() -> Ivms101Person {
+        Ivms101Person::Natural(Ivms101NaturalPerson {
+            first_name: "Amaka".into(),
+            last_name: "Okafor".into(),
+            date_of_birth: Some("1990-05-12".into()),
+            national_id: Some("NIN-12345678901".into()),
+            address: Some("12 Marina Road, Lagos".into()),
+            country_of_residence: Some("NG".into()),
+            account_number: Some("GAJHF7SVXMVDSKJF".into()),
+        })
+    }
+
+    fn make_incomplete_natural(missing: &str) -> Ivms101Person {
+        let mut p = Ivms101NaturalPerson {
+            first_name: "Amaka".into(),
+            last_name: "Okafor".into(),
+            date_of_birth: Some("1990-05-12".into()),
+            national_id: Some("NIN-12345678901".into()),
+            address: Some("12 Marina Road, Lagos".into()),
+            country_of_residence: Some("NG".into()),
+            account_number: Some("GAJHF7SVXMVDSKJF".into()),
+        };
+        match missing {
+            "first_name" => p.first_name = "".into(),
+            "last_name" => p.last_name = "".into(),
+            "national_id" => p.national_id = None,
+            "date_of_birth" => p.date_of_birth = None,
+            "country" => p.country_of_residence = None,
+            "account_number" => p.account_number = None,
+            _ => {}
+        }
+        Ivms101Person::Natural(p)
+    }
+
+    fn validate(person: &Ivms101Person) -> anyhow::Result<()> {
+        match person {
+            Ivms101Person::Natural(p) => {
+                if p.first_name.trim().is_empty() {
+                    return Err(anyhow::anyhow!("first_name required"));
+                }
+                if p.last_name.trim().is_empty() {
+                    return Err(anyhow::anyhow!("last_name required"));
+                }
+                if p.account_number.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow::anyhow!("account_number required"));
+                }
+                if p.national_id.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow::anyhow!("national_id required"));
+                }
+                if p.date_of_birth.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow::anyhow!("date_of_birth required"));
+                }
+                if p.country_of_residence.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow::anyhow!("country_of_residence required"));
+                }
+                Ok(())
+            }
+            Ivms101Person::Legal(p) => {
+                if p.legal_name.trim().is_empty() {
+                    return Err(anyhow::anyhow!("legal_name required"));
+                }
+                if p.account_number.as_deref().unwrap_or("").trim().is_empty() {
+                    return Err(anyhow::anyhow!("account_number required"));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 1. IVMS101 completeness validation
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn completeness_natural_all_fields_passes() {
+        let person = make_complete_natural();
+        assert!(validate(&person).is_ok());
+    }
+
+    #[test]
+    fn completeness_missing_first_name_fails() {
+        let person = make_incomplete_natural("first_name");
+        let err = validate(&person).unwrap_err();
+        assert!(err.to_string().contains("first_name"));
+    }
+
+    #[test]
+    fn completeness_missing_last_name_fails() {
+        let person = make_incomplete_natural("last_name");
+        assert!(validate(&person).is_err());
+    }
+
+    #[test]
+    fn completeness_missing_national_id_fails() {
+        let person = make_incomplete_natural("national_id");
+        assert!(validate(&person).is_err());
+    }
+
+    #[test]
+    fn completeness_missing_dob_fails() {
+        let person = make_incomplete_natural("date_of_birth");
+        assert!(validate(&person).is_err());
+    }
+
+    #[test]
+    fn completeness_missing_country_fails() {
+        let person = make_incomplete_natural("country");
+        assert!(validate(&person).is_err());
+    }
+
+    #[test]
+    fn completeness_missing_account_number_fails() {
+        let person = make_incomplete_natural("account_number");
+        assert!(validate(&person).is_err());
+    }
+
+    #[test]
+    fn completeness_legal_person_passes() {
+        let person = Ivms101Person::Legal(Ivms101LegalPerson {
+            legal_name: "Aframp Ltd".into(),
+            registration_number: Some("RC-123456".into()),
+            country_of_registration: Some("NG".into()),
+            address: None,
+            account_number: Some("GBZXHF7SVXMVDSKJF".into()),
+        });
+        assert!(validate(&person).is_ok());
+    }
+
+    #[test]
+    fn completeness_legal_person_missing_name_fails() {
+        let person = Ivms101Person::Legal(Ivms101LegalPerson {
+            legal_name: "".into(),
+            registration_number: None,
+            country_of_registration: None,
+            address: None,
+            account_number: Some("GBZXHF7SVXMVDSKJF".into()),
+        });
+        assert!(validate(&person).is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Threshold calculation
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn threshold_above_triggers() {
+        let threshold = Decimal::from_str("500000").unwrap();
+        let amount = Decimal::from_str("600000").unwrap();
+        assert!(amount >= threshold);
+    }
+
+    #[test]
+    fn threshold_exactly_at_boundary_triggers() {
+        let threshold = Decimal::from_str("500000").unwrap();
+        let amount = Decimal::from_str("500000").unwrap();
+        assert!(amount >= threshold);
+    }
+
+    #[test]
+    fn threshold_below_does_not_trigger() {
+        let threshold = Decimal::from_str("500000").unwrap();
+        let amount = Decimal::from_str("499999.99").unwrap();
+        assert!(amount < threshold);
+    }
+
+    #[test]
+    fn cross_border_threshold_zero_always_triggers() {
+        let threshold = Decimal::ZERO;
+        let amount = Decimal::from_str("1").unwrap();
+        assert!(amount >= threshold);
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. Protocol selection (fallback chain logic)
+    // -------------------------------------------------------------------------
+
+    fn supports(protocols: &[&str], target: &str) -> bool {
+        protocols.iter().any(|p| *p == target)
+    }
+
+    fn select_protocol(protocols: &[&str]) -> TravelRuleProtocol {
+        if supports(protocols, "trisa") {
+            TravelRuleProtocol::Trisa
+        } else if supports(protocols, "trp") || supports(protocols, "trust") {
+            TravelRuleProtocol::Trp
+        } else if supports(protocols, "open_vasp") || supports(protocols, "openvasp") {
+            TravelRuleProtocol::OpenVasp
+        } else {
+            TravelRuleProtocol::Unknown
+        }
+    }
+
+    #[test]
+    fn trisa_preferred_over_trp() {
+        let protocols = &["trisa", "trp", "open_vasp"];
+        assert_eq!(select_protocol(protocols), TravelRuleProtocol::Trisa);
+    }
+
+    #[test]
+    fn trp_fallback_when_no_trisa() {
+        let protocols = &["trp", "open_vasp"];
+        assert_eq!(select_protocol(protocols), TravelRuleProtocol::Trp);
+    }
+
+    #[test]
+    fn openvasp_fallback_when_no_trisa_or_trp() {
+        let protocols = &["open_vasp"];
+        assert_eq!(select_protocol(protocols), TravelRuleProtocol::OpenVasp);
+    }
+
+    #[test]
+    fn unknown_when_no_recognized_protocol() {
+        let protocols = &["ivms101_direct", "proprietary"];
+        assert_eq!(select_protocol(protocols), TravelRuleProtocol::Unknown);
+    }
+
+    #[test]
+    fn trust_alias_maps_to_trp() {
+        let protocols = &["trust"];
+        assert_eq!(select_protocol(protocols), TravelRuleProtocol::Trp);
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. AES-GCM encryption round-trip
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn aes_gcm_encrypt_decrypt_round_trip() {
+        use aes_gcm::aead::{Aead, KeyInit, OsRng};
+        use aes_gcm::{Aes256Gcm, Key, Nonce};
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+        use rand::RngCore;
+
+        let plaintext = br#"{"first_name":"Amaka","last_name":"Okafor"}"#;
+
+        let mut key_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut key_bytes);
+        let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
+        let cipher = Aes256Gcm::new(key);
+
+        let mut nonce_bytes = [0u8; 12];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = cipher.encrypt(nonce, plaintext.as_ref()).unwrap();
+        let decrypted = cipher.decrypt(nonce, ciphertext.as_ref()).unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. Originator package construction
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn originator_package_serialises_all_fields() {
+        let person = make_complete_natural();
+        let json = serde_json::to_value(&person).unwrap();
+
+        // Natural person should have all fields
+        let inner = &json["natural"];
+        assert_eq!(inner["first_name"], "Amaka");
+        assert_eq!(inner["last_name"], "Okafor");
+        assert!(!inner["national_id"].is_null());
+        assert!(!inner["date_of_birth"].is_null());
+        assert!(!inner["country_of_residence"].is_null());
+        assert!(!inner["account_number"].is_null());
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. Unhosted wallet policy application
+    // -------------------------------------------------------------------------
+
+    fn apply_policy(policy_type: &str, amount: Decimal, threshold: Decimal) -> &'static str {
+        match policy_type {
+            "block" => "blocked",
+            "require_attestation" => "attestation_required",
+            "allow_below_threshold" if amount > threshold => "blocked_above_threshold",
+            _ => "allowed",
+        }
+    }
+
+    #[test]
+    fn policy_block_always_blocks() {
+        let outcome = apply_policy("block", Decimal::from(1_000_000), Decimal::from(500_000));
+        assert_eq!(outcome, "blocked");
+    }
+
+    #[test]
+    fn policy_allow_always_allows() {
+        let outcome = apply_policy("allow", Decimal::from(1_000_000), Decimal::from(500_000));
+        assert_eq!(outcome, "allowed");
+    }
+
+    #[test]
+    fn policy_allow_below_threshold_blocks_above() {
+        let outcome =
+            apply_policy("allow_below_threshold", Decimal::from(600_000), Decimal::from(500_000));
+        assert_eq!(outcome, "blocked_above_threshold");
+    }
+
+    #[test]
+    fn policy_allow_below_threshold_allows_below() {
+        let outcome =
+            apply_policy("allow_below_threshold", Decimal::from(100_000), Decimal::from(500_000));
+        assert_eq!(outcome, "allowed");
+    }
+
+    #[test]
+    fn policy_require_attestation_returns_required() {
+        let outcome = apply_policy("require_attestation", Decimal::from(10), Decimal::from(500_000));
+        assert_eq!(outcome, "attestation_required");
+    }
+
+    // -------------------------------------------------------------------------
+    // 7. High-risk corridor override
+    // -------------------------------------------------------------------------
+
+    fn is_high_risk(destination: &str) -> bool {
+        const HIGH_RISK: &[&str] = &["IR", "KP", "MM", "SY", "RU"];
+        HIGH_RISK.contains(&destination)
+    }
+
+    #[test]
+    fn sanctioned_jurisdiction_is_high_risk() {
+        assert!(is_high_risk("KP")); // North Korea
+        assert!(is_high_risk("IR")); // Iran
+        assert!(is_high_risk("SY")); // Syria
+    }
+
+    #[test]
+    fn normal_jurisdiction_not_high_risk() {
+        assert!(!is_high_risk("NG")); // Nigeria
+        assert!(!is_high_risk("GH")); // Ghana
+        assert!(!is_high_risk("KE")); // Kenya
+    }
+}

--- a/src/travel_rule/worker.rs
+++ b/src/travel_rule/worker.rs
@@ -1,0 +1,111 @@
+use crate::travel_rule::metrics;
+use crate::travel_rule::repository::TravelRuleRepository;
+use std::sync::Arc;
+use tokio::time::{interval, Duration as TokioDuration};
+use tracing::{error, info, warn};
+
+const POLL_INTERVAL_SECS: u64 = 60;
+/// Emit an alert log when this many messages are unacknowledged
+const UNACKNOWLEDGED_ALERT_THRESHOLD: i64 = 10;
+
+pub struct TravelRuleSlaWorker {
+    repo: Arc<TravelRuleRepository>,
+}
+
+impl TravelRuleSlaWorker {
+    pub fn new(repo: Arc<TravelRuleRepository>) -> Self {
+        Self { repo }
+    }
+
+    /// Spawn as a background tokio task.
+    pub fn start(self) {
+        tokio::spawn(async move {
+            let mut ticker = interval(TokioDuration::from_secs(POLL_INTERVAL_SECS));
+            loop {
+                ticker.tick().await;
+                self.run_cycle().await;
+            }
+        });
+    }
+
+    async fn run_cycle(&self) {
+        // 1. Expire SLA-breached exchanges
+        let breached = match self.repo.get_unacknowledged_past_sla().await {
+            Ok(b) => b,
+            Err(e) => {
+                error!(error = %e, "Travel Rule SLA worker: failed to fetch breached exchanges");
+                return;
+            }
+        };
+
+        for exchange in &breached {
+            if let Err(e) = self.repo.mark_sla_breached(exchange.exchange_id).await {
+                error!(
+                    exchange_id = %exchange.exchange_id,
+                    error = %e,
+                    "Travel Rule SLA worker: failed to mark exchange as timed out"
+                );
+            } else {
+                warn!(
+                    exchange_id = %exchange.exchange_id,
+                    vasp_id = %exchange.beneficiary_vasp_id,
+                    transaction_id = %exchange.transaction_id,
+                    "Travel Rule SLA BREACH: outbound message unacknowledged past SLA window"
+                );
+            }
+        }
+
+        if !breached.is_empty() {
+            info!(count = breached.len(), "Travel Rule SLA worker: marked exchanges as timed_out");
+        }
+
+        // 2. Update gauges
+        if let Ok(unack) = self.repo.count_unacknowledged_outbound().await {
+            metrics::UNACKNOWLEDGED_OUTBOUND_COUNT.set(unack as f64);
+
+            if unack >= UNACKNOWLEDGED_ALERT_THRESHOLD {
+                warn!(
+                    count = unack,
+                    threshold = UNACKNOWLEDGED_ALERT_THRESHOLD,
+                    "ALERT: Travel Rule unacknowledged outbound message count exceeds threshold"
+                );
+            }
+        }
+
+        if let Ok(pending) = self.repo.count_pending_inbound_screening().await {
+            metrics::PENDING_INBOUND_SCREENING_COUNT.set(pending as f64);
+        }
+
+        if let Ok(size) = self.repo.vasp_registry_size().await {
+            metrics::VASP_REGISTRY_SIZE.set(size as f64);
+        }
+
+        // 3. Check screening failure rate alert
+        self.check_screening_failure_rate().await;
+    }
+
+    async fn check_screening_failure_rate(&self) {
+        let from = chrono::Utc::now() - chrono::Duration::hours(24);
+        let to = chrono::Utc::now();
+
+        let metrics_result = self.repo.compute_metrics(from, to).await;
+        match metrics_result {
+            Ok(m) if m.inbound_received > 0 => {
+                let failure_rate =
+                    m.inbound_screening_failures as f64 / m.inbound_received as f64;
+                if failure_rate > 0.10 {
+                    warn!(
+                        failure_rate = %format!("{:.1}%", failure_rate * 100.0),
+                        inbound_total = m.inbound_received,
+                        failures = m.inbound_screening_failures,
+                        "ALERT: Travel Rule originator screening failure rate exceeds 10% in last 24h"
+                    );
+                }
+            }
+            Err(e) => {
+                error!(error = %e, "Travel Rule SLA worker: metrics computation failed");
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -7,7 +7,9 @@ pub mod ip_detection_worker;
 pub mod key_rotation_worker;
 pub mod liquidity_monitor_worker;
 pub mod maintenance;
-pub mod merchant_payment_monitor;
+// merchant_payment_monitor: depends on the deleted merchant_gateway module
+// (never restored after the dd3c49f cleanup) and isn't wired into main.rs —
+// excluded from compilation rather than restoring merchant_gateway wholesale.
 pub mod mint_sla_worker;
 pub mod offramp_processor;
 pub mod onramp_processor;

--- a/tests/travel_rule_integration.rs
+++ b/tests/travel_rule_integration.rs
@@ -11,7 +11,7 @@
 #[cfg(feature = "database")]
 mod travel_rule_integration {
     use aframp_backend::travel_rule::{
-        models::*, repository::TravelRuleRepository,
+        models::*, repository::TravelRuleRepository, service::TravelRuleService,
     };
     use rust_decimal::Decimal;
     use sqlx::PgPool;
@@ -456,4 +456,71 @@ mod travel_rule_integration {
         assert_eq!(decrypted, data);
         Ok(())
     }
+
+    // -------------------------------------------------------------------------
+    // 13. Enforcement gate — transfers with incomplete originator/beneficiary
+    //     data are rejected before the transaction can proceed (Issue: Travel
+    //     Rule enforcement on transfers above threshold). Pure (no DB).
+    // -------------------------------------------------------------------------
+
+    fn complete_natural(account_number: Option<&str>) -> Ivms101Person {
+        Ivms101Person::Natural(Ivms101NaturalPerson {
+            first_name: "Amaka".into(),
+            last_name: "Okafor".into(),
+            date_of_birth: None,
+            national_id: None,
+            address: None,
+            country_of_residence: Some("NG".into()),
+            account_number: account_number.map(String::from),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_enforcement_blocks_missing_account_number() {
+        let person = complete_natural(None);
+        let result = TravelRuleService::validate_minimum_fields(&person);
+        assert!(
+            result.is_err(),
+            "a transfer must not be allowed to proceed without an account/wallet identifier"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enforcement_blocks_missing_name() {
+        let person = Ivms101Person::Natural(Ivms101NaturalPerson {
+            first_name: "".into(),
+            last_name: "".into(),
+            date_of_birth: None,
+            national_id: None,
+            address: None,
+            country_of_residence: Some("NG".into()),
+            account_number: Some("GAJHF7SVXMVDSKJF".into()),
+        });
+        let result = TravelRuleService::validate_minimum_fields(&person);
+        assert!(
+            result.is_err(),
+            "a transfer must not be allowed to proceed without originator/beneficiary identification"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enforcement_allows_minimum_fields_present() {
+        let person = complete_natural(Some("GAJHF7SVXMVDSKJF"));
+        let result = TravelRuleService::validate_minimum_fields(&person);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_enforcement_blocks_legal_person_missing_name() {
+        let person = Ivms101Person::Legal(Ivms101LegalPerson {
+            legal_name: "".into(),
+            registration_number: None,
+            country_of_registration: None,
+            address: None,
+            account_number: Some("GBZXHF7SVXMVDSKJF".into()),
+        });
+        let result = TravelRuleService::validate_minimum_fields(&person);
+        assert!(result.is_err());
+    }
+
 }


### PR DESCRIPTION
closes #736 
closes #737 
closes #738 
closes #740 




Problem
The submission engine supports standard transactions but does not implement Stellar fee bump transactions, which are required when submitting on behalf of accounts that cannot pay their own fees (e.g. newly provisioned wallets with no XLM).

Location
src/stellar/submission.rs, src/stellar/models.rs

Proposed Fix
Add FeeBumpEnvelope variant to submission models
Implement submit_fee_bump method in StellarSubmissionEngine
Use the issuer account as the fee-bump source for new wallet activations
Track fee-bump costs in stellar_fee_stats table
Acceptance Criteria
 Fee bump submission implemented
 Used in wallet provisioning flow
 Fee costs tracked
 Test