### PR TITLE
Rate limiting: sensitivity tiers, distributed Lua limiter, quota headers, per-consumer limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,6 +281,11 @@ path = "tests/rate_limit_tier_test.rs"
 required-features = ["cache"]
 
 [[test]]
+name = "advanced_rate_limit_test"
+path = "tests/advanced_rate_limit_test.rs"
+required-features = ["database"]
+
+[[test]]
 name = "request_integrity_test"
 path = "tests/request_integrity_test.rs"
 required-features = ["database"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,11 @@ path = "tests/rate_limit_test.rs"
 required-features = ["cache"]
 
 [[test]]
+name = "rate_limit_tier_test"
+path = "tests/rate_limit_tier_test.rs"
+required-features = ["cache"]
+
+[[test]]
 name = "request_integrity_test"
 path = "tests/request_integrity_test.rs"
 required-features = ["database"]

--- a/TODO.md
+++ b/TODO.md
@@ -6,30 +6,29 @@
   - [x] Create `consumer_rate_limit_overrides` table
 [x] Add migration + run `fix-migrations.sh`
 - [x] 2. Database Repository (`src/database/consumer_rate_limit_repository.rs`)
-- [ ] 3. Extend Rate Limit Middleware (`src/middleware/rate_limit.rs`)
-  - [ ] Extract `AuthenticatedKey` consumer_id/type
-  - [ ] Multi-dimension keys (global/endpoint/tx-type/IP)
-  - [ ] Lua scripts: Sliding window + Token Bucket
-  - [ ] Endpoint sensitivity tiers
-  - [ ] Profile + override merging
-- [ ] 4. Admin Rate Limit Endpoints (`src/api/admin/rate_limits.rs`)
-  - [ ] GET/POST/DELETE `/api/admin/consumers/:id/rate-limits`
-- [ ] 5. Metrics & Logging (`src/middleware/rate_limit_metrics.rs`)
-  - [ ] Prometheus: checks/hits/utilisation
-  - [ ] Breach logs/alerts
-- [ ] 6. Update Config (`rate_limits.yaml`)
-- [ ] 7. Integration Tests (`tests/advanced_rate_limit_test.rs`)
-- [ ] 8. Route Wiring (`src/main.rs`, `src/routes/`)
+- [x] 3. Extend Rate Limit Middleware (`src/middleware/rate_limit.rs`)
+  - [x] Extract `AuthenticatedKey` consumer_id/type (via `middleware::api_key::resolve_api_key`)
+  - [x] Multi-dimension keys (global/endpoint/tx-type/IP)
+  - [x] Lua script: atomic sliding window check-and-increment (token-bucket-equivalent via limit/window; see #727)
+  - [x] Endpoint sensitivity tiers (see #726)
+  - [x] Profile + override merging (via `get_effective_rate_limits` SQL function)
+- [x] 4. Admin Rate Limit Endpoints (`src/api/admin/rate_limits.rs`)
+  - [x] GET/POST/DELETE `/api/admin/consumers/:id/rate-limits`
+- [x] 5. Metrics & Logging (`src/middleware/rate_limit_metrics.rs`)
+  - [x] Prometheus: checks/hits/utilisation (wired into the per-dimension consumer check)
+  - [x] Breach logs/alerts (`record_hit`/`record_429` + `warn!` on breach)
+- [x] 6. Update Config (`rate_limits.yaml`)
+- [x] 7. Integration Tests (`tests/advanced_rate_limit_test.rs`)
+- [x] 8. Route Wiring (`src/main.rs`)
 - [ ] 9. Verification
   - [ ] `cargo test`
   - [ ] `cargo check`
   - [ ] Manual test concurrent requests
 - [ ] 10. Git Branch/PR
-  - [ ] `git checkout -b blackboxai/rate-limiting-175`
   - [ ] Commit changes
-  - [ ] `gh pr create --title "Fix #175: Advanced Per-Consumer Rate Limiting"`
+  - [ ] Open PR
 
-**Current Step: 1/10**
+**Current Step: 8/10 — steps 3-8 implemented across #725/#726/#727/#728; verification (9) and PR (10) pending.**
 # Third-Party Security Audit Framework Implementation TODO
 
 Current Status: [In Progress]  

--- a/rate_limits.yaml
+++ b/rate_limits.yaml
@@ -11,6 +11,15 @@
 #   tier: <CRITICAL|FINANCIAL|STANDARD|PUBLIC>   # optional — used as the
 #     per_ip fallback whenever per_ip is not set explicitly above (Issue #726)
 
+# Per-consumer overrides (Issue #175 / #725): authenticated API-key callers
+# with a `consumer_rate_limit_profiles` row (by consumer_type) or an active
+# `consumer_rate_limit_overrides` row are checked against that DB-backed
+# profile *in addition to* the static limits below, across the "global",
+# "endpoint_critical" / "endpoint_elevated" / "endpoint_standard", "tx_*",
+# and "ip" dimensions. See src/middleware/rate_limit.rs and
+# src/api/admin/rate_limits.rs (admin CRUD for overrides). This file remains
+# the source of truth for unauthenticated / non-API-key traffic.
+
 # Endpoint sensitivity tiers — coarse-grained default limits applied by
 # `tier:` when an endpoint doesn't define its own per_ip limit. Values are
 # requests per window (see acceptance criteria in Issue #726).

--- a/rate_limits.yaml
+++ b/rate_limits.yaml
@@ -8,73 +8,117 @@
 #   per_wallet:
 #     limit: <number>
 #     window: <seconds>
+#   tier: <CRITICAL|FINANCIAL|STANDARD|PUBLIC>   # optional — used as the
+#     per_ip fallback whenever per_ip is not set explicitly above (Issue #726)
+
+# Endpoint sensitivity tiers — coarse-grained default limits applied by
+# `tier:` when an endpoint doesn't define its own per_ip limit. Values are
+# requests per window (see acceptance criteria in Issue #726).
+tiers:
+  CRITICAL:
+    limit: 10
+    window: 60
+  FINANCIAL:
+    limit: 60
+    window: 60
+  STANDARD:
+    limit: 300
+    window: 60
+  PUBLIC:
+    limit: 1000
+    window: 60
 
 endpoints:
+  "/api/mint":
+    tier: CRITICAL
+    per_wallet:
+      limit: 5
+      window: 3600
+
+  "/api/redemption":
+    tier: CRITICAL
+    per_wallet:
+      limit: 5
+      window: 3600
+
   "/api/onramp/initiate":
+    tier: FINANCIAL
     per_wallet:
       limit: 5
       window: 3600
 
   "/api/offramp/initiate":
+    tier: FINANCIAL
     per_wallet:
       limit: 5
       window: 3600
 
   "/api/bills/pay":
+    tier: FINANCIAL
     per_wallet:
       limit: 20
       window: 3600
 
   "/api/wallet/balance":
+    tier: STANDARD
     per_wallet:
       limit: 200
       window: 3600
 
   "/api/onramp/status":
+    tier: STANDARD
     per_wallet:
       limit: 100
       window: 3600
 
   "/api/auth/verify":
+    tier: FINANCIAL
     per_wallet:
       limit: 5
       window: 60
 
   "/api/auth/challenge":
+    tier: STANDARD
     per_ip:
       limit: 10
       window: 60
 
   "/api/onramp/quote":
+    tier: STANDARD
     per_ip:
       limit: 30
       window: 60
     per_wallet:
       limit: 10
       window: 3600
-      
+
   "/api/offramp/quote":
+    tier: STANDARD
     per_wallet:
       limit: 10
       window: 3600
 
   "/api/rates":
+    tier: PUBLIC
     per_ip:
       limit: 100
       window: 60
 
   "/api/fees":
+    tier: PUBLIC
     per_ip:
       limit: 100
       window: 60
 
   "/api/bills/providers":
+    tier: PUBLIC
     per_ip:
       limit: 50
       window: 60
 
 # Default limits applied when no specific endpoint matches
 default:
+  tier: STANDARD
   per_ip:
     limit: 100
     window: 60

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -4,6 +4,7 @@ pub mod dashboard;
 pub mod ip_reputation;
 pub mod keys;
 pub mod partner;
+pub mod rate_limits;
 pub mod reconciliation;
 pub mod revocation;
 pub mod scopes;

--- a/src/api/admin/rate_limits.rs
+++ b/src/api/admin/rate_limits.rs
@@ -1,0 +1,216 @@
+//! Admin endpoints for per-consumer rate limit overrides (Issue #175 / #725).
+//!
+//! Routes:
+//!   GET    /api/admin/consumers/:consumer_id/rate-limits              — effective limits + active overrides
+//!   POST   /api/admin/consumers/:consumer_id/rate-limits              — create an override
+//!   DELETE /api/admin/consumers/:consumer_id/rate-limits/:override_id — remove an override
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::database::consumer_rate_limit_repository::{ConsumerRateLimitRepository, LimitsJson};
+
+// ─── State ───────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct RateLimitAdminState {
+    pub repo: Arc<ConsumerRateLimitRepository>,
+}
+
+// ─── Models ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct OverrideResponse {
+    pub id: Uuid,
+    pub consumer_id: Uuid,
+    pub limits_json: LimitsJson,
+    pub expiry_at: Option<DateTime<Utc>>,
+    pub reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConsumerRateLimitsResponse {
+    pub consumer_id: Uuid,
+    /// Merged limits actually enforced (override, if any, else profile).
+    pub effective_limits: Option<LimitsJson>,
+    pub active_overrides: Vec<OverrideResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateOverrideRequest {
+    pub limits_json: LimitsJson,
+    #[serde(default)]
+    pub expiry_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: ErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorDetail {
+    pub code: String,
+    pub message: String,
+}
+
+fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    (
+        status,
+        Json(ErrorResponse {
+            error: ErrorDetail {
+                code: code.to_string(),
+                message: message.to_string(),
+            },
+        }),
+    )
+        .into_response()
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+/// GET /api/admin/consumers/:consumer_id/rate-limits
+///
+/// Returns the effective (override-or-profile-merged) rate limits for a
+/// consumer plus the list of currently active overrides. Requires admin
+/// authentication (enforced by the surrounding admin router layer).
+pub async fn get_consumer_rate_limits(
+    State(state): State<RateLimitAdminState>,
+    Path(consumer_id): Path<Uuid>,
+) -> Response {
+    let effective_limits = match state.repo.get_effective_limits(consumer_id).await {
+        Ok(limits) => limits,
+        Err(e) => {
+            error!("Failed to load effective rate limits for {}: {}", consumer_id, e);
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                "Failed to load rate limits",
+            );
+        }
+    };
+
+    let overrides = match state.repo.list_overrides(consumer_id).await {
+        Ok(overrides) => overrides,
+        Err(e) => {
+            error!("Failed to list rate limit overrides for {}: {}", consumer_id, e);
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                "Failed to load rate limit overrides",
+            );
+        }
+    };
+
+    Json(ConsumerRateLimitsResponse {
+        consumer_id,
+        effective_limits,
+        active_overrides: overrides
+            .into_iter()
+            .map(|o| OverrideResponse {
+                id: o.id,
+                consumer_id: o.consumer_id,
+                limits_json: o.limits_json,
+                expiry_at: o.expiry_at,
+                reason: o.reason,
+                created_at: o.created_at,
+            })
+            .collect(),
+    })
+    .into_response()
+}
+
+/// POST /api/admin/consumers/:consumer_id/rate-limits
+///
+/// Creates a rate-limit override for a consumer — takes precedence over
+/// their consumer-type profile until `expiry_at` (or forever if unset).
+pub async fn create_consumer_rate_limit_override(
+    State(state): State<RateLimitAdminState>,
+    Path(consumer_id): Path<Uuid>,
+    Json(body): Json<CreateOverrideRequest>,
+) -> Response {
+    if !body.limits_json.is_object() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "INVALID_LIMITS_JSON",
+            "limits_json must be an object of dimension -> {limit, window_secs}",
+        );
+    }
+
+    match state
+        .repo
+        .create_override(
+            consumer_id,
+            &body.limits_json,
+            body.expiry_at,
+            None,
+            body.reason,
+        )
+        .await
+    {
+        Ok(o) => {
+            info!(consumer_id = %consumer_id, override_id = %o.id, "Admin created rate limit override");
+            (
+                StatusCode::CREATED,
+                Json(OverrideResponse {
+                    id: o.id,
+                    consumer_id: o.consumer_id,
+                    limits_json: o.limits_json,
+                    expiry_at: o.expiry_at,
+                    reason: o.reason,
+                    created_at: o.created_at,
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            error!("Failed to create rate limit override for {}: {}", consumer_id, e);
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                "Failed to create rate limit override",
+            )
+        }
+    }
+}
+
+/// DELETE /api/admin/consumers/:consumer_id/rate-limits/:override_id
+///
+/// Removes an override, reverting the consumer to their consumer-type
+/// profile limits.
+pub async fn delete_consumer_rate_limit_override(
+    State(state): State<RateLimitAdminState>,
+    Path((consumer_id, override_id)): Path<(Uuid, Uuid)>,
+) -> Response {
+    match state.repo.delete_override(override_id).await {
+        Ok(true) => {
+            info!(consumer_id = %consumer_id, override_id = %override_id, "Admin deleted rate limit override");
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Ok(false) => error_response(
+            StatusCode::NOT_FOUND,
+            "OVERRIDE_NOT_FOUND",
+            "No override found with that id",
+        ),
+        Err(e) => {
+            error!("Failed to delete rate limit override {}: {}", override_id, e);
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                "Failed to delete rate limit override",
+            )
+        }
+    }
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -479,6 +479,17 @@ per-IP ceiling (requests/minute): `CRITICAL` (10) for fund-movement
 endpoints such as mint and redemption, `FINANCIAL` (60) for onramp/offramp
 initiation, `STANDARD` (300) for general authenticated endpoints, and
 `PUBLIC` (1000) for read-only endpoints such as `/api/rates`.
+
+API-key consumers may additionally be subject to a per-consumer profile
+(by consumer type: mobile_client, partner, microservice, admin) checked
+across four dimensions — global, endpoint sensitivity, transaction type,
+and IP — the most restrictive of which determines the response. Admins
+manage per-consumer overrides (which take precedence over the profile
+until they expire) via:
+
+- `GET /api/admin/consumers/:consumer_id/rate-limits` — effective limits + active overrides
+- `POST /api/admin/consumers/:consumer_id/rate-limits` — create an override (`limits_json`, optional `expiry_at`, `reason`)
+- `DELETE /api/admin/consumers/:consumer_id/rate-limits/:override_id` — remove an override
 ",
         contact(name = "Aframp Engineering"),
         license(name = "Proprietary")

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -459,6 +459,26 @@ Authorization: Bearer <your_jwt_token>
 
 Your Stellar wallet must have an active cNGN trustline before receiving cNGN.
 See the cNGN Integration Guide in `/docs/cngn/` for setup instructions.
+
+## Rate Limiting
+
+Every response carries your current quota for the endpoint you called:
+
+| Header                | Meaning                                              |
+|------------------------|-------------------------------------------------------|
+| `X-RateLimit-Limit`     | Requests allowed in the current window                |
+| `X-RateLimit-Remaining` | Requests left in the current window                   |
+| `X-RateLimit-Reset`     | Unix timestamp (seconds) when the window resets        |
+| `X-RateLimit-Used`      | Requests already consumed in the current window        |
+
+Exceeding the limit returns `429 Too Many Requests` with an additional
+`Retry-After` header (seconds until the window resets).
+
+Endpoints are grouped into sensitivity tiers, each with its own default
+per-IP ceiling (requests/minute): `CRITICAL` (10) for fund-movement
+endpoints such as mint and redemption, `FINANCIAL` (60) for onramp/offramp
+initiation, `STANDARD` (300) for general authenticated endpoints, and
+`PUBLIC` (1000) for read-only endpoints such as `/api/rates`.
 ",
         contact(name = "Aframp Engineering"),
         license(name = "Proprietary")

--- a/src/database/consumer_rate_limit_repository.rs
+++ b/src/database/consumer_rate_limit_repository.rs
@@ -44,7 +44,7 @@ pub type LimitsJson = serde_json::Value; // Flexible JSONB
 #[derive(Debug, Clone, FromRow)]
 pub struct Profile {
     pub consumer_type: String,
-    pub limits_json: PgJson<LimitsJson>,
+    pub limits_json: LimitsJson,
     pub burst_multiplier: f64,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -54,7 +54,7 @@ pub struct Profile {
 pub struct Override {
     pub id: Uuid,
     pub consumer_id: Uuid,
-    pub limits_json: PgJson<LimitsJson>,
+    pub limits_json: LimitsJson,
     pub expiry_at: Option<DateTime<Utc>>,
     pub created_by: Option<Uuid>,
     pub reason: Option<String>,
@@ -86,7 +86,7 @@ impl ConsumerRateLimitRepository {
             RETURNING *
             "#,
             consumer_type,
-            limits_json as PgJson<LimitsJson>,
+            limits_json,
             burst_multiplier
         )
         .fetch_one(self.pool.as_ref())
@@ -125,7 +125,7 @@ impl ConsumerRateLimitRepository {
             RETURNING *
             "#,
             consumer_id,
-            limits_json as PgJson<LimitsJson>,
+            limits_json,
             expiry_at,
             created_by,
             reason

--- a/src/main.rs
+++ b/src/main.rs
@@ -1700,6 +1700,13 @@ async fn main() -> anyhow::Result<()> {
         let ip_reputation_state = api::admin::ip_reputation::IpReputationState {
             repo: database::ip_reputation_repository::IpReputationRepository::new(pool.clone()),
         };
+        let rate_limit_admin_state = api::admin::rate_limits::RateLimitAdminState {
+            repo: std::sync::Arc::new(
+                database::consumer_rate_limit_repository::ConsumerRateLimitRepository::new(
+                    std::sync::Arc::new(pool.clone()),
+                ),
+            ),
+        };
         Router::new()
 
         // ── Revocation & Blacklist routes (Issue #138) ────────────────────────
@@ -1767,6 +1774,20 @@ async fn main() -> anyhow::Result<()> {
                         post(api::admin::ip_reputation::whitelist_ip),
                     )
                     .with_state(ip_reputation_state),
+            )
+            .merge(
+                Router::new()
+                    // Issue #175 / #725 — per-consumer rate limit overrides
+                    .route(
+                        "/api/admin/consumers/{consumer_id}/rate-limits",
+                        get(api::admin::rate_limits::get_consumer_rate_limits)
+                            .post(api::admin::rate_limits::create_consumer_rate_limit_override),
+                    )
+                    .route(
+                        "/api/admin/consumers/{consumer_id}/rate-limits/{override_id}",
+                        delete(api::admin::rate_limits::delete_consumer_rate_limit_override),
+                    )
+                    .with_state(rate_limit_admin_state),
             )
     } else {
         info!("Skipping admin routes (no database)");
@@ -2494,6 +2515,14 @@ async fn main() -> anyhow::Result<()> {
         let rate_limit_state = crate::middleware::rate_limit::RateLimitState {
             cache: std::sync::Arc::new(cache.clone()),
             config: rate_limit_config,
+            consumer_repo: db_pool.clone().map(|pool| {
+                std::sync::Arc::new(
+                    crate::database::consumer_rate_limit_repository::ConsumerRateLimitRepository::new(
+                        std::sync::Arc::new(pool),
+                    ),
+                )
+            }),
+            db_pool: db_pool.clone().map(std::sync::Arc::new),
         };
 
         let replay_state = crate::middleware::replay_prevention::ReplayPreventionState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2483,7 +2483,9 @@ async fn main() -> anyhow::Result<()> {
             default: crate::middleware::rate_limit::EndpointLimits {
                 per_ip: Some(crate::middleware::rate_limit::LimitConfig { limit: 100, window: 60 }),
                 per_wallet: None,
-            }
+                tier: None,
+            },
+            tiers: std::collections::HashMap::new(),
         }
     }));
 

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -8,11 +8,46 @@ use axum::{
 };
 use chrono::Utc;
 use jsonwebtoken::{decode, DecodingKey, Validation};
-use serde::{Deserialize, Serialize};
+use once_cell::sync::Lazy;
+use serde::Deserialize;
 use serde_json::json;
 use std::{collections::HashMap, fs::File, net::SocketAddr, sync::Arc};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use uuid::Uuid;
+
+/// Atomic sliding-window check-and-increment (Issue #727).
+///
+/// Combines ZREMRANGEBYSCORE + ZCARD + conditional ZADD/EXPIRE into a single
+/// Lua script so the check and the increment happen as one atomic operation
+/// on Redis — eliminating the race window that existed between the previous
+/// separate "check" and "add" pipelines (two instances could both observe
+/// `count < limit` and both add, letting `2x limit` requests through).
+///
+/// KEYS[1] = sorted-set key
+/// ARGV[1] = now (ms)
+/// ARGV[2] = window (ms)
+/// ARGV[3] = limit
+/// ARGV[4] = member id (unique per request)
+/// ARGV[5] = window (seconds, for EXPIRE)
+///
+/// Returns { allowed (0|1), count } where `count` is the window occupancy
+/// after this call (post-increment when allowed, current count when not).
+static SLIDING_WINDOW_SCRIPT: Lazy<redis::Script> = Lazy::new(|| {
+    redis::Script::new(
+        r#"
+        redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', tonumber(ARGV[1]) - tonumber(ARGV[2]))
+        local count = redis.call('ZCARD', KEYS[1])
+        local limit = tonumber(ARGV[3])
+        if count < limit then
+            redis.call('ZADD', KEYS[1], ARGV[1], ARGV[4])
+            redis.call('EXPIRE', KEYS[1], ARGV[5])
+            return {1, count + 1}
+        else
+            return {0, count}
+        end
+        "#,
+    )
+});
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct LimitConfig {
@@ -173,48 +208,51 @@ pub async fn rate_limit_middleware(
         }
     };
 
-    // 3. Sliding Window Algorithm Pipeline
+    // 3. Atomic sliding-window check-and-increment (Issue #727). Redis is
+    // the single source of truth across all instances, so this is
+    // distributed-safe; if Redis itself is unavailable, fail open (allow
+    // the request) rather than 500ing every request in the fleet.
+    let now_ms = Utc::now().timestamp_millis();
+    let req_id = Uuid::new_v4().to_string();
+    let reset_at = (now_ms / 1000) + limit_conf.window;
+
     let mut conn = match state.cache.get_connection().await {
         Ok(c) => c,
         Err(e) => {
-            error!("Redis connection failed in rate_limit_middleware: {}", e);
-            let body = Json(json!({"error": "Internal server error"}));
-            return Err((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+            warn!(
+                "Redis connection unavailable in rate_limit_middleware, failing open: {}",
+                e
+            );
+            crate::middleware::rate_limit_metrics::record_redis_fallback("connection_error");
+            return Ok(next.run(req).await);
         }
     };
 
-    let now_ms = Utc::now().timestamp_millis();
-    let window_start_ms = now_ms - (limit_conf.window * 1000);
-    let req_id = Uuid::new_v4().to_string();
-
-    // Pipeline:
-    // ZREMRANGEBYSCORE key -inf window_start_ms
-    // ZCOUNT key -inf +inf
-    let (removed, count): (i64, i64) = match redis::pipe()
-        .atomic()
-        .cmd("ZREMRANGEBYSCORE")
-        .arg(&redis_key)
-        .arg("-inf")
-        .arg(window_start_ms)
-        .cmd("ZCARD")
-        .arg(&redis_key)
-        .query_async(&mut *conn)
+    let (allowed, count): (i64, i64) = match SLIDING_WINDOW_SCRIPT
+        .key(&redis_key)
+        .arg(now_ms)
+        .arg(limit_conf.window * 1000)
+        .arg(limit_conf.limit)
+        .arg(&req_id)
+        .arg(limit_conf.window)
+        .invoke_async(&mut *conn)
         .await
     {
         Ok(res) => res,
         Err(e) => {
-            error!("Redis pipe error in rate_limit_middleware: {}", e);
-            let body = Json(json!({"error": "Internal server error"}));
-            return Err((StatusCode::INTERNAL_SERVER_ERROR, body).into_response());
+            warn!(
+                "Redis Lua script failed in rate_limit_middleware, failing open: {}",
+                e
+            );
+            crate::middleware::rate_limit_metrics::record_redis_fallback("script_error");
+            return Ok(next.run(req).await);
         }
     };
 
     let remaining = limit_conf.limit - count;
+    let retry_after = limit_conf.window;
 
-    let reset_at = (now_ms / 1000) + limit_conf.window;
-    let mut retry_after = limit_conf.window;
-
-    if count >= limit_conf.limit {
+    if allowed == 0 {
         warn!(key = %redis_key, count = count, limit = limit_conf.limit, "Rate limit exceeded");
 
         // Emit metric for alert rule: aframp_rate_limit_breaches_total
@@ -259,27 +297,8 @@ pub async fn rate_limit_middleware(
         return Err(res);
     }
 
-    // Allow path: Add current request
-    let _: () = match redis::pipe()
-        .atomic()
-        .cmd("ZADD")
-        .arg(&redis_key)
-        .arg(now_ms)
-        .arg(&req_id)
-        .cmd("EXPIRE")
-        .arg(&redis_key)
-        .arg(limit_conf.window)
-        .query_async::<()>(&mut *conn)
-        .await
-    {
-        Ok(_) => (),
-        Err(e) => error!(
-            "Failed to add to sorted set for rate_limit_middleware: {}",
-            e
-        ),
-    };
-
-    // Forward the request to the next logical layer
+    // The Lua script already recorded this request atomically — just
+    // forward it and annotate the response with the resulting quota state.
     let mut res = next.run(req).await.into_response();
 
     // Inject successful Rate Limit headers
@@ -289,7 +308,7 @@ pub async fn rate_limit_middleware(
     );
     res.headers_mut().insert(
         "X-RateLimit-Remaining",
-        HeaderValue::from_str(&(remaining - 1).max(0).to_string()).unwrap(),
+        HeaderValue::from_str(&remaining.max(0).to_string()).unwrap(),
     );
     res.headers_mut().insert(
         "X-RateLimit-Reset",
@@ -297,7 +316,7 @@ pub async fn rate_limit_middleware(
     );
     res.headers_mut().insert(
         "X-RateLimit-Used",
-        HeaderValue::from_str(&(count + 1).to_string()).unwrap(),
+        HeaderValue::from_str(&count.to_string()).unwrap(),
     );
 
     Ok(res)

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -20,16 +20,45 @@ pub struct LimitConfig {
     pub window: i64,
 }
 
+/// Endpoint sensitivity tier (Issue #726). Determines the default per-IP
+/// limit applied when an endpoint entry doesn't set `per_ip` explicitly.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EndpointTier {
+    #[serde(rename = "CRITICAL")]
+    Critical,
+    #[serde(rename = "FINANCIAL")]
+    Financial,
+    #[serde(rename = "STANDARD")]
+    Standard,
+    #[serde(rename = "PUBLIC")]
+    Public,
+}
+
+impl EndpointTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EndpointTier::Critical => "CRITICAL",
+            EndpointTier::Financial => "FINANCIAL",
+            EndpointTier::Standard => "STANDARD",
+            EndpointTier::Public => "PUBLIC",
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct EndpointLimits {
     pub per_ip: Option<LimitConfig>,
     pub per_wallet: Option<LimitConfig>,
+    #[serde(default)]
+    pub tier: Option<EndpointTier>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct RateLimitConfig {
     pub endpoints: HashMap<String, EndpointLimits>,
     pub default: EndpointLimits,
+    #[serde(default)]
+    pub tiers: HashMap<EndpointTier, LimitConfig>,
 }
 
 impl RateLimitConfig {
@@ -40,13 +69,25 @@ impl RateLimitConfig {
         Ok(config)
     }
 
+    /// Resolves the limits for a given path, applying the endpoint's
+    /// sensitivity tier (Issue #726) as the per_ip fallback when the
+    /// matched entry (or the default) doesn't define per_ip explicitly.
     pub fn get_limits(&self, path: &str) -> EndpointLimits {
-        for (prefix, limits) in &self.endpoints {
-            if path.starts_with(prefix) {
-                return limits.clone();
-            }
+        let mut limits = self
+            .endpoints
+            .iter()
+            .find(|(prefix, _)| path.starts_with(prefix.as_str()))
+            .map(|(_, limits)| limits.clone())
+            .unwrap_or_else(|| self.default.clone());
+
+        if limits.per_ip.is_none() {
+            limits.per_ip = limits
+                .tier
+                .and_then(|t| self.tiers.get(&t).cloned())
+                .or_else(|| self.default.per_ip.clone());
         }
-        self.default.clone()
+
+        limits
     }
 }
 

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -130,6 +130,107 @@ impl RateLimitConfig {
 pub struct RateLimitState {
     pub cache: Arc<RedisCache>,
     pub config: Arc<RateLimitConfig>,
+    /// Enables per-consumer multi-dimension rate limiting (global/endpoint/
+    /// tx-type/IP, merged from `consumer_rate_limit_profiles` +
+    /// `consumer_rate_limit_overrides`) when a DB pool is configured.
+    /// `None` skips this layer and falls back to the wallet/IP tier limits
+    /// from `rate_limits.yaml` (Issue #175 / #725).
+    pub consumer_repo:
+        Option<Arc<crate::database::consumer_rate_limit_repository::ConsumerRateLimitRepository>>,
+    pub db_pool: Option<Arc<sqlx::PgPool>>,
+}
+
+/// Extracts a raw API key from `Authorization: Bearer <key>` or
+/// `X-API-Key: <key>`. Mirrors `middleware::api_key::extract_raw_key`
+/// (kept private there) — duplicated rather than exposed cross-module since
+/// rate limiting only needs to *identify* the consumer, not authenticate.
+fn extract_raw_api_key(headers: &axum::http::HeaderMap) -> Option<String> {
+    if let Some(bearer) = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    {
+        return Some(bearer.to_string());
+    }
+    headers
+        .get("x-api-key")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+/// Maps an endpoint sensitivity tier (Issue #726) to the matching key in a
+/// consumer's `limits_json` (see `consumer_rate_limit_profiles.limits_json`
+/// seed data in the #175 migration).
+fn endpoint_dimension(tier: Option<EndpointTier>) -> Option<&'static str> {
+    match tier {
+        Some(EndpointTier::Critical) => Some("endpoint_critical"),
+        Some(EndpointTier::Financial) => Some("endpoint_elevated"),
+        Some(EndpointTier::Standard) => Some("endpoint_standard"),
+        Some(EndpointTier::Public) | None => None,
+    }
+}
+
+/// Maps a request path to a transaction-type dimension, when applicable.
+fn tx_type_dimension(path: &str) -> Option<&'static str> {
+    if path.starts_with("/api/onramp") {
+        Some("tx_onramp")
+    } else if path.starts_with("/api/offramp") {
+        Some("tx_offramp")
+    } else if path.starts_with("/api/mint") {
+        Some("tx_mint")
+    } else if path.starts_with("/api/redemption") {
+        Some("tx_redemption")
+    } else {
+        None
+    }
+}
+
+/// Reads a `{limit, window_secs}` dimension out of a consumer's merged
+/// `limits_json`. Returns `None` if the dimension isn't configured for that
+/// consumer type/override, in which case it's simply not checked.
+fn dimension_limit(json: &serde_json::Value, key: &str) -> Option<LimitConfig> {
+    let dim = json.get(key)?;
+    Some(LimitConfig {
+        limit: dim.get("limit")?.as_i64()?,
+        window: dim.get("window_secs")?.as_i64()?,
+    })
+}
+
+/// Outcome of a single dimension check against the atomic sliding-window
+/// script.
+enum DimensionOutcome {
+    Allowed { count: i64 },
+    Denied { count: i64 },
+    RedisUnavailable,
+}
+
+async fn check_dimension(
+    conn: &mut bb8::PooledConnection<'_, bb8_redis::RedisConnectionManager>,
+    redis_key: &str,
+    limit_conf: &LimitConfig,
+    req_id: &str,
+    now_ms: i64,
+) -> DimensionOutcome {
+    match SLIDING_WINDOW_SCRIPT
+        .key(redis_key)
+        .arg(now_ms)
+        .arg(limit_conf.window * 1000)
+        .arg(limit_conf.limit)
+        .arg(req_id)
+        .arg(limit_conf.window)
+        .invoke_async::<(i64, i64)>(&mut **conn)
+        .await
+    {
+        Ok((1, count)) => DimensionOutcome::Allowed { count },
+        Ok((_, count)) => DimensionOutcome::Denied { count },
+        Err(e) => {
+            warn!(
+                "Redis Lua script failed checking dimension {}, failing open: {}",
+                redis_key, e
+            );
+            DimensionOutcome::RedisUnavailable
+        }
+    }
 }
 
 pub async fn rate_limit_middleware(
@@ -190,6 +291,184 @@ pub async fn rate_limit_middleware(
         .and_then(|h| h.to_str().ok())
         .map(|s| s.split(',').next().unwrap_or("").trim().to_string())
         .unwrap_or_else(|| addr.ip().to_string());
+
+    // 2b. Per-consumer multi-dimension rate limiting (Issue #175 / #725).
+    // When the caller authenticates with an API key that has a rate-limit
+    // profile or admin override, that profile is authoritative for this
+    // request and checked across all configured dimensions (global,
+    // endpoint sensitivity, transaction type, IP) — the most restrictive
+    // dimension wins. Falls through to the wallet/IP tier check below when
+    // no DB pool is wired, no API key is present, or the consumer has no
+    // profile configured.
+    if let (Some(pool), Some(repo)) = (state.db_pool.as_ref(), state.consumer_repo.as_ref()) {
+        if let Some(raw_key) = extract_raw_api_key(req.headers()) {
+            if let Some(auth) = crate::middleware::api_key::resolve_api_key(pool, &raw_key).await
+            {
+                if let Ok(Some(limits_json)) = repo.get_effective_limits(auth.consumer_id).await {
+                    let mut dims: Vec<(String, LimitConfig)> = Vec::new();
+                    if let Some(lc) = dimension_limit(&limits_json, "global") {
+                        dims.push(("global".to_string(), lc));
+                    }
+                    if let Some(ep) = endpoint_dimension(limits.tier) {
+                        if let Some(lc) = dimension_limit(&limits_json, ep) {
+                            dims.push((ep.to_string(), lc));
+                        }
+                    }
+                    if let Some(tx) = tx_type_dimension(&path) {
+                        if let Some(lc) = dimension_limit(&limits_json, tx) {
+                            dims.push((tx.to_string(), lc));
+                        }
+                    }
+                    if let Some(lc) = dimension_limit(&limits_json, "ip") {
+                        dims.push(("ip".to_string(), lc));
+                    }
+
+                    if !dims.is_empty() {
+                        let mut conn = match state.cache.get_connection().await {
+                            Ok(c) => c,
+                            Err(e) => {
+                                warn!(
+                                    "Redis connection unavailable for consumer rate limiting, failing open: {}",
+                                    e
+                                );
+                                crate::middleware::rate_limit_metrics::record_redis_fallback(
+                                    "connection_error",
+                                );
+                                return Ok(next.run(req).await);
+                            }
+                        };
+
+                        let now_ms = Utc::now().timestamp_millis();
+                        let req_id = Uuid::new_v4().to_string();
+                        let sensitivity = limits.tier.map(|t| t.as_str()).unwrap_or("STANDARD");
+                        // Headers report the most restrictive (smallest limit) dimension checked.
+                        let mut reporting: Option<(i64, i64, i64)> = None;
+
+                        for (dim_name, dim_limit) in &dims {
+                            // The "ip" dimension is metered per source IP, but the
+                            // *metric label* stays the fixed string "ip" — folding the
+                            // raw IP into a label would blow up Prometheus cardinality.
+                            let redis_key = if dim_name == "ip" {
+                                format!("rate_limit:consumer:{}:ip:{}", auth.consumer_id, ip)
+                            } else {
+                                format!("rate_limit:consumer:{}:{}", auth.consumer_id, dim_name)
+                            };
+                            crate::middleware::rate_limit_metrics::record_check(
+                                dim_name,
+                                &auth.consumer_type,
+                                sensitivity,
+                            );
+
+                            match check_dimension(&mut conn, &redis_key, dim_limit, &req_id, now_ms)
+                                .await
+                            {
+                                DimensionOutcome::RedisUnavailable => {
+                                    crate::middleware::rate_limit_metrics::record_redis_fallback(
+                                        "script_error",
+                                    );
+                                    return Ok(next.run(req).await);
+                                }
+                                DimensionOutcome::Denied { count } => {
+                                    crate::middleware::rate_limit_metrics::record_hit(
+                                        dim_name,
+                                        &auth.consumer_type,
+                                        sensitivity,
+                                    );
+                                    crate::middleware::rate_limit_metrics::record_429(
+                                        auth.consumer_id,
+                                        dim_name,
+                                    );
+                                    warn!(
+                                        consumer_id = %auth.consumer_id,
+                                        dimension = %dim_name,
+                                        count = count,
+                                        limit = dim_limit.limit,
+                                        "Consumer rate limit exceeded"
+                                    );
+
+                                    let reset_at = (now_ms / 1000) + dim_limit.window;
+                                    let response_body = json!({
+                                        "error": {
+                                            "code": "RATE_LIMIT_EXCEEDED",
+                                            "message": "Too many requests",
+                                            "dimension": dim_name,
+                                            "limit": dim_limit.limit,
+                                            "remaining": 0,
+                                            "retry_after": dim_limit.window,
+                                            "reset_at": chrono::DateTime::<Utc>::from_utc(
+                                                chrono::NaiveDateTime::from_timestamp_opt(reset_at, 0).unwrap_or_default(), Utc
+                                            ).to_rfc3339()
+                                        }
+                                    });
+                                    let mut res =
+                                        (StatusCode::TOO_MANY_REQUESTS, Json(response_body))
+                                            .into_response();
+                                    res.headers_mut().insert(
+                                        "X-RateLimit-Limit",
+                                        HeaderValue::from_str(&dim_limit.limit.to_string())
+                                            .unwrap(),
+                                    );
+                                    res.headers_mut().insert(
+                                        "X-RateLimit-Remaining",
+                                        HeaderValue::from_static("0"),
+                                    );
+                                    res.headers_mut().insert(
+                                        "X-RateLimit-Reset",
+                                        HeaderValue::from_str(&reset_at.to_string()).unwrap(),
+                                    );
+                                    res.headers_mut().insert(
+                                        "X-RateLimit-Used",
+                                        HeaderValue::from_str(&count.to_string()).unwrap(),
+                                    );
+                                    res.headers_mut().insert(
+                                        "Retry-After",
+                                        HeaderValue::from_str(&dim_limit.window.to_string())
+                                            .unwrap(),
+                                    );
+                                    return Err(res);
+                                }
+                                DimensionOutcome::Allowed { count } => {
+                                    let pct = (count as f64
+                                        / dim_limit.limit.max(1) as f64)
+                                        * 100.0;
+                                    crate::middleware::rate_limit_metrics::record_utilisation(
+                                        &auth.consumer_type,
+                                        dim_name,
+                                        pct,
+                                    );
+                                    let remaining = (dim_limit.limit - count).max(0);
+                                    let reset_at = (now_ms / 1000) + dim_limit.window;
+                                    let more_restrictive = reporting
+                                        .map(|(l, _, _)| dim_limit.limit < l)
+                                        .unwrap_or(true);
+                                    if more_restrictive {
+                                        reporting = Some((dim_limit.limit, remaining, reset_at));
+                                    }
+                                }
+                            }
+                        }
+
+                        let mut res = next.run(req).await.into_response();
+                        if let Some((limit, remaining, reset_at)) = reporting {
+                            res.headers_mut().insert(
+                                "X-RateLimit-Limit",
+                                HeaderValue::from_str(&limit.to_string()).unwrap(),
+                            );
+                            res.headers_mut().insert(
+                                "X-RateLimit-Remaining",
+                                HeaderValue::from_str(&remaining.to_string()).unwrap(),
+                            );
+                            res.headers_mut().insert(
+                                "X-RateLimit-Reset",
+                                HeaderValue::from_str(&reset_at.to_string()).unwrap(),
+                            );
+                        }
+                        return Ok(res);
+                    }
+                }
+            }
+        }
+    }
 
     let (redis_key, limit_conf) = if let Some(ref w) = wallet_address {
         if let Some(wl) = limits.per_wallet {

--- a/src/middleware/rate_limit_metrics.rs
+++ b/src/middleware/rate_limit_metrics.rs
@@ -68,12 +68,37 @@ pub static RATE_LIMIT_429_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Times the rate limiter fell back to fail-open because Redis was
+/// unreachable or the sliding-window Lua script errored (Issue #727).
+/// A sustained non-zero rate here means rate limiting is effectively
+/// disabled and should page — the labelled `reason` distinguishes a
+/// connection-pool exhaustion/outage from a script-level failure.
+pub static RATE_LIMIT_REDIS_FALLBACK: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        REGISTRY,
+        Opts::new(
+            "aframp_rate_limit_redis_fallback_total",
+            "Requests allowed through without a rate-limit check because Redis was unavailable"
+        )
+        .namespace("aframp")
+        .subsystem("rate_limit"),
+        &["reason"]
+    )
+    .unwrap()
+});
+
 pub fn init_metrics() {
     // Called on startup - ensures all metrics registered
     let _ = *RATE_LIMIT_CHECKS;
     let _ = *RATE_LIMIT_HITS;
     let _ = *RATE_LIMIT_UTILISATION;
     let _ = *RATE_LIMIT_429_RESPONSES;
+    let _ = *RATE_LIMIT_REDIS_FALLBACK;
+}
+
+/// Record a fail-open fallback (Redis unavailable or script error).
+pub fn record_redis_fallback(reason: &str) {
+    RATE_LIMIT_REDIS_FALLBACK.with_label_values(&[reason]).inc();
 }
 
 /// Record a rate limit check

--- a/tests/advanced_rate_limit_test.rs
+++ b/tests/advanced_rate_limit_test.rs
@@ -1,0 +1,143 @@
+//! Integration tests for advanced per-consumer rate limiting (Issue #175 / #725).
+//!
+//! Exercises the real Postgres-backed profile/override merge
+//! (`get_effective_rate_limits`), which can't be verified as a client-side
+//! unit test since the COALESCE-over-LEFT-JOIN-LATERAL merge lives in SQL.
+//!
+//! Run with:
+//!   DATABASE_URL=postgres://... cargo test --test advanced_rate_limit_test --features database -- --nocapture
+
+#![cfg(feature = "database")]
+
+use aframp_backend::database::consumer_rate_limit_repository::ConsumerRateLimitRepository;
+use serde_json::json;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+async fn test_pool() -> Result<PgPool, Box<dyn std::error::Error>> {
+    let url = std::env::var("DATABASE_URL")?;
+    let pool = PgPool::connect(&url).await?;
+    Ok(pool)
+}
+
+async fn seed_consumer(pool: &PgPool, consumer_type: &str) -> Result<Uuid, Box<dyn std::error::Error>> {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO consumers (id, name, consumer_type, environment)
+        VALUES ($1, 'advanced rate limit test consumer', $2, 'testnet')
+        "#,
+    )
+    .bind(id)
+    .bind(consumer_type)
+    .execute(pool)
+    .await?;
+    Ok(id)
+}
+
+async fn cleanup_consumer(pool: &PgPool, consumer_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM consumer_rate_limit_overrides WHERE consumer_id = $1")
+        .bind(consumer_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM consumers WHERE id = $1")
+        .bind(consumer_id)
+        .execute(pool)
+        .await;
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL against a migrated database
+async fn effective_limits_falls_back_to_profile_when_no_override() {
+    let pool = test_pool().await.expect("DATABASE_URL must point to a migrated database");
+    let repo = ConsumerRateLimitRepository::new(Arc::new(pool.clone()));
+
+    // Seeded by the #175 migration for every known consumer_type.
+    let consumer_id = seed_consumer(&pool, "partner").await.expect("seed consumer");
+
+    let effective = repo
+        .get_effective_limits(consumer_id)
+        .await
+        .expect("get_effective_limits should succeed")
+        .expect("partner profile should exist from migration seed data");
+
+    assert_eq!(effective["global"]["limit"], json!(100));
+
+    cleanup_consumer(&pool, consumer_id).await;
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL against a migrated database
+async fn active_override_takes_precedence_over_profile() {
+    let pool = test_pool().await.expect("DATABASE_URL must point to a migrated database");
+    let repo = ConsumerRateLimitRepository::new(Arc::new(pool.clone()));
+
+    let consumer_id = seed_consumer(&pool, "mobile_client").await.expect("seed consumer");
+
+    let override_limits = json!({
+        "global": {"limit": 2, "window_secs": 60},
+        "endpoint_critical": {"limit": 1, "window_secs": 60}
+    });
+    let created = repo
+        .create_override(consumer_id, &override_limits, None, None, Some("integration test".to_string()))
+        .await
+        .expect("create_override should succeed");
+    assert_eq!(created.consumer_id, consumer_id);
+
+    let effective = repo
+        .get_effective_limits(consumer_id)
+        .await
+        .expect("get_effective_limits should succeed")
+        .expect("override should make limits effective");
+    assert_eq!(effective["global"]["limit"], json!(2), "override must win over the mobile_client profile");
+
+    let active = repo.list_overrides(consumer_id).await.expect("list_overrides should succeed");
+    assert_eq!(active.len(), 1);
+
+    let deleted = repo.delete_override(created.id).await.expect("delete_override should succeed");
+    assert!(deleted);
+
+    let effective_after_delete = repo
+        .get_effective_limits(consumer_id)
+        .await
+        .expect("get_effective_limits should succeed")
+        .expect("profile should still apply after override removal");
+    assert_eq!(
+        effective_after_delete["global"]["limit"],
+        json!(10),
+        "should fall back to the mobile_client profile (global limit 10) once the override is gone"
+    );
+
+    cleanup_consumer(&pool, consumer_id).await;
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL against a migrated database
+async fn expired_override_is_not_effective() {
+    let pool = test_pool().await.expect("DATABASE_URL must point to a migrated database");
+    let repo = ConsumerRateLimitRepository::new(Arc::new(pool.clone()));
+
+    let consumer_id = seed_consumer(&pool, "microservice").await.expect("seed consumer");
+
+    let expired_at = chrono::Utc::now() - chrono::Duration::hours(1);
+    // Bypass the repository's implicit "future expiry" assumption by inserting directly,
+    // since create_override doesn't validate expiry_at is in the future at the API layer.
+    sqlx::query(
+        r#"
+        INSERT INTO consumer_rate_limit_overrides (consumer_id, limits_json, expiry_at)
+        VALUES ($1, $2, $3)
+        "#,
+    )
+    .bind(consumer_id)
+    .bind(json!({"global": {"limit": 1, "window_secs": 60}}))
+    .bind(expired_at)
+    .execute(&pool)
+    .await
+    .ok(); // the chk_override_expiry constraint may reject this — that's fine, it's the assertion.
+
+    let active = repo.list_overrides(consumer_id).await.expect("list_overrides should succeed");
+    assert!(active.is_empty(), "expired overrides must not be listed as active");
+
+    cleanup_consumer(&pool, consumer_id).await;
+}

--- a/tests/rate_limit_tier_test.rs
+++ b/tests/rate_limit_tier_test.rs
@@ -1,0 +1,70 @@
+//! Tests for endpoint sensitivity tiers (Issue #726)
+//!
+//! Verifies that CRITICAL / FINANCIAL / STANDARD / PUBLIC tiers defined in
+//! rate_limits.yaml resolve to the correct per-IP limit for representative
+//! routes, and that an endpoint's explicit `per_ip` still wins over its tier.
+
+use aframp_backend::middleware::rate_limit::{EndpointTier, RateLimitConfig};
+
+fn load_config() -> RateLimitConfig {
+    RateLimitConfig::load("rate_limits.yaml").expect("rate_limits.yaml should load")
+}
+
+#[test]
+fn critical_tier_applies_to_mint_and_redemption() {
+    let config = load_config();
+
+    for path in ["/api/mint/requests", "/api/redemption/initiate"] {
+        let limits = config.get_limits(path);
+        assert_eq!(limits.tier, Some(EndpointTier::Critical), "path: {path}");
+        let per_ip = limits.per_ip.expect("critical tier must resolve a per_ip limit");
+        assert_eq!(per_ip.limit, 10);
+        assert_eq!(per_ip.window, 60);
+    }
+}
+
+#[test]
+fn financial_tier_applies_to_offramp_and_onramp_initiate() {
+    let config = load_config();
+
+    for path in ["/api/onramp/initiate", "/api/offramp/initiate"] {
+        let limits = config.get_limits(path);
+        assert_eq!(limits.tier, Some(EndpointTier::Financial), "path: {path}");
+        let per_ip = limits.per_ip.expect("financial tier must resolve a per_ip limit");
+        assert_eq!(per_ip.limit, 60);
+        assert_eq!(per_ip.window, 60);
+    }
+}
+
+#[test]
+fn standard_tier_applies_to_default_fallback() {
+    let config = load_config();
+
+    let limits = config.get_limits("/api/some/unlisted/route");
+    assert_eq!(limits.tier, Some(EndpointTier::Standard));
+    let per_ip = limits.per_ip.expect("default entry defines per_ip explicitly");
+    assert_eq!(per_ip.limit, 100);
+    assert_eq!(per_ip.window, 60);
+}
+
+#[test]
+fn public_tier_applies_to_rates_endpoint() {
+    let config = load_config();
+
+    let limits = config.get_limits("/api/rates");
+    assert_eq!(limits.tier, Some(EndpointTier::Public));
+    let per_ip = limits.per_ip.expect("public tier must resolve a per_ip limit");
+    assert_eq!(per_ip.limit, 100, "explicit per_ip on /api/rates overrides tier default");
+}
+
+#[test]
+fn tier_default_used_when_endpoint_omits_per_ip() {
+    let config = load_config();
+
+    // /api/wallet/balance only sets per_wallet + tier: STANDARD, no per_ip.
+    let limits = config.get_limits("/api/wallet/balance");
+    assert_eq!(limits.tier, Some(EndpointTier::Standard));
+    let per_ip = limits.per_ip.expect("tier fallback should populate per_ip");
+    assert_eq!(per_ip.limit, 300);
+    assert_eq!(per_ip.window, 60);
+}


### PR DESCRIPTION
## Summary

Implements the four open rate-limiting issues as four focused commits on one branch.

### #726 — Per-endpoint sensitivity tiers
- Adds `CRITICAL` (10/min) / `FINANCIAL` (60/min) / `STANDARD` (300/min) / `PUBLIC` (1000/min) tier definitions to `rate_limits.yaml`.
- Each endpoint entry gets a `tier:` field; the middleware (`src/middleware/rate_limit.rs`) resolves it as the `per_ip` fallback whenever an entry doesn't set `per_ip` explicitly, so every matched route always gets a sensitivity-appropriate ceiling.
- Fund-movement endpoints (mint, redemption, onramp/offramp initiate) are tagged `CRITICAL`/`FINANCIAL`; public reads (`/api/rates`, `/api/fees`, `/api/bills/providers`) are `PUBLIC`.
- `tests/rate_limit_tier_test.rs` verifies each tier resolves correctly, including the case where an endpoint only sets `per_wallet` and must fall back to its tier for `per_ip`.

### #727 — Distributed rate limiting via Redis Lua script
- The previous implementation ran a separate "check" pipeline (`ZREMRANGEBYSCORE` + `ZCARD`) and, if under the limit, a second "add" pipeline (`ZADD` + `EXPIRE`). Two concurrent requests — same instance or different replicas — could both observe `count < limit` between those two round trips and both get admitted, multiplying the effective limit under load.
- Replaced both pipelines with a single Lua script (`SLIDING_WINDOW_SCRIPT`) that performs the trim, count, and conditional increment atomically on the Redis server, closing that race — this is what actually makes the limiter correct across multiple instances (all instances already shared Redis; the two-step check wasn't atomic).
- Added a fail-open path: if Redis is unreachable or the script errors, log a warning and let the request through instead of returning 500, and emit `aframp_rate_limit_redis_fallback_total` (labelled by `reason`) so sustained fallback pages someone instead of silently disabling rate limiting.

### #728 — `X-RateLimit-*` headers on all responses
- `X-RateLimit-Limit` / `X-RateLimit-Remaining` / `X-RateLimit-Reset` / `X-RateLimit-Used` were already injected on success and 429, and `Retry-After` was already present on 429. The one real gap — endpoints that only defined a `per_wallet` limit bypassed the middleware entirely (no headers, no limiting) for unauthenticated callers — is closed by the tier-based `per_ip` fallback from #726, which now guarantees every matched route resolves a `per_ip` limit.
- Added a "Rate Limiting" section to the OpenAPI description (`src/api/openapi.rs`) documenting the headers, the 429/`Retry-After` behavior, and the sensitivity tiers.

### #725 — Advanced per-consumer rate limiting (TODO.md Issue #175, steps 3–8)
Steps 1–2 (DB schema + repository) already existed but step 3 onward were unimplemented, and the repository itself had a bug (`PgJson<T>` is undefined — the sqlx `json` cargo feature isn't enabled — fixed by binding the already-JSON `LimitsJson` alias directly, which sqlx supports natively for JSONB columns).

- **Step 3** (`src/middleware/rate_limit.rs`): when a request authenticates with an API key, resolves the consumer (reusing `middleware::api_key::resolve_api_key`) and, if that consumer has a rate-limit profile or override (merged server-side via the existing `get_effective_rate_limits` SQL function), checks it across every configured dimension — global, endpoint sensitivity tier, transaction type (onramp/offramp/mint/redemption), and per-consumer IP — using the atomic script from #727. The most restrictive dimension determines the response headers; any breached dimension short-circuits to 429. Falls back to the existing wallet/IP tier check when no DB pool is configured, no API key is present, or the consumer has no profile.
- **Step 4** (`src/api/admin/rate_limits.rs`): `GET`/`POST`/`DELETE /api/admin/consumers/:id/rate-limits` for admins to inspect effective limits and manage overrides, wired into `main.rs`.
- **Step 5**: wires the already-defined `rate_limit_metrics` counters (checks/hits/utilisation/429) into the new per-dimension check, plus `warn!`-level breach logs. (Metric labels for the IP dimension use the fixed string `"ip"`, not the raw address, to avoid a cardinality blowup.)
- **Step 6**: `rate_limits.yaml` documents how the DB-backed profile layer relates to the static per-endpoint config.
- **Step 7**: `tests/advanced_rate_limit_test.rs` covers profile/override merge precedence and override expiry against a real database.
- **Step 8**: `RateLimitState` now carries an optional consumer repo + DB pool; admin routes merged into the existing admin router.
- Steps 9 (verification) and 10 (PR) were left for review/CI rather than self-certified.

## Known pre-existing issues (not introduced by this PR)

While working in these files I found a few unrelated compile breaks already on `master` that block a clean build regardless of this change:
- `src/main.rs` — a `let mut router = Router::new()...` statement in the admin routes block is missing its terminating `;`.
- `src/api/openapi.rs` — the `paths(...)` list references `crate::partner::handlers::*`, but there's no `partner` module in `src/`.
- `tests/rate_limit_test.rs` — imports a `Bitmesh_backend` crate that doesn't exist (should be `aframp_backend`).

Flagging these for visibility; fixing them was out of scope for this PR.

## Test plan

- [ ] `cargo check --features database` (not run in this environment — flag above)
- [ ] `cargo test --features database` (per #725 acceptance criteria)
- [ ] `cargo test --test rate_limit_tier_test --features cache`
- [ ] `cargo test --test advanced_rate_limit_test --features database -- --ignored` against a migrated database
- [ ] Manual: confirm 429 + headers on a tier-limited endpoint, confirm Lua script atomicity under concurrent load, confirm admin CRUD on `/api/admin/consumers/:id/rate-limits`

Closes #725
Closes #726
Closes #727
Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)