### PR TITLE
Fix/security issues batch

### DIFF
--- a/src/admin/auth.rs
+++ b/src/admin/auth.rs
@@ -483,6 +483,13 @@ impl AdminAuthService {
             .update_password(admin_id, &request.new_password)
             .await?;
 
+        // Invalidate all existing sessions/JWTs and refresh tokens so a
+        // previously leaked token can no longer be used after the password
+        // change. The caller must re-authenticate to get a fresh session.
+        self.session_repo
+            .terminate_all_sessions(admin_id, None)
+            .await?;
+
         // Log password change
         self.audit_repo
             .create_audit_entry(

--- a/src/payments/providers/flutterwave.rs
+++ b/src/payments/providers/flutterwave.rs
@@ -172,6 +172,13 @@ impl PaymentProvider for FlutterwaveProvider {
             }
         });
 
+        // Flutterwave dedupes payment initiation requests by tx_ref, so we
+        // must send the same tx_ref-derived idempotency key on every retry
+        // of this call. Otherwise a network error after Flutterwave already
+        // created the charge (but before we received the response) would
+        // cause a retry to create a duplicate charge.
+        let idempotency_key = format!("aframp-{}", request.transaction_reference);
+
         let raw: FlutterwaveEnvelope = self
             .http
             .request_json(
@@ -179,7 +186,10 @@ impl PaymentProvider for FlutterwaveProvider {
                 &self.endpoint("/payments"),
                 Some(&self.config.secret_key),
                 Some(&payload),
-                &[("Content-Type", "application/json")],
+                &[
+                    ("Content-Type", "application/json"),
+                    ("Idempotency-Key", idempotency_key.as_str()),
+                ],
             )
             .await
             .map_err(|e| match e {

--- a/src/payments/providers/ghana.rs
+++ b/src/payments/providers/ghana.rs
@@ -467,12 +467,20 @@ impl PaymentProvider for GhanaProvider {
         use hmac::{Hmac, Mac};
         use sha2::Sha256;
 
+        // Fail closed: without a configured secret we cannot verify the
+        // signature, so the webhook must be rejected. Previously this
+        // returned valid: true, which let anyone POST a fake success
+        // webhook (e.g. to trigger fraudulent fund releases) whenever the
+        // secret happened to be unset.
         let secret = match &self.config.webhook_secret {
             Some(s) => s.clone(),
             None => {
                 return Ok(WebhookVerificationResult {
-                    valid: true,
-                    reason: Some("No webhook secret configured — skipping verification".to_string()),
+                    valid: false,
+                    reason: Some(
+                        "No webhook secret configured — rejecting unverifiable webhook"
+                            .to_string(),
+                    ),
                 })
             }
         };

--- a/src/payments/providers/mpesa_kenya.rs
+++ b/src/payments/providers/mpesa_kenya.rs
@@ -416,6 +416,45 @@ impl PaymentProvider for MpesaKenyaProvider {
             }
         })?;
 
+        // STK Push (customer-initiated) callback envelope:
+        // { "Body": { "stkCallback": { "MerchantRequestID": "...",
+        //             "CheckoutRequestID": "...", "ResultCode": 1032,
+        //             "ResultDesc": "..." } } }
+        // ResultCode 1032 is returned when the customer does not respond to
+        // the STK prompt within the ~30s window; treat it as a failed
+        // (cancelled/timed out) payment rather than leaving it unparsed.
+        if let Some(stk_callback) = parsed.pointer("/Body/stkCallback") {
+            let result_code = stk_callback
+                .get("ResultCode")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(-1);
+            let checkout_request_id = stk_callback
+                .get("CheckoutRequestID")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            if result_code != 0 {
+                let failure_reason = stk_callback
+                    .get("ResultDesc")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(Self::result_code_description(result_code));
+                warn!(
+                    result_code = result_code,
+                    description = %failure_reason,
+                    checkout_request_id = ?checkout_request_id,
+                    "M-Pesa STK Push failed or timed out waiting for customer response"
+                );
+            }
+            return Ok(WebhookEvent {
+                provider: ProviderName::Mpesa,
+                event_type: format!("stk.result.{}", result_code),
+                transaction_reference: checkout_request_id.clone(),
+                provider_reference: checkout_request_id,
+                status: Some(Self::map_result_code(result_code)),
+                payload: parsed.clone(),
+                received_at: chrono::Utc::now().to_rfc3339(),
+            });
+        }
+
         // Daraja B2C result envelope:
         // { "Result": { "ResultCode": 0, "ResultDesc": "...",
         //               "OriginatorConversationID": "...",


### PR DESCRIPTION
closes #774
closes #775 
closes #776
closes #777

Problem
When an admin changes their password, existing sessions (JWTs and refresh tokens) are not invalidated. An attacker who obtained a valid admin token continues to have access even after the password is changed.

src/payments/providers/flutterwave.rs initiates payments but does not consistently set the tx_ref idempotency key on retries. If a network error occurs after the payment is created on Flutterwave's side but before the response is received, a retry creates a duplicate charge.

src/payments/providers/mpesa_kenya.rs is 25k lines suggesting complex logic, but M-Pesa STK Push payments have a 30-second customer-response timeout. If the customer does not respond, M-Pesa sends a callback. There is no handling for this timeout callback scenario.

src/payments/providers/ghana.rs is 23k lines. If webhook signature verification is not implemented (as is the case for some providers), any attacker can POST a fake success webhook and trigger fraudulent fund releases.