### PR TITLE
Add property-based tests for fee calculation, KYC limits, and exchange rate round-trips

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,6 +320,11 @@ name = "kyc_monthly_volume_reset_integration"
 path = "tests/kyc_monthly_volume_reset_integration.rs"
 required-features = ["database"]
 
+[[test]]
+name = "kyc_limits_proptest"
+path = "tests/kyc_limits_proptest.rs"
+required-features = ["database"]
+
 # ---------------------------------------------------------------------------
 # Examples
 # ---------------------------------------------------------------------------

--- a/src/services/exchange_rate.rs
+++ b/src/services/exchange_rate.rs
@@ -651,4 +651,39 @@ mod tests {
             if from == "USD" && to == "cNGN"
         ));
     }
+
+    // Property-based test (issue #797): a round-trip NGN -> USD -> NGN
+    // conversion, using `compute_gross_amount` (the same pure function the
+    // service uses to apply a rate), must return to within 1 basis point
+    // (0.01%) of the original amount.
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn cents_to_decimal(cents: i64) -> BigDecimal {
+            BigDecimal::from(cents) / BigDecimal::from(100)
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+            #[test]
+            fn ngn_usd_ngn_round_trip_within_one_basis_point(
+                ngn_amount_cents in 1_00i64..1_000_000_00i64,
+                usd_to_ngn_rate_cents in 50_00i64..5_000_00i64,
+            ) {
+                let ngn_amount = cents_to_decimal(ngn_amount_cents);
+                let usd_to_ngn_rate = cents_to_decimal(usd_to_ngn_rate_cents);
+                let ngn_to_usd_rate = BigDecimal::from(1) / usd_to_ngn_rate.clone();
+
+                let usd_amount = compute_gross_amount(&ngn_amount, &ngn_to_usd_rate);
+                let ngn_round_tripped = compute_gross_amount(&usd_amount, &usd_to_ngn_rate);
+
+                let deviation = (&ngn_round_tripped - &ngn_amount).abs();
+                let one_basis_point = &ngn_amount * &BigDecimal::from_str("0.0001").unwrap();
+
+                prop_assert!(deviation <= one_basis_point);
+            }
+        }
+    }
 }

--- a/src/services/fee_calculation.rs
+++ b/src/services/fee_calculation.rs
@@ -509,6 +509,81 @@ mod tests {
         }
     }
 
