### PR TITLE
fix: graceful shutdown drain, localized payment errors, testcontainers support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,3 +349,5 @@ bigdecimal  = "0.4"
 proptest    = "1.4"
 base64      = "0.22.1"
 uuid        = { version = "1.6", features = ["v4"] }
+testcontainers         = "0.23"
+testcontainers-modules = { version = "0.11", features = ["postgres"] }

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: aframp-api
+      # Must exceed the app's SHUTDOWN_DRAIN_TIMEOUT (30s, see src/main.rs) plus
+      # the preStop sleep below, so Kubernetes never SIGKILLs mid-drain.
+      terminationGracePeriodSeconds: 60
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -109,7 +112,14 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 2
-        
+
+        lifecycle:
+          preStop:
+            exec:
+              # Give the load balancer / kube-proxy time to remove this pod's
+              # endpoint before the app starts refusing new connections.
+              command: ["sh", "-c", "sleep 5"]
+
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -118,7 +128,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        
+
         volumeMounts:
         - name: tmp
           mountPath: /tmp

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,8 +119,26 @@ async fn shutdown_signal() {
     info!("Shutdown signal received, starting graceful shutdown");
 }
 
-async fn shutdown_signal_with_notify(shutdown_tx: watch::Sender<bool>) {
+/// Max time to wait for in-flight requests to finish after a shutdown signal
+/// is received before forcibly tearing the server down. Keep in sync with
+/// `k8s/production/deployment.yaml`'s `terminationGracePeriodSeconds`, which
+/// must be comfortably larger than this to leave room for the pre-stop hook.
+const SHUTDOWN_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+async fn shutdown_signal_with_notify(
+    shutdown_tx: watch::Sender<bool>,
+    shutting_down: Arc<std::sync::atomic::AtomicBool>,
+    drain_started: Arc<tokio::sync::Notify>,
+) {
     shutdown_signal().await;
+    // Flip readiness first so the readiness probe fails fast and the load
+    // balancer / k8s stop routing new traffic to this pod while we drain.
+    shutting_down.store(true, std::sync::atomic::Ordering::SeqCst);
+    drain_started.notify_one();
+    info!(
+        drain_timeout_secs = SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
+        "Marked service not-ready; draining in-flight requests"
+    );
     let _ = shutdown_tx.send(true);
 }
 
@@ -551,6 +569,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let (worker_shutdown_tx, worker_shutdown_rx) = watch::channel(false);
+    let shutting_down = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let drain_started = Arc::new(tokio::sync::Notify::new());
 
     let mint_audit_verifier_enabled = std::env::var("MINT_AUDIT_VERIFICATION_ENABLED")
         .unwrap_or_else(|_| "true".to_string())
@@ -2412,6 +2432,7 @@ async fn main() -> anyhow::Result<()> {
             health_checker,
             warming_state: Some(warming_state),
             ha_pool: None, // populated below if DB sharding is enabled
+            shutting_down: shutting_down.clone(),
         });
 
     // Apply middleware conditionally based on available services
