### PR TITLE
Code quality: wire up verification module, document mod.rs stubs, add error handling convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to Aframp Backend
+
+## Error Handling Convention
+
+_Issue #819: the codebase mixes `anyhow::Error` and `thiserror`-derived enums
+across the domain/application boundary. This section establishes the
+convention going forward._
+
+**Domain layer** (`src/kyc/`, `src/services/`, `src/chains/`, repository and
+engine code) — use `thiserror`-derived enums. Domain errors are things a
+caller may need to match on (e.g. `InsufficientLiquidity`, `RateExpired`,
+`WalletNotFound`). A typed enum keeps that possible; `anyhow::Error` erases
+it. See `src/error.rs` (`AppErrorKind`, `DomainError`, `InfrastructureError`,
+`ExternalError`, `ValidationError`) and `src/verification/engine.rs`
+(`VerificationError`) for examples already following this pattern.
+
+**API/handler layer** (`src/main.rs` route handlers, background worker
+entry points) — use `anyhow::Error` (or `anyhow::Result`) for
+context-rich wrapping of lower errors on their way to a log line or a
+generic 500 response, via `.context("...")` / `.with_context(...)`. Handlers
+that need specific HTTP status codes should convert the typed domain error
+into `AppError` (which implements `IntoResponse`) rather than flattening it
+into `anyhow` first.
+
+**Rule of thumb:** if the error crosses a module boundary where the caller
+might branch on the failure kind, it should be a typed `thiserror` enum. If
+it's only ever going to be logged or turned into a generic failure response,
+`anyhow` is fine.
+
+### Code review checklist
+
+- [ ] New domain/service code returns a `thiserror` enum, not `anyhow::Error`,
+      in its public API.
+- [ ] `anyhow` is only used at application boundaries (route handlers, `main.rs`
+      wiring, worker `run()` loops), not threaded through domain logic.
+- [ ] Domain errors that need a specific HTTP status are mapped through
+      `AppError` / `AppErrorKind`, not stringified.

--- a/src/compliance_effectiveness/mod.rs
+++ b/src/compliance_effectiveness/mod.rs
@@ -1,5 +1,12 @@
 //! AML Programme Effectiveness Reporting & Metrics
 //! Issue #396
+//!
+//! Issue #818: this file was flagged as a near-empty stub by byte size alone.
+//! It is intentionally a thin re-export module — the real implementation
+//! (~2000 lines) lives in `handlers.rs`, `models.rs`, `repository.rs`,
+//! `service.rs`, and `worker.rs`, and is mounted in `main.rs` under
+//! `compliance_effectiveness_routes`. Decision: keep as implemented,
+//! not a stub — no action needed beyond documenting this.
 
 pub mod handlers;
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1843,6 +1843,41 @@ async fn main() -> anyhow::Result<()> {
         Router::new()
     };
 
+    // ── Collateral Verification Engine (Proof-of-Reserve, cNGN) ──────────────
+    let verification_routes = if let (Some(pool), Some(client)) =
+        (db_pool.clone(), stellar_client.clone())
+    {
+        let verification_engine = std::sync::Arc::new(
+            verification::VerificationEngine::new(std::sync::Arc::new(client), pool.clone()),
+        );
+        let verification_repo = std::sync::Arc::new(verification::repository::VerificationRepository::new(pool));
+        // Start the scheduled proof-of-reserve worker
+        let verification_worker = verification::worker::VerificationWorker::new(verification_engine.clone());
+        tokio::spawn(verification_worker.run(worker_shutdown_rx.clone()));
+        let verification_state = std::sync::Arc::new(verification::handler::VerificationState {
+            engine: verification_engine,
+            repo: verification_repo,
+        });
+        info!("✅ Collateral verification routes enabled");
+        Router::new()
+            .route(
+                "/api/internal/verification/latest",
+                get(verification::handler::get_latest),
+            )
+            .route(
+                "/api/internal/verification/history",
+                get(verification::handler::get_history),
+            )
+            .route(
+                "/api/internal/verification/trigger",
+                post(verification::handler::trigger_verification),
+            )
+            .with_state(verification_state)
+    } else {
+        info!("⏭️  Skipping collateral verification routes (missing db pool or stellar client)");
+        Router::new()
+    };
+
     // ── Compliance Effectiveness Reporting (AML/KYC KPI Reports) ─────────────
     let compliance_effectiveness_routes = if let Some(ref pool) = db_pool {
         let ce_repo = std::sync::Arc::new(
@@ -2379,6 +2414,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(audit_routes)
         .merge(sar_routes)
         .merge(compliance_effectiveness_routes)
+        .merge(verification_routes)
         .merge(stellar_throughput_routes)
         .merge(kyb_routes)
         .merge(key_rotation_routes)

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -1,3 +1,12 @@
+//! Collateral Verification Engine (Proof-of-Reserve for cNGN).
+//!
+//! Issue #820: this file was flagged as a near-empty stub by byte size alone.
+//! It is intentionally a thin re-export module — the implementation lives in
+//! `engine.rs`, `repository.rs`, `handler.rs`, and `worker.rs`. Those were
+//! previously implemented but never wired into `main.rs`; they are now
+//! mounted at `/api/internal/verification/*` and run on a scheduled worker.
+//! Decision: expand (wire up), not remove — this is not email/phone
+//! verification, it's on-chain vs fiat reserve reconciliation.
 pub mod engine;
 pub mod repository;
 pub mod handler;


### PR DESCRIPTION
## Summary
- Closes #820 
- closes #818 
- closes #819
- 

**#820 — `src/verification/mod.rs` near-empty stub**
This is the Collateral Verification / Proof-of-Reserve engine (cNGN on-chain
supply vs. off-chain fiat reserves, HMAC-signed snapshots). The module was
already fully implemented in `engine.rs` / `repository.rs` / `handler.rs` /
`worker.rs` (~570 lines total), but never mounted in `main.rs`. Wired it up:
- Routes mounted at `/api/internal/verification/{latest,history,trigger}`
- Scheduled `VerificationWorker` started alongside the other background workers
- Follows the same optional `(db_pool, stellar_client)` wiring pattern already
  used for the transaction monitor / offramp processor workers
- Documented the decision (expand, not remove) in `mod.rs`

**#818 — `src/compliance_effectiveness/mod.rs` near-empty stub**
This one is already a fully implemented (~2000 line) and already-wired AML/KYC
reporting service; `mod.rs` is intentionally just a thin re-export file, not a
stub. Documented that decision in `mod.rs` — no functional change needed.

**#819 — inconsistent `anyhow`/`thiserror` error handling**
Added an "Error Handling Convention" section to `CONTRIBUTING.md`:
- Domain layer (services, repositories, engines) → `thiserror`-derived enums
- API/handler layer (route handlers, worker `run()` loops) → `anyhow` for
  context-rich wrapping
- Code review checklist item
- Points at `src/verification/engine.rs`'s `VerificationError` as a
  already-compliant reference example

A full codebase-wide refactor of existing `anyhow` usage is left as
follow-up work per the checklist rather than done blind in this PR (no Rust
toolchain was available in this environment to compile-verify a broad
signature-changing refactor).

## Test plan
- [ ] `cargo check` (not run in this environment — no Rust toolchain
      available; changes were reviewed by hand against existing call
      patterns in `main.rs`)
- [ ] CI: verify the new `/api/internal/verification/*` routes respond and
      the collateral verification worker starts on deploy