+    // Property-based tests (issue #797): fee calculation must never return a
+    // negative fee, and — for the realistic tier ranges seen in
+    // `fee_structures` (<=20% + a small flat component) — must never exceed
+    // the amount being charged.
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        fn cents_to_decimal(cents: i64) -> BigDecimal {
+            BigDecimal::from(cents) / BigDecimal::from(100)
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+            #[test]
+            fn provider_and_platform_fees_are_bounded(
+                amount_cents in 1_000_00i64..1_000_000_000i64,
+                provider_percent_bp in 0i64..2_000i64,
+                provider_flat_cents in 0i64..20_000i64,
+                platform_percent_bp in 0i64..2_000i64,
+            ) {
+                let amount = cents_to_decimal(amount_cents);
+                let config = test_fee_config(
+                    None, None, None, None, None, None,
+                );
+                let config = FeeConfig {
+                    provider_fee_percent: Some(cents_to_decimal(provider_percent_bp)),
+                    provider_fee_flat: Some(cents_to_decimal(provider_flat_cents)),
+                    provider_fee_cap: None,
+                    platform_fee_percent: Some(cents_to_decimal(platform_percent_bp)),
+                    ..config
+                };
+                let service = test_service();
+
+                let provider_fee = service
+                    .calculate_provider_fee(&amount, &config, Some("flutterwave"), Some("card"))
+                    .unwrap();
+                let platform_fee = service.calculate_platform_fee(&amount, &config);
+
+                prop_assert!(provider_fee.calculated >= BigDecimal::from(0));
+                prop_assert!(platform_fee.calculated >= BigDecimal::from(0));
+
+                let total = &provider_fee.calculated + &platform_fee.calculated;
+                prop_assert!(total <= amount);
+            }
+
+            #[test]
+            fn provider_fee_never_exceeds_its_cap(
+                amount_cents in 1_000_00i64..1_000_000_000i64,
+                provider_percent_bp in 0i64..10_000i64,
+                provider_flat_cents in 0i64..1_000_000i64,
+                cap_cents in 0i64..500_000i64,
+            ) {
+                let amount = cents_to_decimal(amount_cents);
+                let cap = cents_to_decimal(cap_cents);
+                let base_config = test_fee_config(None, None, None, None, None, None);
+                let config = FeeConfig {
+                    provider_fee_percent: Some(cents_to_decimal(provider_percent_bp)),
+                    provider_fee_flat: Some(cents_to_decimal(provider_flat_cents)),
+                    provider_fee_cap: Some(cap.clone()),
+                    ..base_config
+                };
+                let service = test_service();
+
+                let provider_fee = service
+                    .calculate_provider_fee(&amount, &config, Some("flutterwave"), Some("card"))
+                    .unwrap();
+
+                prop_assert!(provider_fee.calculated <= cap);
+                prop_assert!(provider_fee.calculated >= BigDecimal::from(0));
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_amount_in_range() {
         let amount = BigDecimal::from_str("10000").unwrap();

--- a/tests/kyc_limits_proptest.rs
+++ b/tests/kyc_limits_proptest.rs
@@ -1,0 +1,83 @@
+//! Property-based tests for KYC transaction limit enforcement (issue #797).
+//!
+//! `TransactionLimitEnforcer::check_transaction_limits` is pure (no DB/redis
+//! access), so it can be exercised directly with proptest-generated inputs.
+
+use aframp_backend::database::kyc_repository::KycTier;
+use aframp_backend::kyc::tier_requirements::TransactionLimitEnforcer;
+use bigdecimal::BigDecimal;
+use proptest::prelude::*;
+
+fn cents_to_decimal(cents: i64) -> BigDecimal {
+    BigDecimal::from(cents) / BigDecimal::from(100)
+}
+
+fn any_tier() -> impl Strategy<Value = KycTier> {
+    prop_oneof![
+        Just(KycTier::Unverified),
+        Just(KycTier::Basic),
+        Just(KycTier::Standard),
+        Just(KycTier::Enhanced),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+    /// If a transaction is allowed, adding it to the current daily and
+    /// monthly volumes must never push either over its limit, and the
+    /// transaction itself must not exceed the single-transaction cap.
+    #[test]
+    fn allowed_transaction_never_exceeds_limits(
+        tier in any_tier(),
+        amount_cents in 1i64..10_000_000_00i64,
+        daily_used_cents in 0i64..10_000_000_00i64,
+        monthly_used_cents in 0i64..50_000_000_00i64,
+    ) {
+        let amount = cents_to_decimal(amount_cents);
+        let daily_used = cents_to_decimal(daily_used_cents);
+        let monthly_used = cents_to_decimal(monthly_used_cents);
+
+        let enforcer = TransactionLimitEnforcer::new(tier.clone());
+        let result = enforcer.check_transaction_limits(
+            amount.clone(),
+            daily_used.clone(),
+            monthly_used.clone(),
+        );
+
+        if result.is_allowed {
+            let limits = aframp_backend::kyc::tier_requirements::KycTierRequirements::get_tier_limits(tier);
+            prop_assert!(amount.clone() <= limits.max_transaction_amount);
+            prop_assert!(daily_used + amount.clone() <= limits.daily_volume_limit);
+            prop_assert!(monthly_used + amount <= limits.monthly_volume_limit);
+        }
+    }
+
+    /// If adding the transaction would push the daily (or monthly) volume
+    /// over its limit, the transaction must be rejected — the enforcer
+    /// must never silently allow a window to exceed its configured cap.
+    #[test]
+    fn over_limit_transaction_is_never_allowed(
+        tier in any_tier(),
+        amount_cents in 1i64..10_000_000_00i64,
+        daily_used_cents in 0i64..10_000_000_00i64,
+        monthly_used_cents in 0i64..50_000_000_00i64,
+    ) {
+        let amount = cents_to_decimal(amount_cents);
+        let daily_used = cents_to_decimal(daily_used_cents);
+        let monthly_used = cents_to_decimal(monthly_used_cents);
+
+        let limits = aframp_backend::kyc::tier_requirements::KycTierRequirements::get_tier_limits(tier.clone());
+        let would_exceed_daily = daily_used.clone() + amount.clone() > limits.daily_volume_limit;
+        let would_exceed_monthly = monthly_used.clone() + amount.clone() > limits.monthly_volume_limit;
+        let would_exceed_single = amount.clone() > limits.max_transaction_amount;
+
+        let enforcer = TransactionLimitEnforcer::new(tier);
+        let result = enforcer.check_transaction_limits(amount, daily_used, monthly_used);
+
+        if would_exceed_daily || would_exceed_monthly || would_exceed_single {
+            prop_assert!(!result.is_allowed);
+            prop_assert!(!result.violations.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #797

`Cargo.toml` already listed `proptest = "1.4"` as a dev-dependency but it
was unused anywhere in the codebase. Added property-based coverage for the
three areas called out in the issue:

- **Fee calculation** (`src/services/fee_calculation.rs`): for realistic
  tier ranges (<=20% combined provider+platform rate, small flat component),
  the combined fee is always non-negative and never exceeds the amount being
  charged; a configured provider fee cap is always respected.
- **KYC limits** (`tests/kyc_limits_proptest.rs`, new): against the pure
  `TransactionLimitEnforcer::check_transaction_limits`, an allowed
  transaction never pushes daily/monthly volume over its tier limit, and a
  transaction that would exceed a limit is never allowed.
- **Exchange rate conversion** (`src/services/exchange_rate.rs`): a
  NGN → USD → NGN round trip through `compute_gross_amount()` stays within
  1 basis point (0.01%) of the original amount.

Each suite runs 10,000 cases via `ProptestConfig::with_cases(10_000)`.

No changes to CI workflow files were needed — the in-module suites are
picked up by the existing `unit-tests` job (`cargo llvm-cov --lib
--all-features`), and the new `tests/kyc_limits_proptest.rs` file is
registered as a `[[test]]` in `Cargo.toml` so it runs under the existing
`integration-tests` job (`cargo test --tests --all-features`).

## Test plan
- [ ] `cargo test --lib --all-features` (not run in this environment — no
      Rust toolchain available; logic was hand-verified against the
      existing `test_service()`/`test_fee_config()` helpers and
      `compute_gross_amount` semantics already covered by the surrounding
      unit tests)
- [ ] `cargo test --tests --all-features -- kyc_limits_proptest`