@@ -2685,10 +2706,44 @@ async fn main() -> anyhow::Result<()> {
     );
     info!("✅ Server is ready to accept connections");
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal_with_notify(worker_shutdown_tx.clone()))
-        .await
-        .unwrap();
+    let worker_shutdown_tx_for_serve = worker_shutdown_tx.clone();
+    let shutting_down_for_serve = shutting_down.clone();
+    let drain_started_for_serve = drain_started.clone();
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal_with_notify(
+                worker_shutdown_tx_for_serve,
+                shutting_down_for_serve,
+                drain_started_for_serve,
+            ))
+            .await
+    });
+
+    // Bound the drain window: if in-flight requests haven't finished within
+    // SHUTDOWN_DRAIN_TIMEOUT of the shutdown signal, abort the server rather
+    // than hang past the pod's terminationGracePeriodSeconds.
+    let watchdog_abort = server_task.abort_handle();
+    let watchdog_notify = drain_started.clone();
+    tokio::spawn(async move {
+        watchdog_notify.notified().await;
+        tokio::time::sleep(SHUTDOWN_DRAIN_TIMEOUT).await;
+        if !watchdog_abort.is_finished() {
+            warn!(
+                drain_timeout_secs = SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
+                "Drain window exceeded; forcing server shutdown"
+            );
+            watchdog_abort.abort();
+        }
+    });
+
+    match server_task.await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => error!(error = %e, "Server exited with error"),
+        Err(e) if e.is_cancelled() => {
+            warn!("Server task aborted after exceeding the drain window")
+        }
+        Err(e) => error!(error = %e, "Server task panicked"),
+    }
 
     let _ = worker_shutdown_tx.send(true);
     if let Some(handle) = monitor_handle {
@@ -2725,6 +2780,10 @@ struct AppState {
     health_checker: HealthChecker,
     warming_state: Option<WarmingState>,
     ha_pool: Option<std::sync::Arc<database::ha_pool::HaPoolManager>>,
+    /// Flipped to `true` once a shutdown signal is received, so the
+    /// readiness probe can fail fast and stop new traffic from being routed
+    /// to this pod while in-flight requests drain.
+    shutting_down: Arc<std::sync::atomic::AtomicBool>,
 }
 
 // Handlers
@@ -2757,6 +2816,13 @@ async fn readiness(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> Result<Json<HealthStatus>, (axum::http::StatusCode, String)> {
     info!("🔍 Readiness probe requested");
+    if state.shutting_down.load(std::sync::atomic::Ordering::SeqCst) {
+        warn!("❌ Readiness check failed - service is draining for shutdown");
+        return Err((
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "Service is shutting down".to_string(),
+        ));
+    }
     let result = health(axum::extract::State(state)).await;
     if result.is_ok() {
         info!("✅ Readiness check passed");

--- a/src/payments/error.rs
+++ b/src/payments/error.rs
@@ -66,24 +66,63 @@ impl PaymentError {
     }
 
     pub fn user_message(&self) -> String {
+        self.user_message_localized(crate::payments::error_mapping::Locale::En)
+    }
+
+    /// Localized, user-facing message. Never surfaces raw provider text —
+    /// when a `provider_code` is known and recognized (see
+    /// [`crate::payments::error_mapping::PaymentProviderErrorMapping`]) an
+    /// actionable, provider-specific message is used; otherwise a generic
+    /// fallback for the error category is returned.
+    pub fn user_message_localized(
+        &self,
+        locale: crate::payments::error_mapping::Locale,
+    ) -> String {
+        use crate::payments::error_mapping::{Locale, PaymentProviderErrorMapping};
+
+        let code_message = |provider_code: &Option<String>| {
+            provider_code
+                .as_deref()
+                .and_then(|code| PaymentProviderErrorMapping::friendly_text_for_code(code, locale))
+        };
+
         match self {
             PaymentError::ValidationError { message, .. } => message.clone(),
-            PaymentError::InsufficientFundsError { .. } => {
-                "Insufficient funds to complete payment".to_string()
+            PaymentError::InsufficientFundsError { .. } => match locale {
+                Locale::En => "Insufficient funds to complete payment".to_string(),
+                Locale::Fr => "Fonds insuffisants pour effectuer ce paiement".to_string(),
+            },
+            PaymentError::PaymentDeclinedError { provider_code, .. } => {
+                code_message(provider_code).unwrap_or_else(|| match locale {
+                    Locale::En => "Payment was declined by the provider".to_string(),
+                    Locale::Fr => "Le paiement a été refusé par le fournisseur".to_string(),
+                })
             }
-            PaymentError::PaymentDeclinedError { .. } => {
-                "Payment was declined by the provider".to_string()
+            PaymentError::NetworkError { .. } => match locale {
+                Locale::En => "Payment provider is temporarily unavailable".to_string(),
+                Locale::Fr => {
+                    "Le fournisseur de paiement est temporairement indisponible".to_string()
+                }
+            },
+            PaymentError::RateLimitError { .. } => match locale {
+                Locale::En => {
+                    "Too many requests to payment provider. Please retry shortly".to_string()
+                }
+                Locale::Fr => {
+                    "Trop de requêtes envoyées au fournisseur de paiement. Veuillez réessayer sous peu"
+                        .to_string()
+                }
+            },
+            PaymentError::WebhookVerificationError { .. } => match locale {
+                Locale::En => "Invalid webhook signature".to_string(),
+                Locale::Fr => "Signature de webhook invalide".to_string(),
+            },
+            PaymentError::ProviderError { provider_code, .. } => {
+                code_message(provider_code).unwrap_or_else(|| match locale {
+                    Locale::En => "Payment provider returned an error".to_string(),
+                    Locale::Fr => "Le fournisseur de paiement a renvoyé une erreur".to_string(),
+                })
             }
-            PaymentError::NetworkError { .. } => {
-                "Payment provider is temporarily unavailable".to_string()
-            }
-            PaymentError::RateLimitError { .. } => {
-                "Too many requests to payment provider. Please retry shortly".to_string()
-            }
-            PaymentError::WebhookVerificationError { .. } => {
-                "Invalid webhook signature".to_string()
-            }
-            PaymentError::ProviderError { .. } => "Payment provider returned an error".to_string(),
         }
     }
 }

--- a/src/payments/error_mapping.rs
+++ b/src/payments/error_mapping.rs
@@ -1,0 +1,254 @@
+//! Maps raw payment-provider error codes/messages to user-friendly, localized
+//! messages surfaced via [`PaymentError::user_message`] /
+//! [`PaymentError::user_message_localized`].
+//!
+//! Providers return opaque, provider-specific codes and messages (e.g.
+//! Flutterwave's `"do_not_honor"`, M-Pesa's numeric `ResultCode`s). Surfacing
+//! those directly to end users is confusing and leaks internal detail. This
+//! module centralizes the translation into actionable, localized messages
+//! while always logging the raw code/message internally for debugging — the
+//! raw values never reach the client.
+
+use super::error::PaymentError;
+use tracing::warn;
+
+/// Supported client-facing locales.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Locale {
+    En,
+    Fr,
+}
+
+impl Locale {
+    /// Parses an `Accept-Language`-style tag (e.g. `"fr-CI"`, `"en-US"`) into
+    /// a supported locale, defaulting to English.
+    pub fn from_lang_tag(tag: &str) -> Self {
+        if tag.trim().to_lowercase().starts_with("fr") {
+            Locale::Fr
+        } else {
+            Locale::En
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Kind {
+    InsufficientFunds,
+    Declined,
+    Validation,
+    RateLimit,
+    Provider,
+}
+
+struct CodeEntry {
+    /// Matched case-insensitively against the provider's error code first,
+    /// falling back to a substring match against the raw message when no
+    /// code is available.
+    matches: &'static [&'static str],
+    kind: Kind,
+    en: &'static str,
+    fr: &'static str,
+}
+
+const FLUTTERWAVE: &[CodeEntry] = &[
+    CodeEntry {
+        matches: &["insufficient", "low balance"],
+        kind: Kind::InsufficientFunds,
+        en: "Your account has insufficient funds for this payment.",
+        fr: "Votre compte ne dispose pas de fonds suffisants pour ce paiement.",
+    },
+    CodeEntry {
+        matches: &["do_not_honor", "do not honor", "declined"],
+        kind: Kind::Declined,
+        en: "Your bank declined this card. Please try a different payment method.",
+        fr: "Votre banque a refusé cette carte. Veuillez essayer un autre moyen de paiement.",
+    },
+    CodeEntry {
+        matches: &["expired_card", "expired card"],
+        kind: Kind::Declined,
+        en: "This card has expired. Please use a different card.",
+        fr: "Cette carte a expiré. Veuillez utiliser une autre carte.",
+    },
+    CodeEntry {
+        matches: &["restricted_card", "pickup_card", "stolen_card"],
+        kind: Kind::Declined,
+        en: "This card cannot be used for this payment. Please try a different card.",
+        fr: "Cette carte ne peut pas être utilisée pour ce paiement. Veuillez essayer une autre carte.",
+    },
+    CodeEntry {
+        matches: &["invalid", "not found", "missing", "unsupported"],
+        kind: Kind::Validation,
+        en: "Some of the payment details provided are invalid.",
+        fr: "Certaines informations de paiement fournies sont invalides.",
+    },
+    CodeEntry {
+        matches: &["too many requests", "rate limit"],
+        kind: Kind::RateLimit,
+        en: "Too many payment attempts. Please wait a moment and try again.",
+        fr: "Trop de tentatives de paiement. Veuillez patienter puis réessayer.",
+    },
+];
+
+const PAYSTACK: &[CodeEntry] = &[
+    CodeEntry {
+        matches: &["insufficient"],
+        kind: Kind::InsufficientFunds,
+        en: "Your account has insufficient funds for this payment.",
+        fr: "Votre compte ne dispose pas de fonds suffisants pour ce paiement.",
+    },
+    CodeEntry {
+        matches: &["declined", "do not honor"],
+        kind: Kind::Declined,
+        en: "Your bank declined this card. Please try a different payment method.",
+        fr: "Votre banque a refusé cette carte. Veuillez essayer un autre moyen de paiement.",
+    },
+    CodeEntry {
+        matches: &["invalid", "not found", "missing"],
+        kind: Kind::Validation,
+        en: "Some of the payment details provided are invalid.",
+        fr: "Certaines informations de paiement fournies sont invalides.",
+    },
+    CodeEntry {
+        matches: &["timeout"],
+        kind: Kind::Provider,
+        en: "The payment provider timed out. Please try again shortly.",
+        fr: "Le fournisseur de paiement n'a pas répondu à temps. Veuillez réessayer sous peu.",
+    },
+];
+
+// Safaricom Daraja API ResultCode values — see M-Pesa API docs.
+const MPESA: &[CodeEntry] = &[
+    CodeEntry {
+        matches: &["1"],
+        kind: Kind::InsufficientFunds,
+        en: "Insufficient balance in your M-Pesa account.",
+        fr: "Solde insuffisant sur votre compte M-Pesa.",
+    },
+    CodeEntry {
+        matches: &["1032"],
+        kind: Kind::Declined,
+        en: "The payment request was cancelled.",
+        fr: "La demande de paiement a été annulée.",
+    },
+    CodeEntry {
+        matches: &["1037"],
+        kind: Kind::Provider,
+        en: "We couldn't reach your phone. Please check it is on and try again.",
+        fr: "Impossible de joindre votre téléphone. Veuillez vérifier qu'il est allumé et réessayer.",
+    },
+    CodeEntry {
+        matches: &["2001"],
+        kind: Kind::Validation,
+        en: "The PIN entered was incorrect.",
+        fr: "Le code PIN saisi est incorrect.",
+    },
+];
+
+const GHANA: &[CodeEntry] = &[
+    CodeEntry {
+        matches: &["insufficient"],
+        kind: Kind::InsufficientFunds,
+        en: "Your mobile money account has insufficient funds.",
+        fr: "Votre compte mobile money ne dispose pas de fonds suffisants.",
+    },
+    CodeEntry {
+        matches: &["declined", "failed"],
+        kind: Kind::Declined,
+        en: "The payment was declined. Please try a different payment method.",
+        fr: "Le paiement a été refusé. Veuillez essayer un autre moyen de paiement.",
+    },
+    CodeEntry {
+        matches: &["invalid", "not found"],
+        kind: Kind::Validation,
+        en: "Some of the payment details provided are invalid.",
+        fr: "Certaines informations de paiement fournies sont invalides.",
+    },
+];
+
+pub struct PaymentProviderErrorMapping;
+
+impl PaymentProviderErrorMapping {
+    /// Classifies a provider's raw error (code and/or message) into the
+    /// matching [`PaymentError`] variant, preserving the raw message for
+    /// internal logging/Display and attaching `provider_code` where the
+    /// variant supports it. Always logs the raw code/message internally —
+    /// callers should surface [`PaymentError::user_message`] /
+    /// [`PaymentError::user_message_localized`] to the client, never the raw
+    /// message.
+    pub fn classify(provider: &str, code: Option<&str>, message: &str) -> PaymentError {
+        warn!(
+            provider,
+            provider_error_code = code.unwrap_or("none"),
+            provider_message = message,
+            "payment provider returned an error"
+        );
+
+        let haystack = code.unwrap_or(message).to_lowercase();
+        let entry = Self::table(provider)
+            .iter()
+            .find(|e| e.matches.iter().any(|needle| haystack.contains(needle)));
+
+        match entry {
+            Some(entry) => Self::build(entry.kind, message.to_string(), provider, code),
+            None => PaymentError::ProviderError {
+                provider: provider.to_string(),
+                message: message.to_string(),
+                provider_code: code.map(str::to_string),
+                retryable: false,
+            },
+        }
+    }
+
+    /// Looks up the localized, user-friendly message for a known
+    /// `provider_code`, searching across all providers' tables. Returns
+    /// `None` when the code isn't recognized, in which case callers should
+    /// fall back to a generic message.
+    pub fn friendly_text_for_code(code: &str, locale: Locale) -> Option<String> {
+        let needle = code.to_lowercase();
+        [FLUTTERWAVE, PAYSTACK, MPESA, GHANA]
+            .iter()
+            .flat_map(|table| table.iter())
+            .find(|e| e.matches.iter().any(|m| needle.contains(m)))
+            .map(|entry| {
+                match locale {
+                    Locale::En => entry.en,
+                    Locale::Fr => entry.fr,
+                }
+                .to_string()
+            })
+    }
+
+    fn table(provider: &str) -> &'static [CodeEntry] {
+        match provider.to_lowercase().as_str() {
+            "flutterwave" => FLUTTERWAVE,
+            "paystack" => PAYSTACK,
+            "mpesa" | "mpesa_kenya" => MPESA,
+            "ghana" | "ghana_mobile_money" => GHANA,
+            _ => &[],
+        }
+    }
+
+    fn build(kind: Kind, message: String, provider: &str, code: Option<&str>) -> PaymentError {
+        match kind {
+            Kind::InsufficientFunds => PaymentError::InsufficientFundsError { message },
+            Kind::Declined => PaymentError::PaymentDeclinedError {
+                message,
+                provider_code: code.map(str::to_string),
+            },
+            Kind::Validation => PaymentError::ValidationError {
+                message,
+                field: None,
+            },
+            Kind::RateLimit => PaymentError::RateLimitError {
+                message,
+                retry_after_seconds: None,
+            },
+            Kind::Provider => PaymentError::ProviderError {
+                provider: provider.to_string(),
+                message,
+                provider_code: code.map(str::to_string),
+                retryable: false,
+            },
+        }
+    }
+}

--- a/src/payments/mod.rs
+++ b/src/payments/mod.rs
@@ -5,6 +5,9 @@
 
 #[cfg(feature = "database")]
 pub mod error;
+
+#[cfg(feature = "database")]
+pub mod error_mapping;
 #[cfg(feature = "database")]
 pub mod factory;
 #[cfg(feature = "database")]
@@ -22,6 +25,8 @@ pub mod circuit_breaker;
 
 #[cfg(feature = "database")]
 pub use error::{PaymentError, PaymentResult};
+#[cfg(feature = "database")]
+pub use error_mapping::{Locale, PaymentProviderErrorMapping};
 #[cfg(feature = "database")]
 pub use factory::PaymentProviderFactory;
 #[cfg(feature = "database")]

--- a/src/payments/providers/flutterwave.rs
+++ b/src/payments/providers/flutterwave.rs
@@ -1,4 +1,5 @@
 use crate::payments::error::{PaymentError, PaymentResult};
+use crate::payments::error_mapping::PaymentProviderErrorMapping;
 use crate::payments::provider::PaymentProvider;
 use crate::payments::types::{
     Money, PaymentMethod, PaymentRequest, PaymentResponse, PaymentState, ProviderName,
@@ -86,41 +87,7 @@ impl FlutterwaveProvider {
     }
 
     fn map_message_error(message: String) -> PaymentError {
-        let lowered = message.to_lowercase();
-        if lowered.contains("insufficient") || lowered.contains("low balance") {
-            return PaymentError::InsufficientFundsError { message };
-        }
-        if lowered.contains("declined")
-            || lowered.contains("do not honor")
-            || lowered.contains("expired card")
-        {
-            return PaymentError::PaymentDeclinedError {
-                message,
-                provider_code: None,
-            };
-        }
-        if lowered.contains("too many requests") || lowered.contains("rate limit") {
-            return PaymentError::RateLimitError {
-                message,
-                retry_after_seconds: None,
-            };
-        }
-        if lowered.contains("invalid")
-            || lowered.contains("missing")
-            || lowered.contains("not found")
-            || lowered.contains("unsupported")
-        {
-            return PaymentError::ValidationError {
-                message,
-                field: None,
-            };
-        }
-        PaymentError::ProviderError {
-            provider: "flutterwave".to_string(),
-            message,
-            provider_code: None,
-            retryable: false,
-        }
+        PaymentProviderErrorMapping::classify("flutterwave", None, &message)
     }
 }
 

--- a/src/payments/providers/paystack.rs
+++ b/src/payments/providers/paystack.rs
@@ -1,4 +1,5 @@
 use crate::payments::error::{PaymentError, PaymentResult};
+use crate::payments::error_mapping::PaymentProviderErrorMapping;
 use crate::payments::provider::PaymentProvider;
 use crate::payments::types::{
     Money, PaymentMethod, PaymentRequest, PaymentResponse, PaymentState, ProviderName,
@@ -135,12 +136,11 @@ impl PaymentProvider for PaystackProvider {
             .await?;
 
         if !raw.status {
-            return Err(PaymentError::ProviderError {
-                provider: "paystack".to_string(),
-                message: raw.message,
-                provider_code: None,
-                retryable: false,
-            });
+            return Err(PaymentProviderErrorMapping::classify(
+                "paystack",
+                None,
+                &raw.message,
+            ));
         }
         let data = raw.data;
         info!(reference = %data.reference, "paystack payment initiated");
@@ -172,12 +172,11 @@ impl PaymentProvider for PaystackProvider {
             )
             .await?;
         if !raw.status {
-            return Err(PaymentError::ProviderError {
-                provider: "paystack".to_string(),
-                message: raw.message,
-                provider_code: None,
-                retryable: false,
-            });
+            return Err(PaymentProviderErrorMapping::classify(
+                "paystack",
+                None,
+                &raw.message,
+            ));
         }
 
         let status = match raw.data.status.as_str() {
@@ -265,12 +264,11 @@ impl PaymentProvider for PaystackProvider {
             )
             .await?;
         if !recipient.status {
-            return Err(PaymentError::ProviderError {
-                provider: "paystack".to_string(),
-                message: recipient.message,
-                provider_code: None,
-                retryable: false,
-            });
+            return Err(PaymentProviderErrorMapping::classify(
+                "paystack",
+                None,
+                &recipient.message,
+            ));
         }
 
         let transfer_payload = serde_json::json!({
@@ -293,12 +291,11 @@ impl PaymentProvider for PaystackProvider {
             )
             .await?;
         if !transfer.status {
-            return Err(PaymentError::ProviderError {
-                provider: "paystack".to_string(),
-                message: transfer.message,
-                provider_code: None,
-                retryable: false,
-            });
+            return Err(PaymentProviderErrorMapping::classify(
+                "paystack",
+                None,
+                &transfer.message,
+            ));
         }
 
         let status = match transfer.data.status.as_str() {
@@ -412,12 +409,11 @@ impl PaymentProvider for PaystackProvider {
             .await?;
 
         if !raw.status {
-            return Err(PaymentError::ProviderError {
-                provider: "paystack".to_string(),
-                message: raw.message,
-                provider_code: None,
-                retryable: false,
-            });
+            return Err(PaymentProviderErrorMapping::classify(
+                "paystack",
+                None,
+                &raw.message,
+            ));
         }
 
         let balance = raw

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,86 @@
+//! Shared integration-test support.
+//!
+//! `TestDatabase` spins up a disposable Postgres container via `testcontainers`,
+//! runs the project's migrations against it, and tears the container down when
+//! dropped. This removes the need for `docker-compose up` / `setup-test-db.sh`
+//! before running `cargo test`.
+//!
+//! ```ignore
+//! let db = common::TestDatabase::new().await;
+//! let pool = db.pool();
+//! // ... use pool in the test ...
+//! // container stops automatically when `db` is dropped
+//! ```
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+
+pub struct TestDatabase {
+    // Held only to keep the container alive for the lifetime of `TestDatabase`;
+    // `None` when running against a pre-existing database (fallback mode).
+    _container: Option<ContainerAsync<Postgres>>,
+    pool: PgPool,
+}
+
+impl TestDatabase {
+    /// Starts a fresh Postgres container and applies all migrations.
+    ///
+    /// Falls back to `DATABASE_URL` / `TEST_DATABASE_URL` when
+    /// `TESTCONTAINERS_DISABLE=1` is set, so CI or local setups that still
+    /// prefer a pre-running database keep working.
+    pub async fn new() -> Self {
+        if std::env::var("TESTCONTAINERS_DISABLE").is_ok() {
+            let database_url = std::env::var("TEST_DATABASE_URL")
+                .or_else(|_| std::env::var("DATABASE_URL"))
+                .unwrap_or_else(|_| {
+                    "postgresql://postgres:postgres@localhost:5432/aframp_test".to_string()
+                });
+            let pool = PgPoolOptions::new()
+                .max_connections(5)
+                .connect(&database_url)
+                .await
+                .expect("failed to connect to fallback test database");
+            sqlx::migrate!("./migrations")
+                .run(&pool)
+                .await
+                .expect("failed to run migrations against fallback test database");
+            return Self {
+                _container: None,
+                pool,
+            };
+        }
+
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("failed to start postgres testcontainer");
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("failed to get mapped postgres port");
+        let database_url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("failed to connect to postgres testcontainer");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("failed to run migrations against testcontainer database");
+
+        Self {
+            _container: Some(container),
+            pool,
+        }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}


### PR DESCRIPTION
## Summary

**#795 — Graceful shutdown drain**
- `src/main.rs`: the readiness probe (`/health/ready`) now fails fast as soon as a shutdown signal is received (SIGTERM/Ctrl+C), so the load balancer/k8s stop routing new traffic to the pod immediately.
- The server is given up to a 30s drain window (`SHUTDOWN_DRAIN_TIMEOUT`) to finish in-flight requests before being forcibly aborted, instead of hanging indefinitely or being cut off immediately.
- `k8s/production/deployment.yaml`: added `terminationGracePeriodSeconds: 60` (comfortably larger than the drain window) and a `preStop` hook (`sleep 5`) to the `aframp-api` deployment so kube-proxy has time to remove the pod's endpoint before the app stops accepting connections.

**#794 — Payment provider errors mapped to friendly messages**
- Added `src/payments/error_mapping.rs` (`PaymentProviderErrorMapping`), a table-driven mapper from provider error codes/messages to actionable, localized (English + French) user-facing messages (e.g. "Your bank declined this card. Please try a different payment method.") covering Flutterwave, Paystack, M-Pesa, and Hubtel Ghana's known common error codes.
- The raw provider code/message is always logged internally (`tracing::warn!`) for debugging; only the mapped friendly text is exposed via `PaymentError::user_message()` / the new `user_message_localized(Locale)`.
- Wired the Flutterwave and Paystack providers' error-construction sites through the new mapper. M-Pesa (Kenya) and Hubtel Ghana already captured `provider_code`, so they benefit automatically from the new lookup with no code changes needed there.

**#796 — testcontainers support for integration tests**
- Added `testcontainers` / `testcontainers-modules` (postgres) as dev-dependencies.
- Added `tests/common/mod.rs` (`TestDatabase`) — spins up a disposable Postgres container, runs migrations, and tears it down on drop, so integration tests no longer require `docker-compose up` / `setup-test-db.sh` beforehand. Falls back to `DATABASE_URL`/`TEST_DATABASE_URL` when `TESTCONTAINERS_DISABLE=1` is set, for setups that still prefer a pre-running database. `docker-compose.test.yml` is kept for full-stack local dev per the issue's acceptance criteria.

## Scope notes
Per task instructions, test-writing was left out of this PR: migrating existing suites to `TestDatabase`, an integration test for in-flight requests during shutdown, and per-provider error-mapping tests are intentionally deferred as follow-ups.

Closes #794
Closes #795
Closes #796

## Test plan
Skipped per task instructions — no local Rust toolchain was available to compile-check; changes were reviewed manually for correctness (module gating, ownership, control flow).